### PR TITLE
CT/T side splits for kills, deaths, ADR and KAST

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ analyse [flags]
 - `-p, --players <players>`: A list of players to analyse. This should be provided as a comma-separated list of player names.
 - `-s, --save`: Flag to save the demo player's data.
 - `--save-type <type>`: Type of file to save the data. Options are `json` and `csv`. The default is `json`.
-- `--details`: Print the extra stat tables that do not fit the main one, such as multi-kill rounds.
+- `--details`: Print the extra stat tables that do not fit the main one: multi-kill rounds and CT/T side splits.
 
 #### Options
 

--- a/_docs/PLAYER_DATA.MD
+++ b/_docs/PLAYER_DATA.MD
@@ -82,13 +82,21 @@ The same core stats split by the side the player was on. Players swap sides at h
 
 | Field | JSON key | Description |
 | --- | --- | --- |
-| Rounds | `rounds` | Rounds the player was in, `{total, ct, t}`. Counted from the players on a side at the round start, so a spectator who joins mid-round is not in it. |
+| Rounds | `rounds` | Rounds the player was in, `{total, ct, t}`. Counted from the players on a side when live play begins, so picking a side during freeze time counts as playing the round. See [who plays a round](#who-plays-a-round). |
 | Kills | `kills` | Enemy kills with the same side split. Teamkills are excluded, exactly as in `kill_stats.total`. |
 | Deaths | `deaths` | Deaths with the same side split, suicides and world deaths included, exactly as in the top-level `deaths`. |
 | ADR | `adr` | Damage per round on each side: `{ct, t}`. See [side denominators](#side-denominators). |
 | KAST | `kast` | KAST percentage on each side: `{ct, t}`, same rule as the match-wide `kast`. |
 
 `kills` and `deaths` always add back up to their match-wide counterparts, so `kills.ct + kills.t == kill_stats.total`.
+
+#### Who plays a round
+
+The roster is read twice: once at the round start, and again when freeze time ends. Freeze time runs after the round has already started, and a player who picks a side inside that window spawns and plays the round like everyone else, so the second read folds them in. Someone who swapped sides in that window plays the round on the side they end freeze time on, which is the side their kills count towards.
+
+The second read never revives anyone. A player who disconnected during freeze time stays counted as having played the round, without survival credit, exactly as a mid-round disconnect is treated.
+
+This also feeds the match-wide `kast`, which is why a freeze-time joiner's KAST rounds are no longer dropped either.
 
 #### Side denominators
 

--- a/_docs/PLAYER_DATA.MD
+++ b/_docs/PLAYER_DATA.MD
@@ -76,6 +76,30 @@ The opening duel is the first enemy kill of a round. Teamkills, suicides and wor
 | OpeningDeaths | `opening_deaths` | Rounds opened by this player's death, with the same side split. |
 | OpeningSuccessRate | `opening_success_rate` | Percentage of the player's opening kills whose round their team went on to win. 0 without any opening kills. This is a rate, not a count — some trackers use "opening success" to mean the opening-kill tally instead. |
 
+### Side split stats (`side_stats`)
+
+The same core stats split by the side the player was on. Players swap sides at halftime, so the split is attributed round by round: a kill counts on the side the player held when they got it, never on the team they finished the match on.
+
+| Field | JSON key | Description |
+| --- | --- | --- |
+| Rounds | `rounds` | Rounds the player was in, `{total, ct, t}`. Counted from the players on a side at the round start, so a spectator who joins mid-round is not in it. |
+| Kills | `kills` | Enemy kills with the same side split. Teamkills are excluded, exactly as in `kill_stats.total`. |
+| Deaths | `deaths` | Deaths with the same side split, suicides and world deaths included, exactly as in the top-level `deaths`. |
+| ADR | `adr` | Damage per round on each side: `{ct, t}`. See [side denominators](#side-denominators). |
+| KAST | `kast` | KAST percentage on each side: `{ct, t}`, same rule as the match-wide `kast`. |
+
+`kills` and `deaths` always add back up to their match-wide counterparts, so `kills.ct + kills.t == kill_stats.total`.
+
+#### Side denominators
+
+`adr` and `kast` are divided by `rounds.ct` and `rounds.t` — the rounds that player actually spent on that side. There is no alternative: sides swap at halftime, so no single match-wide CT round count applies to every player, and a substitute or a late connect plays a different number of rounds than the match has.
+
+The match-wide `assist_stats.adr` and `player_map_stats.kast` keep dividing by the rounds of the whole match, following HLTV convention. **The two only reconcile for a player who was there for every round.** For anyone else, the per-side numbers are the higher, more flattering ones, because they are not diluted by the rounds the player missed. One of the test fixtures has a player who joined for the last 3 of 8 rounds: their match ADR is 59.6 and their T-side ADR is 159.0, and both are correct under their own rule.
+
+`adr` and `kast` are 0 for a side the player never played, not null — a `rounds.ct` of 0 gives an `adr.ct` of 0.
+
+Unlike the counts, these two are rates and so have no `total` field. The match-wide value is the existing `assist_stats.adr` / `player_map_stats.kast`.
+
 ## Match data
 
 The JSON table output also carries match-level data:

--- a/cmd/dataexport/player_export.go
+++ b/cmd/dataexport/player_export.go
@@ -21,7 +21,7 @@ func WritePlayersToFile(players map[uint64]*demoparser.DemoPlayer, saveType stri
 		defer csvFile.Close()
 
 		csvRecords := [][]string{
-			{"Name", "Kills", "Deaths", "K/D", "HS", "Assists", "Flash Assists", "Damage Given", "ADR", "KAST (%)", "Precision (%)", "Trade Kills", "Opening Kills", "Opening Deaths", "Opening Success (%)", "MVPs", "ACEs", "2K", "3K", "4K", "5K", "Clutches Won", "Best Weapon"},
+			{"Name", "Kills", "Deaths", "K/D", "HS", "Assists", "Flash Assists", "Damage Given", "ADR", "KAST (%)", "Precision (%)", "Trade Kills", "Opening Kills", "Opening Deaths", "Opening Success (%)", "MVPs", "ACEs", "2K", "3K", "4K", "5K", "Clutches Won", "Rounds CT", "Rounds T", "Kills CT", "Kills T", "Deaths CT", "Deaths T", "ADR CT", "ADR T", "KAST CT (%)", "KAST T (%)", "Best Weapon"},
 		}
 		for _, player := range sortedByKills(players) {
 			csvRecords = append(csvRecords, []string{
@@ -47,6 +47,16 @@ func WritePlayersToFile(players map[uint64]*demoparser.DemoPlayer, saveType stri
 				fmt.Sprintf("%d", player.PlayerMapStats.MultiKills.K4),
 				fmt.Sprintf("%d", player.PlayerMapStats.MultiKills.K5),
 				fmt.Sprintf("%d", player.PlayerMapStats.ClutchesWon),
+				fmt.Sprintf("%d", player.SideStats.Rounds.CT),
+				fmt.Sprintf("%d", player.SideStats.Rounds.T),
+				fmt.Sprintf("%d", player.SideStats.Kills.CT),
+				fmt.Sprintf("%d", player.SideStats.Kills.T),
+				fmt.Sprintf("%d", player.SideStats.Deaths.CT),
+				fmt.Sprintf("%d", player.SideStats.Deaths.T),
+				fmt.Sprintf("%.1f", player.SideStats.ADR.CT),
+				fmt.Sprintf("%.1f", player.SideStats.ADR.T),
+				fmt.Sprintf("%.1f", player.SideStats.KAST.CT),
+				fmt.Sprintf("%.1f", player.SideStats.KAST.T),
 				demoparser.GetPlayerBestWeapon(player.KillStats.WeaponsKills),
 			})
 		}

--- a/cmd/dataexport/table_print.go
+++ b/cmd/dataexport/table_print.go
@@ -71,6 +71,39 @@ func PrintCLIDataTable(playerToAnalyse map[uint64]*demoparser.DemoPlayer, mapDat
 // each in its own narrow table. Only shown with --details.
 func PrintCLIDetailTables(playerToAnalyse map[uint64]*demoparser.DemoPlayer) {
 	printMultiKillTable(playerToAnalyse)
+	printSideSplitTable(playerToAnalyse)
+}
+
+// countSplit formats a side-split count as "ct / t".
+func countSplit(count demoparser.SideCount) string {
+	return fmt.Sprintf("%d / %d", count.CT, count.T)
+}
+
+// rateSplit formats a side-split rate as "ct / t".
+func rateSplit(rate demoparser.SideRate) string {
+	return fmt.Sprintf("%.1f / %.1f", rate.CT, rate.T)
+}
+
+// printSideSplitTable lists the core stats split by side. Rounds are in
+// there because per-side ADR and KAST are divided by them, which makes a
+// lopsided split worth seeing next to the rates it produced.
+func printSideSplitTable(playerToAnalyse map[uint64]*demoparser.DemoPlayer) {
+	t := table.NewWriter()
+	t.SetOutputMirror(os.Stdout)
+	t.SetTitle("Side splits (CT / T)")
+	t.AppendHeader(table.Row{"Name", "Rounds", "Kills", "Deaths", "ADR", "KAST (%)"})
+	for _, player := range sortedByKills(playerToAnalyse) {
+		side := player.SideStats
+		t.AppendRow(table.Row{
+			player.Name,
+			countSplit(side.Rounds),
+			countSplit(side.Kills),
+			countSplit(side.Deaths),
+			rateSplit(side.ADR),
+			rateSplit(side.KAST),
+		})
+	}
+	t.Render()
 }
 
 // printMultiKillTable lists the multi-kill rounds per player. The buckets

--- a/cmd/demo_parser/demo_parser.go
+++ b/cmd/demo_parser/demo_parser.go
@@ -18,8 +18,9 @@ type analyser struct {
 	parser      demoinfocs.Parser
 	players     map[uint64]*DemoPlayer
 	tracker     *roundTracker
-	kastRounds  map[uint64]int
-	openingWins map[uint64]int // rounds won after taking the opening kill
+	kastRounds  map[uint64]SideCount // rounds with KAST, total and per side
+	sideDamage  map[uint64]SideCount // damage given, total and per side
+	openingWins map[uint64]int       // rounds won after taking the opening kill
 	lastHealth  map[uint64]int
 	mapData     MapData
 	gameMode    string
@@ -36,7 +37,8 @@ func ProcessDemo(demoPath string) (*ProcessedDemo, error) {
 		parser:      demoinfocs.NewParser(file),
 		players:     make(map[uint64]*DemoPlayer),
 		tracker:     newRoundTracker(),
-		kastRounds:  make(map[uint64]int),
+		kastRounds:  make(map[uint64]SideCount),
+		sideDamage:  make(map[uint64]SideCount),
 		openingWins: make(map[uint64]int),
 		lastHealth:  make(map[uint64]int),
 	}
@@ -143,6 +145,7 @@ func (a *analyser) onKill(e events.Kill) {
 
 	if victim := a.ensurePlayer(e.Victim); victim != nil {
 		victim.Deaths++
+		victim.SideStats.Deaths.count(e.Victim.Team)
 	}
 
 	// Suicides and world deaths (fall damage, C4) have no killer to credit.
@@ -163,6 +166,7 @@ func (a *analyser) onKill(e events.Kill) {
 			killer.KillStats.TeamKills++
 		} else {
 			killer.KillStats.Total++
+			killer.SideStats.Kills.count(killerTeam)
 			if e.IsHeadshot {
 				killer.KillStats.HeadShots++
 			}
@@ -226,6 +230,7 @@ func (a *analyser) onPlayerHurt(e events.PlayerHurt) {
 	}
 	if attacker := a.ensurePlayer(e.Attacker); attacker != nil {
 		attacker.AssistStats.DamageGiven += realDamage
+		addSide(a.sideDamage, attacker.SteamID, e.Attacker.Team, realDamage)
 	}
 }
 
@@ -253,15 +258,30 @@ func (a *analyser) onRoundEndOfficial(e events.RoundEndOfficial) {
 	a.applyRoundOutcome(a.tracker.finalize())
 }
 
-// count records one round on the side the player was playing.
-func (s *SideCount) count(side common.Team) {
-	s.Total++
+// add credits n to the side the player was on. Anything but CT and T only
+// reaches the total, which cannot happen for the events that call this: a
+// player has to be on a side to kill, die or deal damage.
+func (s *SideCount) add(side common.Team, n int) {
+	s.Total += n
 	switch side {
 	case common.TeamCounterTerrorists:
-		s.CT++
+		s.CT += n
 	case common.TeamTerrorists:
-		s.T++
+		s.T += n
 	}
+}
+
+// count records one round on the side the player was playing.
+func (s *SideCount) count(side common.Team) {
+	s.add(side, 1)
+}
+
+// addSide credits n to the counter kept under id, which the maps hold by
+// value so a player that has never been counted reads as an empty one.
+func addSide(counters map[uint64]SideCount, id uint64, side common.Team, n int) {
+	counter := counters[id]
+	counter.add(side, n)
+	counters[id] = counter
 }
 
 // add credits one round with the given number of enemy kills to its bucket.
@@ -306,12 +326,17 @@ func (a *analyser) applyRoundOutcome(outcome roundOutcome) {
 	if p := a.players[outcome.opening.victim]; p != nil {
 		p.OpeningDuelStats.OpeningDeaths.count(outcome.opening.victimTeam)
 	}
-	for id := range outcome.participants {
-		if _, isHuman := a.players[id]; !isHuman {
+	// The side a player counts on is the one they started the round on, so
+	// that a halftime swap moves them without touching what they did before
+	// it. Everything else here comes from the same round.
+	for id, side := range outcome.participants {
+		p := a.players[id]
+		if p == nil {
 			continue
 		}
+		p.SideStats.Rounds.count(side)
 		if outcome.kast[id] {
-			a.kastRounds[id]++
+			addSide(a.kastRounds, id, side, 1)
 		}
 	}
 }
@@ -329,7 +354,7 @@ func (a *analyser) syncScoreboardMVPs() {
 }
 
 // finalise fills in everything that needs the full match: final score and
-// the per-player derived stats (precision, ADR, KAST).
+// the per-player derived stats.
 func (a *analyser) finalise() {
 	a.applyRoundOutcome(a.tracker.finalize())
 	a.syncScoreboardMVPs()
@@ -339,15 +364,45 @@ func (a *analyser) finalise() {
 	a.mapData.RoundsWonCT = gs.TeamCounterTerrorists().Score()
 	a.mapData.RoundsWonT = gs.TeamTerrorists().Score()
 
+	a.derive(a.mapData.TotalRounds)
+}
+
+// perRound divides by the rounds the value was accumulated over, reporting
+// 0 for a player who never played any of them.
+func perRound(value, rounds int) float64 {
+	if rounds == 0 {
+		return 0
+	}
+	return float64(value) / float64(rounds)
+}
+
+// derive computes the per-player stats that need the finished match:
+// precision, ADR, KAST and the side splits of the last two. It is separate
+// from finalise so tests can drive it with a round count instead of a demo.
+func (a *analyser) derive(totalRounds int) {
 	for id, p := range a.players {
 		if p.KillStats.Total > 0 {
 			p.KillStats.Precision = float64(p.KillStats.HeadShots) / float64(p.KillStats.Total)
 		}
-		// ADR and KAST both use the match's round count, following the
-		// convention of HLTV-style stat sites.
-		if a.mapData.TotalRounds > 0 {
-			p.AssistStats.ADR = float64(p.AssistStats.DamageGiven) / float64(a.mapData.TotalRounds)
-			p.PlayerMapStats.KAST = 100 * float64(a.kastRounds[id]) / float64(a.mapData.TotalRounds)
+		// The match-wide ADR and KAST both use the match's round count,
+		// following the convention of HLTV-style stat sites.
+		if totalRounds > 0 {
+			p.AssistStats.ADR = perRound(p.AssistStats.DamageGiven, totalRounds)
+			p.PlayerMapStats.KAST = 100 * perRound(a.kastRounds[id].Total, totalRounds)
+		}
+		// Their side splits cannot: sides swap at halftime, so there is no
+		// match-wide CT or T round count that holds for every player. Each
+		// side is divided by the rounds that player spent on it, which for
+		// anyone who played the whole match adds back up to the same total.
+		rounds := p.SideStats.Rounds
+		damage, kast := a.sideDamage[id], a.kastRounds[id]
+		p.SideStats.ADR = SideRate{
+			CT: perRound(damage.CT, rounds.CT),
+			T:  perRound(damage.T, rounds.T),
+		}
+		p.SideStats.KAST = SideRate{
+			CT: 100 * perRound(kast.CT, rounds.CT),
+			T:  100 * perRound(kast.T, rounds.T),
 		}
 		if kills := p.OpeningDuelStats.OpeningKills.Total; kills > 0 {
 			p.OpeningDuelStats.OpeningSuccessRate = 100 * float64(a.openingWins[id]) / float64(kills)

--- a/cmd/demo_parser/demo_parser.go
+++ b/cmd/demo_parser/demo_parser.go
@@ -72,6 +72,7 @@ func (a *analyser) registerHandlers() {
 		}
 	})
 	a.parser.RegisterEventHandler(a.onRoundStart)
+	a.parser.RegisterEventHandler(a.onRoundFreezetimeEnd)
 	a.parser.RegisterEventHandler(a.onKill)
 	a.parser.RegisterEventHandler(a.onPlayerHurt)
 	a.parser.RegisterEventHandler(a.onRoundMVP)
@@ -119,23 +120,40 @@ func (a *analyser) inWarmup() bool {
 	return a.parser.GameState().IsWarmupPeriod()
 }
 
+// playingRoster reads the players currently on a side into the shape the
+// round tracker takes, registering anyone seen for the first time and
+// seeding the health their damage is measured against.
+func (a *analyser) playingRoster() map[uint64]common.Team {
+	roster := make(map[uint64]common.Team)
+	for _, p := range a.parser.GameState().Participants().Playing() {
+		if p.Team != common.TeamTerrorists && p.Team != common.TeamCounterTerrorists {
+			continue
+		}
+		roster[trackerID(p)] = p.Team
+		a.lastHealth[trackerID(p)] = p.Health()
+		a.ensurePlayer(p)
+	}
+	return roster
+}
+
 func (a *analyser) onRoundStart(e events.RoundStart) {
 	if a.inWarmup() {
 		return
 	}
 	// Close the previous round in case its official end was never seen.
 	a.applyRoundOutcome(a.tracker.finalize())
+	a.tracker.startRound(a.playingRoster())
+}
 
-	alive := make(map[uint64]common.Team)
-	for _, p := range a.parser.GameState().Participants().Playing() {
-		if p.Team != common.TeamTerrorists && p.Team != common.TeamCounterTerrorists {
-			continue
-		}
-		alive[trackerID(p)] = p.Team
-		a.lastHealth[trackerID(p)] = p.Health()
-		a.ensurePlayer(p)
+// onRoundFreezetimeEnd folds the players who picked a side during freeze
+// time into the round. RoundStart snapshots the roster before that window
+// opens, so without this they play a round that counts them nowhere: their
+// kills, deaths and damage land on a side whose round count never moved.
+func (a *analyser) onRoundFreezetimeEnd(e events.RoundFreezetimeEnd) {
+	if a.inWarmup() {
+		return
 	}
-	a.tracker.startRound(alive)
+	a.tracker.joinRound(a.playingRoster())
 }
 
 func (a *analyser) onKill(e events.Kill) {

--- a/cmd/demo_parser/demo_parser_test.go
+++ b/cmd/demo_parser/demo_parser_test.go
@@ -319,6 +319,36 @@ func TestSideAdrAndKastDivideByRoundsOnThatSide(t *testing.T) {
 	}
 }
 
+// Freeze time runs after RoundStart has snapshotted the roster, and a
+// player who picks a side inside that window still plays the whole round.
+// Their damage and KAST are attributed to that side, so the side's round
+// count has to move with them or the rates divide by nothing.
+func TestFreezeTimeJoinerPlaysTheRound(t *testing.T) {
+	holder := player(shooterID, "holder", common.TeamCounterTerrorists)
+	joiner := player(victimID, "joiner", common.TeamSpectators)
+	a := liveAnalyser(holder, joiner)
+
+	a.onRoundStart(events.RoundStart{})
+	joiner.Team = common.TeamTerrorists
+	a.onRoundFreezetimeEnd(events.RoundFreezetimeEnd{})
+	hurtBy(a, joiner, holder, 40)
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
+	a.onRoundEndOfficial(events.RoundEndOfficial{})
+
+	a.derive(1)
+
+	p := a.players[victimID]
+	if want := (SideCount{Total: 1, T: 1}); p.SideStats.Rounds != want {
+		t.Fatalf("joiner rounds = %+v, want %+v", p.SideStats.Rounds, want)
+	}
+	if got := p.SideStats.ADR.T; !closeTo(got, 40) {
+		t.Errorf("joiner T-side ADR = %v, want 40: 40 damage over the one round they played", got)
+	}
+	if got := p.SideStats.KAST.T; !closeTo(got, 100) {
+		t.Errorf("joiner T-side KAST = %v, want 100: they survived the round they joined", got)
+	}
+}
+
 // Bots all report SteamID64 0, so a kill between two different bots must
 // not be misread as one bot suiciding on itself (both sides comparing
 // equal). Getting that wrong drops the bot kill as a killerless event,

--- a/cmd/demo_parser/demo_parser_test.go
+++ b/cmd/demo_parser/demo_parser_test.go
@@ -1,6 +1,7 @@
 package demoparser
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -44,7 +45,8 @@ func liveAnalyser(playing ...*common.Player) *analyser {
 		parser:      &matchParser{playing: playing},
 		players:     make(map[uint64]*DemoPlayer),
 		tracker:     newRoundTracker(),
-		kastRounds:  make(map[uint64]int),
+		kastRounds:  make(map[uint64]SideCount),
+		sideDamage:  make(map[uint64]SideCount),
 		openingWins: make(map[uint64]int),
 		lastHealth:  make(map[uint64]int),
 	}
@@ -155,7 +157,7 @@ func TestSurvivorsGetKastWhenTheRoundEndsOfficially(t *testing.T) {
 	a.onRoundEnd(events.RoundEnd{Winner: common.TeamCounterTerrorists})
 	a.onRoundEndOfficial(events.RoundEndOfficial{})
 
-	if got := a.kastRounds[victimID]; got != 1 {
+	if got := a.kastRounds[victimID].Total; got != 1 {
 		t.Errorf("victim kast rounds = %d, want 1: nobody died all round", got)
 	}
 }
@@ -169,12 +171,12 @@ func TestPostRoundDeathBeforeOfficialEndCancelsKast(t *testing.T) {
 	a.onKill(events.Kill{Killer: shooter, Victim: victim, Weapon: &common.Equipment{Type: common.EqAK47}})
 	a.onRoundEndOfficial(events.RoundEndOfficial{})
 
-	if got := a.kastRounds[victimID]; got != 0 {
+	if got := a.kastRounds[victimID].Total; got != 0 {
 		t.Errorf("victim kast rounds = %d, want 0: they were killed before the official round end", got)
 	}
 	// The shooter keeps their survival, which also proves the round was
 	// finalized at all rather than the whole outcome being dropped.
-	if got := a.kastRounds[shooterID]; got != 1 {
+	if got := a.kastRounds[shooterID].Total; got != 1 {
 		t.Errorf("shooter kast rounds = %d, want 1", got)
 	}
 }
@@ -199,6 +201,121 @@ func TestOpeningDuelIsCredited(t *testing.T) {
 	}
 	if got := a.openingWins[shooterID]; got != 1 {
 		t.Errorf("shooter opening wins = %d, want 1: their team won the round", got)
+	}
+}
+
+// playRound runs a whole round through the handlers, with the kills that
+// happened in it.
+func playRound(a *analyser, winner common.Team, kills ...events.Kill) {
+	a.onRoundStart(events.RoundStart{})
+	for _, kill := range kills {
+		a.onKill(kill)
+	}
+	a.onRoundEnd(events.RoundEnd{Winner: winner})
+	a.onRoundEndOfficial(events.RoundEndOfficial{})
+}
+
+// hurtBy lands one hit for the given damage, starting the victim from full
+// health. Stub players report no health of their own, so the round start
+// leaves them on 0 and the double-counting cap would swallow the hit.
+func hurtBy(a *analyser, attacker, victim *common.Player, damage int) {
+	a.lastHealth[trackerID(victim)] = 100
+	a.onPlayerHurt(events.PlayerHurt{
+		Player:            victim,
+		Attacker:          attacker,
+		Weapon:            &common.Equipment{Type: common.EqAK47},
+		HealthDamageTaken: damage,
+		Health:            100 - damage,
+	})
+}
+
+// closeTo compares rates, which come out of a division that rarely lands on
+// an exact float.
+func closeTo(got, want float64) bool {
+	return math.Abs(got-want) < 1e-9
+}
+
+// Sides swap at halftime, so a kill has to land on the side the player was
+// on when they got it, never on the one they finish the match on.
+func TestSideStatsFollowTheHalftimeSwap(t *testing.T) {
+	first := player(shooterID, "first", common.TeamTerrorists)
+	second := player(victimID, "second", common.TeamCounterTerrorists)
+	a := liveAnalyser(first, second)
+
+	playRound(a, common.TeamTerrorists, events.Kill{
+		Killer: first, Victim: second, Weapon: &common.Equipment{Type: common.EqAK47},
+	})
+
+	// Halftime. Both change ends, and the one who died takes revenge.
+	first.Team, second.Team = common.TeamCounterTerrorists, common.TeamTerrorists
+	playRound(a, common.TeamTerrorists, events.Kill{
+		Killer: second, Victim: first, Weapon: &common.Equipment{Type: common.EqAK47},
+	})
+
+	// Both players did the same thing on the same sides, one half apart, so
+	// they end on identical splits however they finished the match.
+	for _, id := range []uint64{shooterID, victimID} {
+		side := a.players[id].SideStats
+		if want := (SideCount{Total: 2, CT: 1, T: 1}); side.Rounds != want {
+			t.Errorf("player %d rounds = %+v, want %+v", id, side.Rounds, want)
+		}
+		if want := (SideCount{Total: 1, T: 1}); side.Kills != want {
+			t.Errorf("player %d kills = %+v, want %+v: they fragged on the T side", id, side.Kills, want)
+		}
+		if want := (SideCount{Total: 1, CT: 1}); side.Deaths != want {
+			t.Errorf("player %d deaths = %+v, want %+v: they died on the CT side", id, side.Deaths, want)
+		}
+	}
+}
+
+// Per-side ADR and KAST divide by the rounds the player spent on that side,
+// the only denominator there is once sides swap. The match-wide pair keeps
+// dividing by the rounds of the whole match, so the three differ.
+func TestSideAdrAndKastDivideByRoundsOnThatSide(t *testing.T) {
+	shooter := player(shooterID, "shooter", common.TeamTerrorists)
+	victim := player(victimID, "victim", common.TeamCounterTerrorists)
+	a := liveAnalyser(shooter, victim)
+
+	// Three rounds as T: 30 damage in each, surviving the first two and
+	// dying in the third with no kill, assist or trade to keep KAST.
+	for round := range 3 {
+		a.onRoundStart(events.RoundStart{})
+		hurtBy(a, shooter, victim, 30)
+		if round == 2 {
+			a.onKill(events.Kill{Killer: victim, Victim: shooter, Weapon: &common.Equipment{Type: common.EqAK47}})
+		}
+		a.onRoundEnd(events.RoundEnd{Winner: common.TeamCounterTerrorists})
+		a.onRoundEndOfficial(events.RoundEndOfficial{})
+	}
+
+	// Halftime, then a single round on CT with 60 damage and a survival.
+	shooter.Team, victim.Team = common.TeamCounterTerrorists, common.TeamTerrorists
+	a.onRoundStart(events.RoundStart{})
+	hurtBy(a, shooter, victim, 60)
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamCounterTerrorists})
+	a.onRoundEndOfficial(events.RoundEndOfficial{})
+
+	a.derive(4)
+
+	p := a.players[shooterID]
+	if want := (SideCount{Total: 4, CT: 1, T: 3}); p.SideStats.Rounds != want {
+		t.Fatalf("rounds = %+v, want %+v", p.SideStats.Rounds, want)
+	}
+	// 90 damage over three T rounds, 60 over the one CT round.
+	if got := p.SideStats.ADR; !closeTo(got.T, 30) || !closeTo(got.CT, 60) {
+		t.Errorf("side ADR = %+v, want {CT: 60, T: 30}", got)
+	}
+	// KAST in two of the three T rounds, and in the only CT one.
+	if got := p.SideStats.KAST; !closeTo(got.T, 100*2.0/3) || !closeTo(got.CT, 100) {
+		t.Errorf("side KAST = %+v, want {CT: 100, T: 66.67}", got)
+	}
+	// The match-wide pair divides 150 damage and 3 KAST rounds by all four
+	// rounds instead, landing between the two sides.
+	if got := p.AssistStats.ADR; !closeTo(got, 37.5) {
+		t.Errorf("match ADR = %v, want 37.5", got)
+	}
+	if got := p.PlayerMapStats.KAST; !closeTo(got, 75) {
+		t.Errorf("match KAST = %v, want 75", got)
 	}
 }
 

--- a/cmd/demo_parser/integration_test.go
+++ b/cmd/demo_parser/integration_test.go
@@ -31,10 +31,15 @@ type demoFixture struct {
 //     its MVP counts can only come from the scoreboard entity property.
 //     Dropping syncScoreboardMVPs zeroes this golden's MVPs.
 //
-// Neither demo contains shotgun damage, so the per-event damage cap for
-// double-reported pellets cannot be locked from here; it is covered by
-// TestShotgunPelletsDoNotDoubleCountDamage instead. A fixture with shotgun
-// hits would close that end to end, tracked in issue #12.
+// Two things these fixtures cannot cover, both left to unit tests:
+//
+//   - Neither demo contains shotgun damage, so the per-event damage cap for
+//     double-reported pellets is covered by
+//     TestShotgunPelletsDoNotDoubleCountDamage instead. A fixture with
+//     shotgun hits would close that end to end, tracked in issue #12.
+//   - Both matches end before halftime (8 and 10 rounds), so every player
+//     stays on one side and the goldens never exercise the side swap. That
+//     is TestSideStatsFollowTheHalftimeSwap's job.
 var demoFixtures = []demoFixture{
 	{
 		name:   "mirage_round_mvp_events",

--- a/cmd/demo_parser/round_tracker.go
+++ b/cmd/demo_parser/round_tracker.go
@@ -85,6 +85,27 @@ func (rt *roundTracker) startRound(alive map[uint64]common.Team) {
 	rt.updateClutchCandidates()
 }
 
+// joinRound folds the players on a side when live play begins into the
+// round. Picking a side during freeze time happens after startRound took
+// its snapshot, and those players play the round like anyone else. Someone
+// who left in the meantime is not brought back to life.
+func (rt *roundTracker) joinRound(alive map[uint64]common.Team) {
+	if !rt.live {
+		return
+	}
+	for id, team := range alive {
+		_, started := rt.startAlive[id]
+		_, stillAlive := rt.alive[id]
+		// A player who swapped sides during freeze time plays the round on
+		// the side they start it on, the one their kills count towards.
+		rt.startAlive[id] = team
+		if !started || stillAlive {
+			rt.alive[id] = team
+		}
+	}
+	rt.updateClutchCandidates()
+}
+
 // kill records a death in the current round. killer and assister are 0 for
 // world deaths and suicides; byWorld marks deaths with no real cause (falls,
 // match-end cleanup kills), as opposed to the bomb or an enemy. It reports

--- a/cmd/demo_parser/round_tracker_test.go
+++ b/cmd/demo_parser/round_tracker_test.go
@@ -175,6 +175,33 @@ func TestMultiKillCountsPostRoundKills(t *testing.T) {
 	}
 }
 
+func TestFreezeTimeJoinKeepsSideAndDoesNotRevive(t *testing.T) {
+	rt := newRoundTracker()
+	rt.startRound(fiveVsFive())
+	rt.disconnect(5)
+
+	// Player 16 picks a side during freeze time and player 1 swaps to CT,
+	// while player 5 is already gone. The refresh still lists all of them.
+	roster := fiveVsFive()
+	roster[16] = common.TeamCounterTerrorists
+	roster[1] = common.TeamCounterTerrorists
+	rt.joinRound(roster)
+
+	outcome := endRound(rt, common.TeamCounterTerrorists)
+	if outcome.participants[16] != common.TeamCounterTerrorists {
+		t.Errorf("player 16 joined during freeze time and must play the round on CT, got %v", outcome.participants[16])
+	}
+	if !outcome.kast[16] {
+		t.Error("player 16 survived the round they joined and must have KAST")
+	}
+	if outcome.participants[1] != common.TeamCounterTerrorists {
+		t.Errorf("player 1 swapped sides during freeze time, got %v", outcome.participants[1])
+	}
+	if outcome.kast[5] {
+		t.Error("player 5 left during freeze time and must not be revived into a survival")
+	}
+}
+
 func TestClutchWon(t *testing.T) {
 	rt := newRoundTracker()
 	rt.startRound(fiveVsFive())

--- a/cmd/demo_parser/testdata/golden_ancient.json
+++ b/cmd/demo_parser/testdata/golden_ancient.json
@@ -46,6 +46,31 @@
           "t": 0
         },
         "opening_success_rate": 0
+      },
+      "side_stats": {
+        "rounds": {
+          "total": 8,
+          "ct": 8,
+          "t": 0
+        },
+        "kills": {
+          "total": 4,
+          "ct": 4,
+          "t": 0
+        },
+        "deaths": {
+          "total": 4,
+          "ct": 4,
+          "t": 0
+        },
+        "adr": {
+          "ct": 47.75,
+          "t": 0
+        },
+        "kast": {
+          "ct": 87.5,
+          "t": 0
+        }
       }
     },
     "76561198071075349": {
@@ -95,6 +120,31 @@
           "t": 0
         },
         "opening_success_rate": 0
+      },
+      "side_stats": {
+        "rounds": {
+          "total": 8,
+          "ct": 8,
+          "t": 0
+        },
+        "kills": {
+          "total": 9,
+          "ct": 9,
+          "t": 0
+        },
+        "deaths": {
+          "total": 3,
+          "ct": 3,
+          "t": 0
+        },
+        "adr": {
+          "ct": 96.75,
+          "t": 0
+        },
+        "kast": {
+          "ct": 100,
+          "t": 0
+        }
       }
     },
     "76561198307159112": {
@@ -142,6 +192,31 @@
           "t": 0
         },
         "opening_success_rate": 0
+      },
+      "side_stats": {
+        "rounds": {
+          "total": 8,
+          "ct": 0,
+          "t": 8
+        },
+        "kills": {
+          "total": 1,
+          "ct": 0,
+          "t": 1
+        },
+        "deaths": {
+          "total": 7,
+          "ct": 0,
+          "t": 7
+        },
+        "adr": {
+          "ct": 0,
+          "t": 18.25
+        },
+        "kast": {
+          "ct": 0,
+          "t": 37.5
+        }
       }
     },
     "76561198387460920": {
@@ -187,6 +262,31 @@
           "t": 0
         },
         "opening_success_rate": 0
+      },
+      "side_stats": {
+        "rounds": {
+          "total": 8,
+          "ct": 8,
+          "t": 0
+        },
+        "kills": {
+          "total": 0,
+          "ct": 0,
+          "t": 0
+        },
+        "deaths": {
+          "total": 5,
+          "ct": 5,
+          "t": 0
+        },
+        "adr": {
+          "ct": 9.125,
+          "t": 0
+        },
+        "kast": {
+          "ct": 87.5,
+          "t": 0
+        }
       }
     },
     "76561198826243397": {
@@ -235,6 +335,31 @@
           "t": 0
         },
         "opening_success_rate": 100
+      },
+      "side_stats": {
+        "rounds": {
+          "total": 8,
+          "ct": 8,
+          "t": 0
+        },
+        "kills": {
+          "total": 3,
+          "ct": 3,
+          "t": 0
+        },
+        "deaths": {
+          "total": 4,
+          "ct": 4,
+          "t": 0
+        },
+        "adr": {
+          "ct": 50.125,
+          "t": 0
+        },
+        "kast": {
+          "ct": 75,
+          "t": 0
+        }
       }
     },
     "76561198966281369": {
@@ -286,6 +411,31 @@
           "t": 0
         },
         "opening_success_rate": 100
+      },
+      "side_stats": {
+        "rounds": {
+          "total": 8,
+          "ct": 8,
+          "t": 0
+        },
+        "kills": {
+          "total": 10,
+          "ct": 10,
+          "t": 0
+        },
+        "deaths": {
+          "total": 5,
+          "ct": 5,
+          "t": 0
+        },
+        "adr": {
+          "ct": 136.5,
+          "t": 0
+        },
+        "kast": {
+          "ct": 100,
+          "t": 0
+        }
       }
     },
     "76561199102419525": {
@@ -335,6 +485,31 @@
           "t": 0
         },
         "opening_success_rate": 0
+      },
+      "side_stats": {
+        "rounds": {
+          "total": 8,
+          "ct": 0,
+          "t": 8
+        },
+        "kills": {
+          "total": 6,
+          "ct": 0,
+          "t": 6
+        },
+        "deaths": {
+          "total": 7,
+          "ct": 0,
+          "t": 7
+        },
+        "adr": {
+          "ct": 0,
+          "t": 80.125
+        },
+        "kast": {
+          "ct": 0,
+          "t": 62.5
+        }
       }
     },
     "76561199271102802": {
@@ -382,6 +557,31 @@
           "t": 2
         },
         "opening_success_rate": 100
+      },
+      "side_stats": {
+        "rounds": {
+          "total": 8,
+          "ct": 0,
+          "t": 8
+        },
+        "kills": {
+          "total": 1,
+          "ct": 0,
+          "t": 1
+        },
+        "deaths": {
+          "total": 8,
+          "ct": 0,
+          "t": 8
+        },
+        "adr": {
+          "ct": 0,
+          "t": 22.25
+        },
+        "kast": {
+          "ct": 0,
+          "t": 25
+        }
       }
     },
     "76561199311359933": {
@@ -430,6 +630,31 @@
           "t": 0
         },
         "opening_success_rate": 100
+      },
+      "side_stats": {
+        "rounds": {
+          "total": 3,
+          "ct": 0,
+          "t": 3
+        },
+        "kills": {
+          "total": 5,
+          "ct": 0,
+          "t": 5
+        },
+        "deaths": {
+          "total": 2,
+          "ct": 0,
+          "t": 2
+        },
+        "adr": {
+          "ct": 0,
+          "t": 159
+        },
+        "kast": {
+          "ct": 0,
+          "t": 66.66666666666666
+        }
       }
     },
     "76561199558715190": {
@@ -478,6 +703,31 @@
           "t": 3
         },
         "opening_success_rate": 0
