### PR TITLE
Opening duels: entry kills, entry deaths and success rate

### DIFF
--- a/_docs/PLAYER_DATA.MD
+++ b/_docs/PLAYER_DATA.MD
@@ -42,6 +42,16 @@ The `--save` flag writes every analysed player to a file. JSON contains all fiel
 | ClutchesWon | `clutches_won` | Rounds won after being the last player alive on the team against at least one enemy (1v1 counts). Winning by defuse or time counts — no kills required. |
 | KAST | `kast` | Percentage of the match's rounds with a Kill, Assist, Survival or Traded death (a teammate killed your killer within 5 seconds). Dying before the round officially ends cancels survival — including exit frags and the bomb going off after the whistle (HLTV convention). Match-end cleanup kills do not count. |
 
+### Opening duel stats (`opening_duel_stats`)
+
+The opening duel is the first enemy kill of a round. Teamkills, suicides and world deaths never open a round, and neither does a kill landing after the round is already decided. The table shows opening kills and deaths as the `Entry` column, e.g. `5:3`.
+
+| Field | JSON key | Description |
+| --- | --- | --- |
+| OpeningKills | `opening_kills` | Rounds opened by a kill from this player: `{total, ct, t}`, split by the side the player was on. |
+| OpeningDeaths | `opening_deaths` | Rounds opened by this player's death, with the same side split. |
+| OpeningSuccess | `opening_success` | Percentage of the player's opening kills whose round their team went on to win. 0 without any opening kills. |
+
 ## Match data
 
 The JSON table output also carries match-level data:

--- a/_docs/PLAYER_DATA.MD
+++ b/_docs/PLAYER_DATA.MD
@@ -21,8 +21,19 @@ The `--save` flag writes every analysed player to a file. JSON contains all fiel
 | HeadShots | `headshots` | Enemy kills that were headshots. |
 | Precision | `precision` | Headshot ratio: `headshots / total`, from 0 to 1. Shown as a percentage in the table and CSV. |
 | WeaponsKills | `weapons_kills` | Kills per weapon name. |
