### PR TITLE
Multi-kill rounds: 2k/3k/4k/5k buckets and a --details table

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ analyse [flags]
 - `-p, --players <players>`: A list of players to analyse. This should be provided as a comma-separated list of player names.
 - `-s, --save`: Flag to save the demo player's data.
 - `--save-type <type>`: Type of file to save the data. Options are `json` and `csv`. The default is `json`.
+- `--details`: Print the extra stat tables that do not fit the main one, such as multi-kill rounds.
 
 #### Options
 

--- a/_docs/PLAYER_DATA.MD
+++ b/_docs/PLAYER_DATA.MD
@@ -1,6 +1,6 @@
 # Player data
 
-The `--save` flag writes every analysed player to a file. JSON contains all fields below; CSV contains a flattened selection of them plus the computed K/D. Stats never include warmup. Bots are never listed, but kills on bots count like any other kill.
+The `--save` flag writes every analysed player to a file. JSON contains all fields below; CSV contains a flattened selection of them plus the computed K/D. The CLI table shows a narrower selection still, with `--details` printing the rest in extra tables below it. Stats never include warmup. Bots are never listed, but kills on bots count like any other kill.
 
 ## Fields
 
@@ -50,8 +50,21 @@ The 5-second window is a deliberate choice, not a value read out of the demo: HL
 | --- | --- | --- |
 | MVPs | `mvps` | Round MVP awards. |
 | ACEs | `aces` | Rounds with 5 or more enemy kills. |