+      },
+      "side_stats": {
+        "rounds": {
+          "total": 8,
+          "ct": 0,
+          "t": 8
+        },
+        "kills": {
+          "total": 3,
+          "ct": 0,
+          "t": 3
+        },
+        "deaths": {
+          "total": 7,
+          "ct": 0,
+          "t": 7
+        },
+        "adr": {
+          "ct": 0,
+          "t": 57.25
+        },
+        "kast": {
+          "ct": 0,
+          "t": 62.5
+        }
       }
     }
   },

--- a/cmd/demo_parser/testdata/golden_mirage.json
+++ b/cmd/demo_parser/testdata/golden_mirage.json
@@ -48,6 +48,31 @@
           "t": 0
         },
         "opening_success_rate": 100
+      },
+      "side_stats": {
+        "rounds": {
+          "total": 10,
+          "ct": 0,
+          "t": 10
+        },
+        "kills": {
+          "total": 11,
+          "ct": 0,
+          "t": 11
+        },
+        "deaths": {
+          "total": 6,
+          "ct": 0,
+          "t": 6
+        },
+        "adr": {
+          "ct": 0,
+          "t": 120.7
+        },
+        "kast": {
+          "ct": 0,
+          "t": 100
+        }
       }
     },
     "76561198073049527": {
@@ -97,6 +122,31 @@
           "t": 0
         },
         "opening_success_rate": 0