-| TradeKills | `trade_kills` | Kills on an enemy who had killed a teammate within the previous 5 seconds. |
+| TradeKills | `trade_kills` | Kills on the enemy who had killed a teammate earlier in the same round, within 5 seconds of that death. See [trade window](#trade-window) for the exact rule. |
 | TeamKills | `team_kills` | Kills on teammates. |
+
+#### Trade window
+
+A kill is a trade when it lands on the *specific* enemy who killed a teammate, within 5 seconds of that teammate's death. In detail:
+
+- It must be that killer. Killing any other enemy inside the window is not a trade.
+- Both deaths have to fall in the same round.
+- One kill counts once, even when the enemy it lands on had killed two teammates.
+- Kills after the round is decided still count, so exit frags can be trades.
+
+The 5-second window is a deliberate choice, not a value read out of the demo: HLTV states 5 seconds for Rating 3.0 ("two kills within 5 seconds") and Refrag documents the same for its Trades column. Other trackers differ — Leetify builds 4-second kill chains instead — so trade counts are not comparable between tools even when the label matches. If you are forking and your league counts trades differently, the window is the `tradeWindow` constant at the top of `cmd/demo_parser/round_tracker.go`.
 
 ### Assist stats (`assist_stats`)
 
@@ -50,7 +61,7 @@ The opening duel is the first enemy kill of a round. Teamkills, suicides and wor
 | --- | --- | --- |
 | OpeningKills | `opening_kills` | Rounds opened by a kill from this player: `{total, ct, t}`, split by the side the player was on. |
 | OpeningDeaths | `opening_deaths` | Rounds opened by this player's death, with the same side split. |
-| OpeningSuccess | `opening_success` | Percentage of the player's opening kills whose round their team went on to win. 0 without any opening kills. |
+| OpeningSuccessRate | `opening_success_rate` | Percentage of the player's opening kills whose round their team went on to win. 0 without any opening kills. This is a rate, not a count — some trackers use "opening success" to mean the opening-kill tally instead. |
 
 ## Match data
 

--- a/cmd/dataexport/player_export.go
+++ b/cmd/dataexport/player_export.go
@@ -47,7 +47,7 @@ func WritePlayersToFile(players map[uint64]*demoparser.DemoPlayer, saveType stri
 				fmt.Sprintf("%d", player.KillStats.TradeKills),
 				fmt.Sprintf("%d", player.OpeningDuelStats.OpeningKills.Total),
 				fmt.Sprintf("%d", player.OpeningDuelStats.OpeningDeaths.Total),
-				fmt.Sprintf("%.1f", player.OpeningDuelStats.OpeningSuccess),
+				fmt.Sprintf("%.1f", player.OpeningDuelStats.OpeningSuccessRate),
 				fmt.Sprintf("%d", player.PlayerMapStats.MVPs),
 				fmt.Sprintf("%d", player.PlayerMapStats.ACEs),
 				fmt.Sprintf("%d", player.PlayerMapStats.ClutchesWon),

--- a/cmd/dataexport/player_export.go
+++ b/cmd/dataexport/player_export.go
@@ -29,7 +29,7 @@ func WritePlayersToFile(players map[uint64]*demoparser.DemoPlayer, saveType stri
 		})
 
 		csvRecords := [][]string{
-			{"Name", "Kills", "Deaths", "K/D", "HS", "Assists", "Flash Assists", "Damage Given", "ADR", "KAST (%)", "Precision (%)", "Trade Kills", "MVPs", "ACEs", "Clutches Won", "Best Weapon"},
+			{"Name", "Kills", "Deaths", "K/D", "HS", "Assists", "Flash Assists", "Damage Given", "ADR", "KAST (%)", "Precision (%)", "Trade Kills", "Opening Kills", "Opening Deaths", "Opening Success (%)", "MVPs", "ACEs", "Clutches Won", "Best Weapon"},
 		}
 		for _, player := range sortedPlayers {
 			csvRecords = append(csvRecords, []string{
@@ -45,6 +45,9 @@ func WritePlayersToFile(players map[uint64]*demoparser.DemoPlayer, saveType stri
 				fmt.Sprintf("%.1f", player.PlayerMapStats.KAST),
 				fmt.Sprintf("%.1f", player.KillStats.Precision*100),
 				fmt.Sprintf("%d", player.KillStats.TradeKills),
+				fmt.Sprintf("%d", player.OpeningDuelStats.OpeningKills.Total),
+				fmt.Sprintf("%d", player.OpeningDuelStats.OpeningDeaths.Total),
+				fmt.Sprintf("%.1f", player.OpeningDuelStats.OpeningSuccess),
 				fmt.Sprintf("%d", player.PlayerMapStats.MVPs),
 				fmt.Sprintf("%d", player.PlayerMapStats.ACEs),
 				fmt.Sprintf("%d", player.PlayerMapStats.ClutchesWon),

--- a/cmd/dataexport/table_print.go
+++ b/cmd/dataexport/table_print.go
@@ -18,10 +18,15 @@ func kdRatio(kills, deaths int) string {
 	return fmt.Sprintf("%.3f", float64(kills)/float64(deaths))
 }
 
+// entryScore formats opening duels as kills:deaths, e.g. "5:3".
+func entryScore(opening demoparser.OpeningDuelStats) string {
+	return fmt.Sprintf("%d:%d", opening.OpeningKills.Total, opening.OpeningDeaths.Total)
+}
+
 func PrintCLIDataTable(playerToAnalyse map[uint64]*demoparser.DemoPlayer, mapData *demoparser.MapData, gameMode string) {
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
-	t.AppendHeader(table.Row{"Name", "Kills", "Deaths", "K/D", "HS", "Assists", "ADR", "KAST (%)", "Precision (%)", "Best Weapon"})
+	t.AppendHeader(table.Row{"Name", "Kills", "Deaths", "K/D", "HS", "Assists", "ADR", "KAST (%)", "Entry", "Precision (%)", "Best Weapon"})
 	for _, player := range playerToAnalyse {
 		playerBestWeapon := demoparser.GetPlayerBestWeapon(player.KillStats.WeaponsKills)
 		t.AppendRow(table.Row{
@@ -33,6 +38,7 @@ func PrintCLIDataTable(playerToAnalyse map[uint64]*demoparser.DemoPlayer, mapDat
 			player.AssistStats.Total,
 			fmt.Sprintf("%.1f", player.AssistStats.ADR),
 			fmt.Sprintf("%.1f", player.PlayerMapStats.KAST),
+			entryScore(player.OpeningDuelStats),
 			fmt.Sprintf("%.1f", player.KillStats.Precision*100),
 			playerBestWeapon,
 		})

--- a/cmd/demo_parser/demo_parser.go
+++ b/cmd/demo_parser/demo_parser.go
@@ -15,13 +15,14 @@ import (
 // analyser accumulates player stats while the demo is parsed. Round-scoped
 // bookkeeping (clutches, aces, trades, KAST) is delegated to roundTracker.
 type analyser struct {
-	parser     demoinfocs.Parser
-	players    map[uint64]*DemoPlayer
-	tracker    *roundTracker
-	kastRounds map[uint64]int
-	lastHealth map[uint64]int
-	mapData    MapData
-	gameMode   string
+	parser      demoinfocs.Parser
+	players     map[uint64]*DemoPlayer
+	tracker     *roundTracker
+	kastRounds  map[uint64]int
+	openingWins map[uint64]int // rounds won after taking the opening kill
+	lastHealth  map[uint64]int
+	mapData     MapData
+	gameMode    string
 }
 
 func ProcessDemo(demoPath string) (*ProcessedDemo, error) {
@@ -32,11 +33,12 @@ func ProcessDemo(demoPath string) (*ProcessedDemo, error) {
 	defer file.Close()
 
 	a := &analyser{
-		parser:     demoinfocs.NewParser(file),
-		players:    make(map[uint64]*DemoPlayer),
-		tracker:    newRoundTracker(),
-		kastRounds: make(map[uint64]int),
-		lastHealth: make(map[uint64]int),
+		parser:      demoinfocs.NewParser(file),
+		players:     make(map[uint64]*DemoPlayer),
+		tracker:     newRoundTracker(),
+		kastRounds:  make(map[uint64]int),
+		openingWins: make(map[uint64]int),
+		lastHealth:  make(map[uint64]int),
 	}
 	defer a.parser.Close()
 
@@ -248,6 +250,17 @@ func (a *analyser) onRoundEndOfficial(e events.RoundEndOfficial) {
 	a.applyRoundOutcome(a.tracker.finalize())
 }
 
+// count records one round on the side the player was playing.
+func (s *SideCount) count(side common.Team) {
+	s.Total++
+	switch side {
+	case common.TeamCounterTerrorists:
+		s.CT++
+	case common.TeamTerrorists:
+		s.T++
+	}
+}
+
 func (a *analyser) applyRoundOutcome(outcome roundOutcome) {
 	if !outcome.played {
 		return
@@ -259,6 +272,15 @@ func (a *analyser) applyRoundOutcome(outcome roundOutcome) {
 	}
 	if p := a.players[outcome.clutcher]; p != nil {
 		p.PlayerMapStats.ClutchesWon++
+	}
+	if p := a.players[outcome.opening.killer]; p != nil {
+		p.OpeningDuelStats.OpeningKills.count(outcome.opening.killerTeam)
+		if outcome.openingWon {
+			a.openingWins[outcome.opening.killer]++
+		}
+	}
+	if p := a.players[outcome.opening.victim]; p != nil {
+		p.OpeningDuelStats.OpeningDeaths.count(outcome.opening.victimTeam)
 	}
 	for id := range outcome.participants {
 		if _, isHuman := a.players[id]; !isHuman {
@@ -302,6 +324,9 @@ func (a *analyser) finalise() {
 		if a.mapData.TotalRounds > 0 {
 			p.AssistStats.ADR = float64(p.AssistStats.DamageGiven) / float64(a.mapData.TotalRounds)
 			p.PlayerMapStats.KAST = 100 * float64(a.kastRounds[id]) / float64(a.mapData.TotalRounds)
+		}
+		if kills := p.OpeningDuelStats.OpeningKills.Total; kills > 0 {
+			p.OpeningDuelStats.OpeningSuccess = 100 * float64(a.openingWins[id]) / float64(kills)
 		}
 	}
 }

--- a/cmd/demo_parser/demo_parser.go
+++ b/cmd/demo_parser/demo_parser.go
@@ -329,7 +329,7 @@ func (a *analyser) finalise() {
 			p.PlayerMapStats.KAST = 100 * float64(a.kastRounds[id]) / float64(a.mapData.TotalRounds)
 		}
 		if kills := p.OpeningDuelStats.OpeningKills.Total; kills > 0 {
-			p.OpeningDuelStats.OpeningSuccess = 100 * float64(a.openingWins[id]) / float64(kills)
+			p.OpeningDuelStats.OpeningSuccessRate = 100 * float64(a.openingWins[id]) / float64(kills)
 		}
 	}
 }

--- a/cmd/demo_parser/demo_parser.go
+++ b/cmd/demo_parser/demo_parser.go
@@ -146,7 +146,10 @@ func (a *analyser) onKill(e events.Kill) {
 	}
 
 	// Suicides and world deaths (fall damage, C4) have no killer to credit.
-	suicide := e.Killer != nil && e.Killer.SteamID64 == e.Victim.SteamID64
+	// Bots all report SteamID64 0, so identity has to go through trackerID
+	// (which gives each bot a distinct ID) or two different bots trading
+	// kills would misread as one bot suiciding on itself.
+	suicide := e.Killer != nil && trackerID(e.Killer) == trackerID(e.Victim)
 	var killerID uint64
 	var killerTeam common.Team
 	if e.Killer != nil && !suicide {

--- a/cmd/demo_parser/demo_parser_test.go
+++ b/cmd/demo_parser/demo_parser_test.go
@@ -41,11 +41,12 @@ func (p matchParticipants) Playing() []*common.Player { return p.playing }
 
 func liveAnalyser(playing ...*common.Player) *analyser {
 	return &analyser{
-		parser:     &matchParser{playing: playing},
-		players:    make(map[uint64]*DemoPlayer),
-		tracker:    newRoundTracker(),
-		kastRounds: make(map[uint64]int),
-		lastHealth: make(map[uint64]int),
+		parser:      &matchParser{playing: playing},
+		players:     make(map[uint64]*DemoPlayer),
+		tracker:     newRoundTracker(),
+		kastRounds:  make(map[uint64]int),
+		openingWins: make(map[uint64]int),
+		lastHealth:  make(map[uint64]int),
 	}
 }
 
@@ -170,6 +171,29 @@ func TestPostRoundDeathBeforeOfficialEndCancelsKast(t *testing.T) {
 	// finalized at all rather than the whole outcome being dropped.
 	if got := a.kastRounds[shooterID]; got != 1 {
 		t.Errorf("shooter kast rounds = %d, want 1", got)
+	}
+}
+
+// The opening duel of the round has to land on both players' stats: an
+// opening kill on the killer's side, an opening death on the victim's side,
+// and a win counted towards the killer's opening success rate.
+func TestOpeningDuelIsCredited(t *testing.T) {
+	a, shooter, victim := liveRound()
+
+	a.onKill(events.Kill{Killer: shooter, Victim: victim, Weapon: &common.Equipment{Type: common.EqAK47}})
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
+	a.onRoundEndOfficial(events.RoundEndOfficial{})
+
+	kills := a.players[shooterID].OpeningDuelStats.OpeningKills
+	if kills.Total != 1 || kills.T != 1 || kills.CT != 0 {
+		t.Errorf("shooter opening kills = %+v, want one on the T side", kills)
+	}
+	deaths := a.players[victimID].OpeningDuelStats.OpeningDeaths
+	if deaths.Total != 1 || deaths.CT != 1 || deaths.T != 0 {
+		t.Errorf("victim opening deaths = %+v, want one on the CT side", deaths)
+	}
+	if got := a.openingWins[shooterID]; got != 1 {
+		t.Errorf("shooter opening wins = %d, want 1: their team won the round", got)
 	}
 }
 

--- a/cmd/demo_parser/demo_parser_test.go
+++ b/cmd/demo_parser/demo_parser_test.go
@@ -59,6 +59,11 @@ func player(id uint64, name string, team common.Team) *common.Player {
 	return &common.Player{SteamID64: id, UserID: int(id), Name: name, Team: team}
 }
 
+// botPlayer builds a bot, whose SteamID64 is always 0 like every other bot's.
+func botPlayer(userID int, name string, team common.Team) *common.Player {
+	return &common.Player{IsBot: true, UserID: userID, Name: name, Team: team}
+}
+
 // hurt builds a PlayerHurt from an enemy shooter, where healthAfter is the
 // victim's health once the event has been applied.
 func hurt(weapon common.EquipmentType, damageTaken, healthAfter int) events.PlayerHurt {
@@ -194,6 +199,28 @@ func TestOpeningDuelIsCredited(t *testing.T) {
 	}
 	if got := a.openingWins[shooterID]; got != 1 {
 		t.Errorf("shooter opening wins = %d, want 1: their team won the round", got)
+	}
+}
+
+// Bots all report SteamID64 0, so a kill between two different bots must
+// not be misread as one bot suiciding on itself (both sides comparing
+// equal). Getting that wrong drops the bot kill as a killerless event,
+// which would let a later human kill wrongly become the round's opener.
+func TestBotOnBotKillDoesNotStealTheOpeningDuel(t *testing.T) {
+	botT := botPlayer(101, "bot-t", common.TeamTerrorists)
+	botCT := botPlayer(102, "bot-ct", common.TeamCounterTerrorists)
+	shooter := player(shooterID, "shooter", common.TeamTerrorists)
+	victim := player(victimID, "victim", common.TeamCounterTerrorists)
+	a := liveAnalyser(botT, botCT, shooter, victim)
+
+	a.onRoundStart(events.RoundStart{})
+	a.onKill(events.Kill{Killer: botT, Victim: botCT, Weapon: &common.Equipment{Type: common.EqAK47}})
+	a.onKill(events.Kill{Killer: shooter, Victim: victim, Weapon: &common.Equipment{Type: common.EqAK47}})
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
+	a.onRoundEndOfficial(events.RoundEndOfficial{})
+
+	if got := a.players[shooterID].OpeningDuelStats.OpeningKills.Total; got != 0 {
+		t.Errorf("shooter opening kills = %d, want 0: the bot-on-bot kill opened the round first", got)
 	}
 }
 

--- a/cmd/demo_parser/round_tracker.go
+++ b/cmd/demo_parser/round_tracker.go
@@ -22,11 +22,20 @@ type deathRecord struct {
 	at         time.Duration
 }
 
+// openingDuel is the first enemy kill of a round. A zero killer means the
+// round had none.
+type openingDuel struct {
+	killer, victim         uint64
+	killerTeam, victimTeam common.Team
+}
+
 // roundOutcome is what a finished round contributes to player stats.
 type roundOutcome struct {
 	played       bool
 	aces         []uint64
 	clutcher     uint64 // winner-side player that won a 1vX, 0 if none
+	opening      openingDuel
+	openingWon   bool // the opening killer's team won the round
 	participants map[uint64]common.Team
 	kast         map[uint64]bool // players that got a Kill, Assist, Survived or were Traded
 }
@@ -45,6 +54,7 @@ type roundTracker struct {
 	traded     map[uint64]bool
 	deaths     []deathRecord
 	clutchers  map[common.Team]uint64
+	opening    openingDuel
 }
 
 func newRoundTracker() *roundTracker {
@@ -66,6 +76,7 @@ func (rt *roundTracker) startRound(alive map[uint64]common.Team) {
 	rt.traded = make(map[uint64]bool)
 	rt.deaths = nil
 	rt.clutchers = make(map[common.Team]uint64)
+	rt.opening = openingDuel{}
 	rt.updateClutchCandidates()
 }
 
@@ -80,6 +91,13 @@ func (rt *roundTracker) kill(killer, victim uint64, killerTeam, victimTeam commo
 
 	isTrade := false
 	if killer != 0 && killerTeam != victimTeam {
+		// The first enemy kill is the round's opening duel. Teamkills,
+		// suicides and world deaths never open a round, and once the round
+		// is decided nothing can (a bomb explosion or exit frag in an
+		// otherwise killless round is not an entry).
+		if rt.opening.killer == 0 && !rt.ending {
+			rt.opening = openingDuel{killer: killer, victim: victim, killerTeam: killerTeam, victimTeam: victimTeam}
+		}
 		rt.enemyKills[killer]++
 		if assister != 0 {
 			rt.assists[assister] = true
@@ -181,6 +199,8 @@ func (rt *roundTracker) finalize() roundOutcome {
 	outcome := roundOutcome{
 		played:       true,
 		clutcher:     rt.clutchers[rt.winner],
+		opening:      rt.opening,
+		openingWon:   rt.opening.killer != 0 && rt.opening.killerTeam == rt.winner,
 		participants: rt.startAlive,
 		kast:         make(map[uint64]bool),
 	}

--- a/cmd/demo_parser/round_tracker_test.go
+++ b/cmd/demo_parser/round_tracker_test.go
@@ -316,6 +316,75 @@ func TestNoClutchCandidacyAfterRoundDecided(t *testing.T) {
 	}
 }
 
+func TestOpeningDuelGoesToFirstEnemyKill(t *testing.T) {
+	rt := newRoundTracker()
+	rt.startRound(fiveVsFive())
+
+	rt.kill(11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
+	rt.kill(2, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(12))
+
+	outcome := endRound(rt, common.TeamCounterTerrorists)
+	want := openingDuel{killer: 11, victim: 1, killerTeam: common.TeamCounterTerrorists, victimTeam: common.TeamTerrorists}
+	if outcome.opening != want {
+		t.Errorf("opening = %+v, want %+v", outcome.opening, want)
+	}
+	if !outcome.openingWon {
+		t.Error("player 11's team took the opening kill and won, openingWon must be true")
+	}
+}
+
+func TestOpeningDuelInLostRoundIsNotWon(t *testing.T) {
+	rt := newRoundTracker()
+	rt.startRound(fiveVsFive())
+
+	rt.kill(11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
+
+	if outcome := endRound(rt, common.TeamTerrorists); outcome.openingWon {
+		t.Error("the opening killer's team lost the round, openingWon must be false")
+	}
+}
+
+func TestOpeningDuelSkipsTeamkillsAndWorldDeaths(t *testing.T) {
+	rt := newRoundTracker()
+	rt.startRound(fiveVsFive())
+
+	// A teamkill and a fall death come first; neither opens the round.
+	rt.kill(1, 2, common.TeamTerrorists, common.TeamTerrorists, 0, false, at(5))
+	rt.kill(0, 3, common.TeamUnassigned, common.TeamTerrorists, 0, true, at(8))
+	rt.kill(11, 4, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
+
+	outcome := endRound(rt, common.TeamCounterTerrorists)
+	if outcome.opening.killer != 11 || outcome.opening.victim != 4 {
+		t.Errorf("opening = %+v, want the first enemy kill (11 on 4)", outcome.opening)
+	}
+}
+
+func TestRoundWithoutKillsHasNoOpeningDuel(t *testing.T) {
+	rt := newRoundTracker()
+	rt.startRound(fiveVsFive())
+
+	outcome := endRound(rt, common.TeamCounterTerrorists)
+	if outcome.opening.killer != 0 {
+		t.Errorf("opening = %+v, want none", outcome.opening)
+	}
+	if outcome.openingWon {
+		t.Error("a round without an opening kill cannot be an opening success")
+	}
+}
+
+func TestPostRoundKillIsNotAnOpeningDuel(t *testing.T) {
+	rt := newRoundTracker()
+	rt.startRound(fiveVsFive())
+	rt.markEnd(common.TeamCounterTerrorists)
+
+	// An exit frag in an otherwise killless round is no entry.
+	rt.kill(11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(70))
+
+	if outcome := rt.finalize(); outcome.opening.killer != 0 {
+		t.Errorf("opening = %+v, want none after the round was decided", outcome.opening)
+	}
+}
+
 func TestGetPlayerBestWeapon(t *testing.T) {
 	weapon := GetPlayerBestWeapon(map[string]int{"AK-47": 12, "AWP": 7, "Glock-18": 1})
 	if weapon != "AK-47" {

--- a/cmd/demo_parser/testdata/golden_ancient.json
+++ b/cmd/demo_parser/testdata/golden_ancient.json
@@ -27,6 +27,19 @@
         "aces": 0,
         "clutches_won": 0,
         "kast": 87.5
+      },
+      "opening_duel_stats": {
+        "opening_kills": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_deaths": {
+          "total": 1,
+          "ct": 1,
+          "t": 0
+        },
+        "opening_success": 0
       }
     },
     "76561198071075349": {
@@ -57,6 +70,19 @@
         "aces": 0,
         "clutches_won": 1,
         "kast": 100
+      },
+      "opening_duel_stats": {
+        "opening_kills": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_deaths": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_success": 0
       }
     },
     "76561198307159112": {
@@ -85,6 +111,19 @@
         "aces": 0,
         "clutches_won": 0,
         "kast": 37.5
+      },
+      "opening_duel_stats": {
+        "opening_kills": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_deaths": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_success": 0
       }
     },
     "76561198387460920": {
@@ -111,6 +150,19 @@
         "aces": 0,
         "clutches_won": 0,
         "kast": 87.5
+      },
+      "opening_duel_stats": {
+        "opening_kills": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_deaths": {
+          "total": 1,
+          "ct": 1,
+          "t": 0
+        },
+        "opening_success": 0
       }
     },
     "76561198826243397": {
@@ -140,6 +192,19 @@
         "aces": 0,
         "clutches_won": 0,
         "kast": 75
+      },
+      "opening_duel_stats": {
+        "opening_kills": {
+          "total": 2,
+          "ct": 2,
+          "t": 0
+        },
+        "opening_deaths": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_success": 100
       }
     },
     "76561198966281369": {
@@ -172,6 +237,19 @@
         "aces": 0,
         "clutches_won": 0,
         "kast": 100
+      },
+      "opening_duel_stats": {
+        "opening_kills": {
+          "total": 3,
+          "ct": 3,
+          "t": 0
+        },
+        "opening_deaths": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_success": 100
       }
     },
     "76561199102419525": {
@@ -202,6 +280,19 @@
         "aces": 0,
         "clutches_won": 1,
         "kast": 62.5
+      },
+      "opening_duel_stats": {
+        "opening_kills": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_deaths": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_success": 0
       }
     },
     "76561199271102802": {
@@ -230,6 +321,19 @@
         "aces": 0,
         "clutches_won": 0,
         "kast": 25
+      },
+      "opening_duel_stats": {
+        "opening_kills": {
+          "total": 1,
+          "ct": 0,
+          "t": 1
+        },
+        "opening_deaths": {
+          "total": 2,
+          "ct": 0,
+          "t": 2
+        },
+        "opening_success": 100
       }
     },
     "76561199311359933": {
@@ -259,6 +363,19 @@
         "aces": 0,
         "clutches_won": 0,
         "kast": 25
+      },
+      "opening_duel_stats": {
+        "opening_kills": {
+          "total": 1,
+          "ct": 0,
+          "t": 1
+        },
+        "opening_deaths": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_success": 100
       }
     },
     "76561199558715190": {
@@ -288,6 +405,19 @@
         "aces": 0,
         "clutches_won": 0,
         "kast": 62.5
+      },
+      "opening_duel_stats": {
+        "opening_kills": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_deaths": {
+          "total": 3,
+          "ct": 0,
+          "t": 3
+        },
+        "opening_success": 0
       }
     }
   },

--- a/cmd/demo_parser/testdata/golden_ancient.json
+++ b/cmd/demo_parser/testdata/golden_ancient.json
@@ -39,7 +39,7 @@
           "ct": 1,
           "t": 0
         },
-        "opening_success": 0
+        "opening_success_rate": 0
       }
     },
     "76561198071075349": {
@@ -82,7 +82,7 @@
           "ct": 0,
           "t": 0
         },
-        "opening_success": 0
+        "opening_success_rate": 0
       }
     },
     "76561198307159112": {
@@ -123,7 +123,7 @@
           "ct": 0,
           "t": 0
         },
-        "opening_success": 0
+        "opening_success_rate": 0
       }
     },
     "76561198387460920": {
@@ -162,7 +162,7 @@
           "ct": 1,
           "t": 0
         },