+| MultiKills | `multi_kills` | Multi-kill rounds bucketed by kill count: `{k2, k3, k4, k5}`. See [multi-kill rounds](#multi-kill-rounds). |
 | ClutchesWon | `clutches_won` | Rounds won after being the last player alive on the team against at least one enemy (1v1 counts). Winning by defuse or time counts — no kills required. |
 | KAST | `kast` | Percentage of the match's rounds with a Kill, Assist, Survival or Traded death (a teammate killed your killer within 5 seconds). Dying before the round officially ends cancels survival — including exit frags and the bomb going off after the whistle (HLTV convention). Match-end cleanup kills do not count. |
+
+#### Multi-kill rounds
+
+`multi_kills` counts rounds, not kills. A round with three enemy kills adds one to `k3`, and nothing else.
+
+- **Buckets are exclusive.** A 4k is only a 4k, never also a 2k and a 3k. So `k2 + k3 + k4 + k5` is the number of rounds the player got at least two enemy kills in, and each bucket is directly usable as one of the six sub-ratings of HLTV Rating 3.0.
+- **Enemy kills only**, the same rule ACEs use. Teamkills never count, so four enemy kills plus a teamkill is a 4k.
+- **A round with 0 or 1 kills is in no bucket.** The smallest multi-kill is the 2k.
+- **Post-round kills count**, exit frags included, again matching ACEs.
+- **`k5` and `aces` are the same rounds by construction.** Both are "5 or more enemy kills" — `k5` takes everything from 5 up rather than exactly 5, so the two can never disagree even in the freak case of a sixth kill after a disconnect and reconnect. The duplication is deliberate: `multi_kills` stays a complete, self-contained bucket set for the rating work, and `aces` stays where it has always been for anything already reading it.
+
+The four counts are in the JSON, in the CSV as the `2K`/`3K`/`4K`/`5K` columns, and in the `Multi-kill rounds` table that `--details` prints. The main table does not show them; it is already wide enough.
 
 ### Opening duel stats (`opening_duel_stats`)
 

--- a/cmd/analyse.go
+++ b/cmd/analyse.go
@@ -19,6 +19,7 @@ var players []string // players is the list of players to analyse.
 var demoPath string  // demoPath is the path to the demo file.
 var save bool        // save is the flag to save the demo players data.
 var saveType string  // saveType is the type of storage to use.
+var details bool     // details prints the stats that do not fit the main table.
 
 func init() {
 	// Add the analyse command as a subcommand of rootCmd.
@@ -28,6 +29,7 @@ func init() {
 	analyseCmd.Flags().StringSliceVarP(&players, "players", "p", []string{}, "Players to analyse.")
 	analyseCmd.Flags().BoolVarP(&save, "save", "s", false, "Save the demo players data.")
 	analyseCmd.Flags().StringVar(&saveType, "save-type", "json", "Type of file to save the data [json, csv], default is json.")
+	analyseCmd.Flags().BoolVar(&details, "details", false, "Print the extra stat tables that do not fit the main one.")
 }
 
 var analyseCmd = &cobra.Command{
@@ -92,6 +94,9 @@ var analyseCmd = &cobra.Command{
 		}
 
 		dataexport.PrintCLIDataTable(playersToAnalyse, &processedDemoData.Map, processedDemoData.GameMode)
+		if details {
+			dataexport.PrintCLIDetailTables(playersToAnalyse)
+		}
 
 		if save {
 			lipgloss.Println(printstyle.StyleSuccess.Render("\nWritting data to file..."))

--- a/cmd/dataexport/player_export.go
+++ b/cmd/dataexport/player_export.go
@@ -1,13 +1,10 @@
 package dataexport
 
 import (
-	"cmp"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
-	"maps"
 	"os"
-	"slices"
 	"time"
 
 	demoparser "github.com/taua-almeida/cs2-analyser-tool/cmd/demo_parser"
@@ -23,15 +20,10 @@ func WritePlayersToFile(players map[uint64]*demoparser.DemoPlayer, saveType stri
 		}
 		defer csvFile.Close()
 
-		// Sort rows by kills so the CSV matches the table output.
-		sortedPlayers := slices.SortedFunc(maps.Values(players), func(a, b *demoparser.DemoPlayer) int {
-			return cmp.Compare(b.KillStats.Total, a.KillStats.Total)
-		})
-
 		csvRecords := [][]string{
-			{"Name", "Kills", "Deaths", "K/D", "HS", "Assists", "Flash Assists", "Damage Given", "ADR", "KAST (%)", "Precision (%)", "Trade Kills", "Opening Kills", "Opening Deaths", "Opening Success (%)", "MVPs", "ACEs", "Clutches Won", "Best Weapon"},
+			{"Name", "Kills", "Deaths", "K/D", "HS", "Assists", "Flash Assists", "Damage Given", "ADR", "KAST (%)", "Precision (%)", "Trade Kills", "Opening Kills", "Opening Deaths", "Opening Success (%)", "MVPs", "ACEs", "2K", "3K", "4K", "5K", "Clutches Won", "Best Weapon"},
 		}
-		for _, player := range sortedPlayers {
+		for _, player := range sortedByKills(players) {
 			csvRecords = append(csvRecords, []string{
 				player.Name,
 				fmt.Sprintf("%d", player.KillStats.Total),
@@ -50,6 +42,10 @@ func WritePlayersToFile(players map[uint64]*demoparser.DemoPlayer, saveType stri
 				fmt.Sprintf("%.1f", player.OpeningDuelStats.OpeningSuccessRate),
 				fmt.Sprintf("%d", player.PlayerMapStats.MVPs),
 				fmt.Sprintf("%d", player.PlayerMapStats.ACEs),
+				fmt.Sprintf("%d", player.PlayerMapStats.MultiKills.K2),
+				fmt.Sprintf("%d", player.PlayerMapStats.MultiKills.K3),
+				fmt.Sprintf("%d", player.PlayerMapStats.MultiKills.K4),
+				fmt.Sprintf("%d", player.PlayerMapStats.MultiKills.K5),
 				fmt.Sprintf("%d", player.PlayerMapStats.ClutchesWon),
 				demoparser.GetPlayerBestWeapon(player.KillStats.WeaponsKills),
 			})

--- a/cmd/dataexport/table_print.go
+++ b/cmd/dataexport/table_print.go
@@ -1,13 +1,28 @@
 package dataexport
 
 import (
+	"cmp"
 	"fmt"
+	"maps"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	demoparser "github.com/taua-almeida/cs2-analyser-tool/cmd/demo_parser"
 )
+
+// sortedByKills orders players the way the main table does, most kills
+// first, so every output lists them in the same order. Ties break by name
+// to keep that order stable across runs.
+func sortedByKills(players map[uint64]*demoparser.DemoPlayer) []*demoparser.DemoPlayer {
+	return slices.SortedFunc(maps.Values(players), func(a, b *demoparser.DemoPlayer) int {
+		if c := cmp.Compare(b.KillStats.Total, a.KillStats.Total); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Name, b.Name)
+	})
+}
 
 // kdRatio formats kills/deaths, treating zero deaths as one so the ratio
 // stays finite.
@@ -48,6 +63,26 @@ func PrintCLIDataTable(playerToAnalyse map[uint64]*demoparser.DemoPlayer, mapDat
 	t.AppendFooter(table.Row{"Score CT : T", fmt.Sprintf("%d : %d", mapData.RoundsWonCT, mapData.RoundsWonT)})
 	if gameMode != "" {
 		t.SetCaption("This is a demo of a: %s game\n", strings.ToUpper(gameMode))
+	}
+	t.Render()
+}
+
+// PrintCLIDetailTables prints the stats that do not fit the main table,
+// each in its own narrow table. Only shown with --details.
+func PrintCLIDetailTables(playerToAnalyse map[uint64]*demoparser.DemoPlayer) {
+	printMultiKillTable(playerToAnalyse)
+}
+
+// printMultiKillTable lists the multi-kill rounds per player. The buckets
+// are exclusive, so each round shows up in exactly one column.
+func printMultiKillTable(playerToAnalyse map[uint64]*demoparser.DemoPlayer) {
+	t := table.NewWriter()
+	t.SetOutputMirror(os.Stdout)
+	t.SetTitle("Multi-kill rounds")
+	t.AppendHeader(table.Row{"Name", "2K", "3K", "4K", "5K"})
+	for _, player := range sortedByKills(playerToAnalyse) {
+		multiKills := player.PlayerMapStats.MultiKills
+		t.AppendRow(table.Row{player.Name, multiKills.K2, multiKills.K3, multiKills.K4, multiKills.K5})
 	}
 	t.Render()
 }

--- a/cmd/demo_parser/demo_parser.go
+++ b/cmd/demo_parser/demo_parser.go
@@ -264,6 +264,22 @@ func (s *SideCount) count(side common.Team) {
 	}
 }
 
+// add credits one round with the given number of enemy kills to its bucket.
+// The top bucket takes everything from aceKills up, so it always holds the
+// same rounds as ACEs, and rounds below multiKillMin fall through uncounted.
+func (m *MultiKillRounds) add(kills int) {
+	switch {
+	case kills >= aceKills:
+		m.K5++
+	case kills == 4:
+		m.K4++
+	case kills == 3:
+		m.K3++
+	case kills == 2:
+		m.K2++
+	}
+}
+
 func (a *analyser) applyRoundOutcome(outcome roundOutcome) {
 	if !outcome.played {
 		return
@@ -271,6 +287,11 @@ func (a *analyser) applyRoundOutcome(outcome roundOutcome) {
 	for _, id := range outcome.aces {
 		if p := a.players[id]; p != nil {
 			p.PlayerMapStats.ACEs++
+		}
+	}
+	for id, kills := range outcome.multiKills {
+		if p := a.players[id]; p != nil {
+			p.PlayerMapStats.MultiKills.add(kills)
 		}
 	}
 	if p := a.players[outcome.clutcher]; p != nil {

--- a/cmd/demo_parser/round_tracker.go
+++ b/cmd/demo_parser/round_tracker.go
@@ -13,6 +13,10 @@ const tradeWindow = 5 * time.Second
 // aceKills is the number of enemy kills in a single round that make an ace.
 const aceKills = 5
 
+// multiKillMin is the fewest enemy kills in a round that make it a
+// multi-kill round, the smallest bucket being the 2k.
+const multiKillMin = 2
+
 var bothTeams = []common.Team{common.TeamTerrorists, common.TeamCounterTerrorists}
 
 type deathRecord struct {
@@ -33,7 +37,8 @@ type openingDuel struct {
 type roundOutcome struct {
 	played       bool
 	aces         []uint64
-	clutcher     uint64 // winner-side player that won a 1vX, 0 if none
+	multiKills   map[uint64]int // enemy kills of the players that got at least a 2k
+	clutcher     uint64         // winner-side player that won a 1vX, 0 if none
 	opening      openingDuel
 	openingWon   bool // the opening killer's team won the round
 	participants map[uint64]common.Team
@@ -198,6 +203,7 @@ func (rt *roundTracker) finalize() roundOutcome {
 
 	outcome := roundOutcome{
 		played:       true,
+		multiKills:   make(map[uint64]int),
 		clutcher:     rt.clutchers[rt.winner],
 		opening:      rt.opening,
 		openingWon:   rt.opening.killer != 0 && rt.opening.killerTeam == rt.winner,
@@ -207,6 +213,9 @@ func (rt *roundTracker) finalize() roundOutcome {
 	for id, kills := range rt.enemyKills {
 		if kills >= aceKills {
 			outcome.aces = append(outcome.aces, id)
+		}
+		if kills >= multiKillMin {
+			outcome.multiKills[id] = kills
 		}
 	}
 	for id := range rt.startAlive {

--- a/cmd/demo_parser/round_tracker_test.go
+++ b/cmd/demo_parser/round_tracker_test.go
@@ -79,6 +79,102 @@ func TestTeamkillsDoNotMakeAnAce(t *testing.T) {
 	}
 }
 
+// killEnemies has player 1 kill n CTs in one round.
+func killEnemies(rt *roundTracker, n int) {
+	for i := range n {
+		rt.kill(1, uint64(11+i), common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10+i))
+	}
+}
+
+// bucketOf runs a round in which player 1 gets n enemy kills and reports
+// which multi-kill bucket it landed in, or 0 for no multi-kill at all.
+// Landing in two buckets is the failure the exclusivity test is after, so
+// it is reported here rather than silently collapsed.
+func bucketOf(t *testing.T, n int) int {
+	t.Helper()
+	rt := newRoundTracker()
+	rt.startRound(fiveVsFive())
+	killEnemies(rt, n)
+
+	var got MultiKillRounds
+	got.add(endRound(rt, common.TeamTerrorists).multiKills[1])
+	switch got {
+	case MultiKillRounds{}:
+		return 0
+	case MultiKillRounds{K2: 1}:
+		return 2
+	case MultiKillRounds{K3: 1}:
+		return 3
+	case MultiKillRounds{K4: 1}:
+		return 4
+	case MultiKillRounds{K5: 1}:
+		return 5
+	}
+	t.Fatalf("%d enemy kills landed in more than one bucket: %+v", n, got)
+	return 0
+}
+
+func TestMultiKillBuckets(t *testing.T) {
+	// Buckets are exclusive: every round lands in exactly one of them, and
+	// a single kill is no multi-kill at all.
+	cases := []struct{ kills, bucket int }{
+		{0, 0}, {1, 0}, {2, 2}, {3, 3}, {4, 4}, {5, 5},
+	}
+	for _, c := range cases {
+		if got := bucketOf(t, c.kills); got != c.bucket {
+			t.Errorf("%d enemy kills landed in bucket %d, want %d (0 = no multi-kill)", c.kills, got, c.bucket)
+		}
+	}
+}
+
+func TestMultiKillTopBucketMatchesAce(t *testing.T) {
+	rt := newRoundTracker()
+	rt.startRound(fiveVsFive())
+
+	// Six enemy kills need a CT who reconnected, but if it ever happens the
+	// round has to stay a single 5k so the bucket cannot drift from ACEs.
+	killEnemies(rt, 5)
+	rt.kill(1, 16, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(20))
+
+	outcome := endRound(rt, common.TeamTerrorists)
+	var got MultiKillRounds
+	got.add(outcome.multiKills[1])
+	if want := (MultiKillRounds{K5: 1}); got != want {
+		t.Errorf("six kills gave %+v, want %+v", got, want)
+	}
+	if !slices.Contains(outcome.aces, uint64(1)) {
+		t.Errorf("six kills must also be an ace, aces = %v", outcome.aces)
+	}
+}
+
+func TestTeamkillsDoNotMakeAMultiKill(t *testing.T) {
+	rt := newRoundTracker()
+	rt.startRound(fiveVsFive())
+
+	// One enemy kill plus two teamkills is not a 3k, and not even a 2k.
+	rt.kill(1, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10))
+	rt.kill(1, 2, common.TeamTerrorists, common.TeamTerrorists, 0, false, at(12))
+	rt.kill(1, 3, common.TeamTerrorists, common.TeamTerrorists, 0, false, at(14))
+
+	if outcome := endRound(rt, common.TeamTerrorists); len(outcome.multiKills) != 0 {
+		t.Errorf("teamkills counted towards a multi-kill: %v", outcome.multiKills)
+	}
+}
+
+func TestMultiKillCountsPostRoundKills(t *testing.T) {
+	rt := newRoundTracker()
+	rt.startRound(fiveVsFive())
+	rt.markEnd(common.TeamTerrorists)
+
+	// Exit frags are enemy kills like any other, the same way they already
+	// count towards an ace.
+	killEnemies(rt, 2)
+
+	if outcome := rt.finalize(); outcome.multiKills[1] != 2 {
+		t.Errorf("multiKills[1] = %d, want 2 post-round kills to count", outcome.multiKills[1])
+	}
+}
+
 func TestClutchWon(t *testing.T) {
 	rt := newRoundTracker()
 	rt.startRound(fiveVsFive())

--- a/cmd/demo_parser/testdata/golden_ancient.json
+++ b/cmd/demo_parser/testdata/golden_ancient.json
@@ -25,6 +25,12 @@
       "player_map_stats": {
         "mvps": 1,
         "aces": 0,
+        "multi_kills": {
+          "k2": 1,
+          "k3": 0,
+          "k4": 0,
+          "k5": 0
+        },
         "clutches_won": 0,
         "kast": 87.5
       },
@@ -68,6 +74,12 @@
       "player_map_stats": {
         "mvps": 1,
         "aces": 0,
+        "multi_kills": {
+          "k2": 2,
+          "k3": 0,
+          "k4": 0,
+          "k5": 0
+        },
         "clutches_won": 1,
         "kast": 100
       },
@@ -109,6 +121,12 @@
       "player_map_stats": {
         "mvps": 0,
         "aces": 0,
+        "multi_kills": {
+          "k2": 0,
+          "k3": 0,
+          "k4": 0,
+          "k5": 0
+        },
         "clutches_won": 0,
         "kast": 37.5
       },
@@ -148,6 +166,12 @@
       "player_map_stats": {
         "mvps": 0,
         "aces": 0,
+        "multi_kills": {
+          "k2": 0,
+          "k3": 0,
+          "k4": 0,
+          "k5": 0
+        },
         "clutches_won": 0,
         "kast": 87.5
       },
@@ -190,6 +214,12 @@
       "player_map_stats": {
         "mvps": 1,
         "aces": 0,
+        "multi_kills": {
+          "k2": 1,
+          "k3": 0,
+          "k4": 0,
+          "k5": 0
+        },
         "clutches_won": 0,
         "kast": 75
       },
@@ -235,6 +265,12 @@
       "player_map_stats": {
         "mvps": 2,
         "aces": 0,
+        "multi_kills": {
+          "k2": 2,
+          "k3": 1,
+          "k4": 0,
+          "k5": 0
+        },
         "clutches_won": 0,
         "kast": 100
       },
@@ -278,6 +314,12 @@
       "player_map_stats": {
         "mvps": 1,
         "aces": 0,
+        "multi_kills": {
+          "k2": 1,
+          "k3": 1,
+          "k4": 0,
+          "k5": 0
+        },
         "clutches_won": 1,
         "kast": 62.5
       },
@@ -319,6 +361,12 @@
       "player_map_stats": {
         "mvps": 0,
         "aces": 0,
+        "multi_kills": {
+          "k2": 0,
+          "k3": 0,
+          "k4": 0,
+          "k5": 0
+        },
         "clutches_won": 0,
         "kast": 25
       },
@@ -361,6 +409,12 @@
       "player_map_stats": {
         "mvps": 1,
         "aces": 0,
+        "multi_kills": {
+          "k2": 1,
+          "k3": 1,
+          "k4": 0,
+          "k5": 0
+        },
         "clutches_won": 0,
         "kast": 25
       },
@@ -403,6 +457,12 @@
       "player_map_stats": {
         "mvps": 0,
         "aces": 0,
+        "multi_kills": {
+          "k2": 0,
+          "k3": 0,
+          "k4": 0,
+          "k5": 0
+        },
         "clutches_won": 0,
         "kast": 62.5
       },

--- a/cmd/demo_parser/testdata/golden_mirage.json
+++ b/cmd/demo_parser/testdata/golden_mirage.json
@@ -27,6 +27,12 @@
       "player_map_stats": {
         "mvps": 1,
         "aces": 0,
+        "multi_kills": {
+          "k2": 2,
+          "k3": 1,
+          "k4": 0,
+          "k5": 0
+        },
         "clutches_won": 0,
         "kast": 100
       },
@@ -70,6 +76,12 @@
       "player_map_stats": {
         "mvps": 0,
         "aces": 0,
+        "multi_kills": {
+          "k2": 0,
+          "k3": 0,
+          "k4": 0,
+          "k5": 0
+        },
         "clutches_won": 0,
         "kast": 70
       },
@@ -112,6 +124,12 @@
       "player_map_stats": {
         "mvps": 1,
         "aces": 0,
+        "multi_kills": {
+          "k2": 1,
+          "k3": 0,
+          "k4": 0,
+          "k5": 0
+        },
         "clutches_won": 0,
         "kast": 80
       },
@@ -157,6 +175,12 @@
       "player_map_stats": {
         "mvps": 1,
         "aces": 0,
+        "multi_kills": {
+          "k2": 2,
+          "k3": 0,
+          "k4": 0,
+          "k5": 0
+        },
         "clutches_won": 1,
         "kast": 50
       },
@@ -200,6 +224,12 @@
       "player_map_stats": {
         "mvps": 3,
         "aces": 0,
+        "multi_kills": {
+          "k2": 1,
+          "k3": 0,
+          "k4": 0,
+          "k5": 0
+        },
         "clutches_won": 0,
         "kast": 90
       },
@@ -243,6 +273,12 @@
       "player_map_stats": {
         "mvps": 1,
         "aces": 0,
+        "multi_kills": {
+          "k2": 2,
+          "k3": 0,
+          "k4": 0,
+          "k5": 0
+        },
         "clutches_won": 0,
         "kast": 90
       },
@@ -286,6 +322,12 @@
       "player_map_stats": {
         "mvps": 1,
         "aces": 0,
+        "multi_kills": {
+          "k2": 3,
+          "k3": 0,
+          "k4": 0,
+          "k5": 0
+        },
         "clutches_won": 0,
         "kast": 60
       },
@@ -328,6 +370,12 @@
       "player_map_stats": {
         "mvps": 1,
         "aces": 0,
+        "multi_kills": {
+          "k2": 4,
+          "k3": 0,
+          "k4": 0,
+          "k5": 0
+        },
         "clutches_won": 0,
         "kast": 100
       },
@@ -371,6 +419,12 @@
       "player_map_stats": {
         "mvps": 0,
         "aces": 0,
+        "multi_kills": {
+          "k2": 1,
+          "k3": 0,
+          "k4": 0,
+          "k5": 0
+        },
         "clutches_won": 0,
         "kast": 30
       },
@@ -413,6 +467,12 @@
       "player_map_stats": {
         "mvps": 0,
         "aces": 0,
+        "multi_kills": {
+          "k2": 0,
+          "k3": 0,
+          "k4": 0,
+          "k5": 0
+        },
         "clutches_won": 0,
         "kast": 70
       },

--- a/cmd/demo_parser/types.go
+++ b/cmd/demo_parser/types.go
@@ -16,11 +16,22 @@ type AssistStats struct {
 	ADR            float64 `json:"adr"`
 }
 
+// MultiKillRounds counts rounds by how many enemies the player killed in
+// them. The buckets are exclusive, so a 4k round is only a 4k and the four
+// of them add up to the rounds with at least two enemy kills.
+type MultiKillRounds struct {
+	K2 int `json:"k2"`
+	K3 int `json:"k3"`
+	K4 int `json:"k4"`
+	K5 int `json:"k5"`
+}
+
 type PlayerMapStats struct {
-	MVPs        int     `json:"mvps"`
-	ACEs        int     `json:"aces"`
-	ClutchesWon int     `json:"clutches_won"`
-	KAST        float64 `json:"kast"`
+	MVPs        int             `json:"mvps"`
+	ACEs        int             `json:"aces"`
+	MultiKills  MultiKillRounds `json:"multi_kills"`
+	ClutchesWon int             `json:"clutches_won"`
+	KAST        float64         `json:"kast"`
 }
 
 // SideCount is a per-round counter split by the side the player was on.


### PR DESCRIPTION
First half of #5. Counts the rounds in which a player got 2, 3, 4 or 5 enemy kills. The CT/T side splits are the second half and follow in a PR stacked on this one.

`roundTracker.enemyKills` already had the numbers — this reads the same map ACEs read and hands the counts to `roundOutcome.multiKills`, which `applyRoundOutcome` buckets onto the player.

### Decisions

**Buckets are exclusive.** A 4k round increments `k4` and nothing else, so `k2 + k3 + k4 + k5` is the number of rounds with at least two enemy kills, and each bucket drops straight into the multi-kill sub-rating of Rating 3.0 (#3). Cumulative buckets would have made the rating differencing them first.

**`k5` is kept alongside `aces`, deliberately redundant.** Both are "5 or more enemy kills", so they cannot disagree — `k5` takes everything from 5 up rather than exactly 5, which also covers the freak case of a 6th kill after a reconnect. The reason to keep both: `multi_kills` stays a complete self-contained bucket set for the rating work, and removing `aces` would break the documented JSON key and the CSV column for anything already reading them.

**The main table does not show them.** It is 11 columns already and #6 flags the same crowding, so this adds a `--details` flag that prints a narrow `Multi-kill rounds` table below the main one. #6 sketched the same flag for utility stats, so it has a second user waiting. JSON always carries the fields; CSV gains `2K`/`3K`/`4K`/`5K`.

One thing that came along for the ride: the CSV's kills sort is now a shared `sortedByKills` helper the detail table uses too, with a name tie-break added so equal-kill players stop reordering between runs.

### Verification

- Goldens regenerated: **+120 lines, 0 deletions** across both fixtures. No existing value moved.
- `gofmt -l .`, `go vet ./...` and `REQUIRE_TEST_DEMO=1 go test ./...` clean.
- New tracker tests cover the bucket boundaries (a 2k is not a 3k, 1 kill is no bucket at all, no round lands in two buckets), teamkills not counting, the top bucket agreeing with ACEs at 6 kills, and post-round exit frags counting the way they already do for ACEs.

Rules and the aces overlap are documented in `_docs/PLAYER_DATA.MD` under "Multi-kill rounds".

Part of #5.