+      },
+      "side_stats": {
+        "rounds": {
+          "total": 10,
+          "ct": 10,
+          "t": 0
+        },
+        "kills": {
+          "total": 3,
+          "ct": 3,
+          "t": 0
+        },
+        "deaths": {
+          "total": 9,
+          "ct": 9,
+          "t": 0
+        },
+        "adr": {
+          "ct": 52.3,
+          "t": 0
+        },
+        "kast": {
+          "ct": 70,
+          "t": 0
+        }
       }
     },
     "76561198118803912": {
@@ -145,6 +195,31 @@
           "t": 1
         },
         "opening_success_rate": 0
+      },
+      "side_stats": {
+        "rounds": {
+          "total": 10,
+          "ct": 0,
+          "t": 10
+        },
+        "kills": {
+          "total": 5,
+          "ct": 0,
+          "t": 5
+        },
+        "deaths": {
+          "total": 8,
+          "ct": 0,
+          "t": 8
+        },
+        "adr": {
+          "ct": 0,
+          "t": 56.6
+        },
+        "kast": {
+          "ct": 0,
+          "t": 80
+        }
       }
     },
     "76561198194694750": {
@@ -196,6 +271,31 @@
           "t": 0
         },
         "opening_success_rate": 0
+      },
+      "side_stats": {
+        "rounds": {
+          "total": 10,
+          "ct": 10,
+          "t": 0
+        },
+        "kills": {
+          "total": 6,
+          "ct": 6,
+          "t": 0
+        },
+        "deaths": {
+          "total": 8,
+          "ct": 8,
+          "t": 0
+        },
+        "adr": {
+          "ct": 74.2,
+          "t": 0
+        },
+        "kast": {
+          "ct": 50,
+          "t": 0
+        }
       }
     },
     "76561198202353993": {
@@ -245,6 +345,31 @@
           "t": 0
         },
         "opening_success_rate": 0