-        "opening_success": 0
+        "opening_success_rate": 0
       }
     },
     "76561198826243397": {
@@ -204,7 +204,7 @@
           "ct": 0,
           "t": 0
         },
-        "opening_success": 100
+        "opening_success_rate": 100
       }
     },
     "76561198966281369": {
@@ -249,7 +249,7 @@
           "ct": 0,
           "t": 0
         },
-        "opening_success": 100
+        "opening_success_rate": 100
       }
     },
     "76561199102419525": {
@@ -292,7 +292,7 @@
           "ct": 0,
           "t": 0
         },
-        "opening_success": 0
+        "opening_success_rate": 0
       }
     },
     "76561199271102802": {
@@ -333,7 +333,7 @@
           "ct": 0,
           "t": 2
         },
-        "opening_success": 100
+        "opening_success_rate": 100
       }
     },
     "76561199311359933": {
@@ -375,7 +375,7 @@
           "ct": 0,
           "t": 0
         },
-        "opening_success": 100
+        "opening_success_rate": 100
       }
     },
     "76561199558715190": {
@@ -417,7 +417,7 @@
           "ct": 0,
           "t": 3
         },
-        "opening_success": 0
+        "opening_success_rate": 0
       }
     }
   },

--- a/cmd/demo_parser/testdata/golden_mirage.json
+++ b/cmd/demo_parser/testdata/golden_mirage.json
@@ -41,7 +41,7 @@
           "ct": 0,
           "t": 0
         },