+      },
+      "side_stats": {
+        "rounds": {
+          "total": 10,
+          "ct": 0,
+          "t": 10
+        },
+        "kills": {
+          "total": 4,
+          "ct": 0,
+          "t": 4
+        },
+        "deaths": {
+          "total": 3,
+          "ct": 0,
+          "t": 3
+        },
+        "adr": {
+          "ct": 0,
+          "t": 31.3
+        },
+        "kast": {
+          "ct": 0,
+          "t": 90
+        }
       }
     },
     "76561198244754626": {
@@ -294,6 +419,31 @@
           "t": 0
         },
         "opening_success_rate": 80
+      },
+      "side_stats": {
+        "rounds": {
+          "total": 10,
+          "ct": 0,
+          "t": 10
+        },
+        "kills": {
+          "total": 10,
+          "ct": 0,
+          "t": 10
+        },
+        "deaths": {
+          "total": 6,
+          "ct": 0,
+          "t": 6
+        },
+        "adr": {
+          "ct": 0,
+          "t": 94.2
+        },
+        "kast": {
+          "ct": 0,
+          "t": 90
+        }
       }
     },
     "76561198258044111": {
@@ -343,6 +493,31 @@
           "t": 0
         },
         "opening_success_rate": 0
+      },
+      "side_stats": {
+        "rounds": {
+          "total": 10,
+          "ct": 10,
+          "t": 0
+        },
+        "kills": {
+          "total": 8,
+          "ct": 8,
+          "t": 0
+        },
+        "deaths": {
+          "total": 9,
+          "ct": 9,
+          "t": 0
+        },
+        "adr": {
+          "ct": 77.5,
+          "t": 0
+        },
+        "kast": {
+          "ct": 60,
+          "t": 0
+        }
       }
     },
     "76561198265366770": {
@@ -391,6 +566,31 @@
           "t": 0
         },
         "opening_success_rate": 100