-        "opening_success": 100
+        "opening_success_rate": 100
       }
     },
     "76561198073049527": {
@@ -84,7 +84,7 @@
           "ct": 2,
           "t": 0
         },
-        "opening_success": 0
+        "opening_success_rate": 0
       }
     },
     "76561198118803912": {
@@ -126,7 +126,7 @@
           "ct": 0,
           "t": 1
         },
-        "opening_success": 0
+        "opening_success_rate": 0
       }
     },
     "76561198194694750": {
@@ -171,7 +171,7 @@
           "ct": 2,
           "t": 0
         },
-        "opening_success": 0
+        "opening_success_rate": 0
       }
     },
     "76561198202353993": {
@@ -214,7 +214,7 @@
           "ct": 0,
           "t": 0
         },
-        "opening_success": 0
+        "opening_success_rate": 0
       }
     },
     "76561198244754626": {
@@ -257,7 +257,7 @@
           "ct": 0,
           "t": 0
         },
-        "opening_success": 80
+        "opening_success_rate": 80
       }
     },
     "76561198258044111": {
@@ -300,7 +300,7 @@
           "ct": 0,
           "t": 0
         },
-        "opening_success": 0
+        "opening_success_rate": 0
       }
     },
     "76561198265366770": {
@@ -342,7 +342,7 @@
           "ct": 0,
           "t": 0
         },