+      },
+      "side_stats": {
+        "rounds": {
+          "total": 10,
+          "ct": 0,
+          "t": 10
+        },
+        "kills": {
+          "total": 11,
+          "ct": 0,
+          "t": 11
+        },
+        "deaths": {
+          "total": 5,
+          "ct": 0,
+          "t": 5
+        },
+        "adr": {
+          "ct": 0,
+          "t": 113.9
+        },
+        "kast": {
+          "ct": 0,
+          "t": 100
+        }
       }
     },
     "76561198280975787": {
@@ -440,6 +640,31 @@
           "t": 0
         },
         "opening_success_rate": 100
+      },
+      "side_stats": {
+        "rounds": {
+          "total": 9,
+          "ct": 9,
+          "t": 0
+        },
+        "kills": {
+          "total": 4,
+          "ct": 4,
+          "t": 0
+        },
+        "deaths": {
+          "total": 9,
+          "ct": 9,
+          "t": 0
+        },
+        "adr": {
+          "ct": 37.888888888888886,
+          "t": 0
+        },
+        "kast": {
+          "ct": 33.33333333333333,
+          "t": 0
+        }
       }
     },
     "76561198324843075": {
@@ -488,6 +713,31 @@
           "t": 0
         },
         "opening_success_rate": 0