-        "opening_success": 100
+        "opening_success_rate": 100
       }
     },
     "76561198280975787": {
@@ -385,7 +385,7 @@
           "ct": 1,
           "t": 0
         },
-        "opening_success": 100
+        "opening_success_rate": 100
       }
     },
     "76561198324843075": {
@@ -427,7 +427,7 @@
           "ct": 3,
           "t": 0
         },
-        "opening_success": 0
+        "opening_success_rate": 0
       }
     }
   },

--- a/cmd/demo_parser/testdata/golden_mirage.json
+++ b/cmd/demo_parser/testdata/golden_mirage.json
@@ -29,6 +29,19 @@
         "aces": 0,
         "clutches_won": 0,
         "kast": 100
+      },
+      "opening_duel_stats": {
+        "opening_kills": {
+          "total": 2,
+          "ct": 0,
+          "t": 2
+        },
+        "opening_deaths": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_success": 100
       }
     },
     "76561198073049527": {
@@ -59,6 +72,19 @@
         "aces": 0,
         "clutches_won": 0,
         "kast": 70
+      },
+      "opening_duel_stats": {
+        "opening_kills": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_deaths": {
+          "total": 2,
+          "ct": 2,
+          "t": 0
+        },
+        "opening_success": 0
       }
     },
     "76561198118803912": {
@@ -88,6 +114,19 @@
         "aces": 0,
         "clutches_won": 0,
         "kast": 80
+      },
+      "opening_duel_stats": {
+        "opening_kills": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_deaths": {
+          "total": 1,
+          "ct": 0,
+          "t": 1
+        },
+        "opening_success": 0
       }
     },
     "76561198194694750": {
@@ -120,6 +159,19 @@
         "aces": 0,
         "clutches_won": 1,
         "kast": 50
+      },
+      "opening_duel_stats": {
+        "opening_kills": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_deaths": {
+          "total": 2,
+          "ct": 2,
+          "t": 0
+        },
+        "opening_success": 0
       }
     },
     "76561198202353993": {
@@ -150,6 +202,19 @@
         "aces": 0,
         "clutches_won": 0,
         "kast": 90
+      },
+      "opening_duel_stats": {
+        "opening_kills": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_deaths": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_success": 0
       }
     },
     "76561198244754626": {
@@ -180,6 +245,19 @@
         "aces": 0,
         "clutches_won": 0,
         "kast": 90
+      },
+      "opening_duel_stats": {
+        "opening_kills": {
+          "total": 5,
+          "ct": 0,
+          "t": 5
+        },
+        "opening_deaths": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_success": 80
       }
     },
     "76561198258044111": {
@@ -210,6 +288,19 @@
         "aces": 0,
         "clutches_won": 0,
         "kast": 60
+      },
+      "opening_duel_stats": {
+        "opening_kills": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_deaths": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_success": 0
       }
     },
     "76561198265366770": {
@@ -239,6 +330,19 @@
         "aces": 0,
         "clutches_won": 0,
         "kast": 100
+      },
+      "opening_duel_stats": {
+        "opening_kills": {
+          "total": 1,
+          "ct": 0,
+          "t": 1
+        },
+        "opening_deaths": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_success": 100
       }
     },
     "76561198280975787": {
@@ -269,6 +373,19 @@
         "aces": 0,
         "clutches_won": 0,
         "kast": 30
+      },
+      "opening_duel_stats": {
+        "opening_kills": {
+          "total": 1,
+          "ct": 1,
+          "t": 0
+        },
+        "opening_deaths": {
+          "total": 1,
+          "ct": 1,
+          "t": 0
+        },
+        "opening_success": 100
       }
     },
     "76561198324843075": {
@@ -298,6 +415,19 @@
         "aces": 0,
         "clutches_won": 0,
         "kast": 70
+      },
+      "opening_duel_stats": {
+        "opening_kills": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "opening_deaths": {
+          "total": 3,
+          "ct": 3,
+          "t": 0
+        },
+        "opening_success": 0
       }
     }
   },

--- a/cmd/demo_parser/types.go
+++ b/cmd/demo_parser/types.go
@@ -30,10 +30,14 @@ type SideCount struct {
 	T     int `json:"t"`
 }
 
+// OpeningDuelStats counts the rounds a player opened or was opened on.
+// OpeningSuccessRate is a percentage rather than a count, and is named apart
+// from the counts because other trackers use "opening success" for the
+// opening-kill tally itself.
 type OpeningDuelStats struct {
-	OpeningKills   SideCount `json:"opening_kills"`
-	OpeningDeaths  SideCount `json:"opening_deaths"`
-	OpeningSuccess float64   `json:"opening_success"`
+	OpeningKills       SideCount `json:"opening_kills"`
+	OpeningDeaths      SideCount `json:"opening_deaths"`
+	OpeningSuccessRate float64   `json:"opening_success_rate"`
 }
 
 type DemoPlayer struct {

--- a/cmd/demo_parser/types.go
+++ b/cmd/demo_parser/types.go
@@ -23,14 +23,28 @@ type PlayerMapStats struct {
 	KAST        float64 `json:"kast"`
 }
 
+// SideCount is a per-round counter split by the side the player was on.
+type SideCount struct {
+	Total int `json:"total"`
+	CT    int `json:"ct"`
+	T     int `json:"t"`
+}
+
+type OpeningDuelStats struct {
+	OpeningKills   SideCount `json:"opening_kills"`
+	OpeningDeaths  SideCount `json:"opening_deaths"`
+	OpeningSuccess float64   `json:"opening_success"`
+}
+
 type DemoPlayer struct {
-	SteamID        uint64         `json:"steam_id"`
-	Name           string         `json:"name"`
-	UserID         int            `json:"user_id"`
-	Deaths         int            `json:"deaths"`
-	KillStats      KillStats      `json:"kill_stats"`
-	AssistStats    AssistStats    `json:"assist_stats"`
-	PlayerMapStats PlayerMapStats `json:"player_map_stats"`
+	SteamID          uint64           `json:"steam_id"`
+	Name             string           `json:"name"`
+	UserID           int              `json:"user_id"`
+	Deaths           int              `json:"deaths"`
+	KillStats        KillStats        `json:"kill_stats"`
+	AssistStats      AssistStats      `json:"assist_stats"`
+	PlayerMapStats   PlayerMapStats   `json:"player_map_stats"`
+	OpeningDuelStats OpeningDuelStats `json:"opening_duel_stats"`
 }
 
 type MapData struct {


### PR DESCRIPTION
Closes #4

The round tracker records the first enemy kill of each round as the opening duel. Teamkills, suicides, world deaths and kills landing after the round is decided never open a round.

- Per player: opening kills and opening deaths with a CT/T side split, plus `opening_success` — the percentage of opening-kill rounds their team went on to win.
- JSON export: new `opening_duel_stats` group (`opening_kills`, `opening_deaths`, `opening_success`).
- Table: new `Entry` column showing `kills:deaths`, e.g. `5:3`.
- CSV: Opening Kills, Opening Deaths and Opening Success (%) columns.
- Docs updated in `_docs/PLAYER_DATA.MD`; golden files regenerated against both fixture demos.