+      },
+      "side_stats": {
+        "rounds": {
+          "total": 10,
+          "ct": 10,
+          "t": 0
+        },
+        "kills": {
+          "total": 2,
+          "ct": 2,
+          "t": 0
+        },
+        "deaths": {
+          "total": 10,
+          "ct": 10,
+          "t": 0
+        },
+        "adr": {
+          "ct": 42.5,
+          "t": 0
+        },
+        "kast": {
+          "ct": 70,
+          "t": 0
+        }
       }
     }
   },

--- a/cmd/demo_parser/types.go
+++ b/cmd/demo_parser/types.go
@@ -41,6 +41,31 @@ type SideCount struct {
 	T     int `json:"t"`
 }
 
+// SideRate is a per-side average or percentage. It carries no total: the
+// match-wide value keeps its own field, AssistStats.ADR or
+// PlayerMapStats.KAST.
+type SideRate struct {
+	CT float64 `json:"ct"`
+	T  float64 `json:"t"`
+}
+
+// SideStats splits the core stats by the side the player was on. Sides swap
+// at halftime, so every split is attributed round by round and never from
+// the team the player finished the match on.
+//
+// ADR and KAST are divided by Rounds.CT and Rounds.T, the rounds the player
+// was actually in on that side, which is the only denominator that exists
+// per player. The match-wide ADR and KAST instead divide by the rounds of
+// the whole match, so the two only reconcile for a player who was there for
+// all of them.
+type SideStats struct {
+	Rounds SideCount `json:"rounds"`
+	Kills  SideCount `json:"kills"`
+	Deaths SideCount `json:"deaths"`
+	ADR    SideRate  `json:"adr"`
+	KAST   SideRate  `json:"kast"`
+}
+
 // OpeningDuelStats counts the rounds a player opened or was opened on.
 // OpeningSuccessRate is a percentage rather than a count, and is named apart
 // from the counts because other trackers use "opening success" for the
@@ -60,6 +85,7 @@ type DemoPlayer struct {
 	AssistStats      AssistStats      `json:"assist_stats"`
 	PlayerMapStats   PlayerMapStats   `json:"player_map_stats"`
 	OpeningDuelStats OpeningDuelStats `json:"opening_duel_stats"`
+	SideStats        SideStats        `json:"side_stats"`
 }
 
 type MapData struct {


### PR DESCRIPTION
Second half of #5, stacked on #17 — **review that one first, this diff is against it.**

Splits kills, deaths, ADR and KAST by the side the player was on, in a new `side_stats` block. `SideCount` is reused for the counts; rates get a `SideRate` (`{ct, t}`) since a total would only duplicate the fields that already hold it.

### Side attribution

Kills, deaths and damage are attributed as the events land, from the team the player is on at that moment — which *is* the side they hold for that round, since nobody switches mid-round. Rounds and KAST come from `roundOutcome.participants`, which is the round-start snapshot. Neither path can read the team the player finished the match on, which is the thing that breaks at halftime.

Doing kills through `participants` instead was the alternative; attributing at the event keeps `kills.ct + kills.t == kill_stats.total` unconditionally, where the snapshot would silently drop a player who connected mid-round.

### The denominator, which is the part worth arguing about

Per-side ADR and KAST divide by `rounds.ct` / `rounds.t` — the rounds that player actually spent on that side. There is no alternative: sides swap, so no match-wide CT round count applies to everyone.

The match-wide ADR and KAST keep dividing by the whole match's rounds (HLTV convention, unchanged). **So the two only reconcile for a player who played every round.** The `ancient` fixture has a live example — Nagi joined for the last 3 of 8 rounds, match ADR 59.6, T-side ADR 159.0. Both correct under their own rule, and the difference is real information rather than a bug. Documented under "Side denominators".

`derive` is split out of `finalise` so the round count comes in as an argument. That is what lets the denominators be tested without a demo file.

### Verification

- Goldens regenerated: **+500 lines, 0 deletions**. Every existing value held.
- Checked across both goldens that `kills.ct + kills.t` equals `kill_stats.total`, `deaths` likewise, per-side damage adds back to `damage_given`, and per-side KAST rounds add back to the match KAST rounds.
- `gofmt -l .`, `go vet ./...`, `REQUIRE_TEST_DEMO=1 go test ./...` clean.
- `TestSideStatsFollowTheHalftimeSwap` drives two players through a swap and asserts both end on identical splits however they finished. `TestSideAdrAndKastDivideByRoundsOnThatSide` gives a player 3 T rounds and 1 CT round with different damage in each and pins all three numbers apart: ADR 30 on T, 60 on CT, 37.5 match-wide.

One gap, called out in `integration_test.go` next to the existing shotgun note: **both fixtures end before halftime** (8 and 10 rounds), so the goldens cannot exercise a swap at all. The unit test is the only coverage of it. A fixture that reaches halftime would close that, and is the same kind of gap issue #12 already tracks.

`--details` now prints the side-split table below the multi-kill one; CSV gains 10 columns; the main table is still untouched.

Closes #5.
