### PR TITLE
Export deaths traded as a player stat

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ analyse [flags]
 - `-p, --players <players>`: A list of players to analyse. This should be provided as a comma-separated list of player names.
 - `-s, --save`: Flag to save the demo player's data.
 - `--save-type <type>`: Type of file to save the data. Options are `json` and `csv`. The default is `json`.
-- `--details`: Print the extra stat tables that do not fit the main one: multi-kill rounds and CT/T side splits.
+- `--details`: Print the extra stat tables that do not fit the main one: multi-kill rounds, trades and CT/T side splits.
 
 #### Options
 
@@ -65,4 +65,3 @@ go build
 ### Submit a pull request
 
 If you'd like to contribute, please fork the repository and open a pull request to the `main` branch.
-

--- a/_docs/PLAYER_DATA.MD
+++ b/_docs/PLAYER_DATA.MD
@@ -12,7 +12,7 @@ The `--save` flag writes every analysed player to a file. JSON contains all fiel
 | Name | `name` | Last name the player used in the demo. |
 | UserID | `user_id` | Server user ID in this demo. |
 | Deaths | `deaths` | Deaths, including suicides and world deaths (fall damage, C4). |
-| DeathsTraded | `deaths_traded` | Deaths avenged by a teammate inside the trade window: `{total, ct, t}`, split by the side the player was on that round. |
+| DeathsTraded | `deaths_traded` | Per-round traded-death count: `{total, ct, t}`. A round contributes once when at least one of the player's deaths was avenged inside the trade window. |
 
 ### Kill stats (`kill_stats`)
 
@@ -34,7 +34,7 @@ A kill is a trade when it lands on the *specific* enemy who killed a teammate, w
 - One kill gives its player one `trade_kill`, even when the enemy it lands on had killed two teammates. Each qualifying teammate gets one `deaths_traded`, so that one kill can trade two deaths.
 - Post-round events deliberately remain eligible: a death after the round is decided can be traded, and a revenge kill after the round can trade an earlier death, as long as both events stay in this round and inside the window. This differs from opening duels, which cannot start after the round is decided.
 
-`deaths_traded` lives at the player top level beside `deaths` because it describes what happened to the player who died, not a kill they made. It is a count, and a round can add at most one per player because a player dies at most once in a round. Its CT/T split always uses the side that player held in that round, never the team they finished the match on. No separate rate is stored: consumers can derive `deaths_traded.total / deaths` when they need it.
+`deaths_traded` lives at the player top level beside `deaths` because it describes what happened to the player who died, not a kill they made. It is a per-round count, not a per-death count: the tracker records a boolean per player, so a round adds at most one even when a respawn mode lets that player die and be traded more than once. Its CT/T split always uses the side that player held in that round, never the team they finished the match on. No separate rate is stored. `deaths_traded.total / deaths` is only a per-death rate in modes without mid-round respawns; in respawn modes the numerator stays per-round while `deaths` counts every death.
 
 The 5-second window is a deliberate choice, not a value read out of the demo: HLTV states 5 seconds for Rating 3.0 ("two kills within 5 seconds") and Refrag documents the same for its Trades column. Other trackers differ — Leetify builds 4-second kill chains instead — so trade counts are not comparable between tools even when the label matches. If you are forking and your league counts trades differently, the window is the `tradeWindow` constant at the top of `cmd/demo_parser/round_tracker.go`.
 

--- a/_docs/PLAYER_DATA.MD
+++ b/_docs/PLAYER_DATA.MD
@@ -12,6 +12,7 @@ The `--save` flag writes every analysed player to a file. JSON contains all fiel
 | Name | `name` | Last name the player used in the demo. |
 | UserID | `user_id` | Server user ID in this demo. |
 | Deaths | `deaths` | Deaths, including suicides and world deaths (fall damage, C4). |
+| DeathsTraded | `deaths_traded` | Deaths avenged by a teammate inside the trade window: `{total, ct, t}`, split by the side the player was on that round. |
 
 ### Kill stats (`kill_stats`)
 
@@ -30,10 +31,14 @@ A kill is a trade when it lands on the *specific* enemy who killed a teammate, w
 
 - It must be that killer. Killing any other enemy inside the window is not a trade.
 - Both deaths have to fall in the same round.
-- One kill counts once, even when the enemy it lands on had killed two teammates.
-- Kills after the round is decided still count, so exit frags can be trades.
+- One kill gives its player one `trade_kill`, even when the enemy it lands on had killed two teammates. Each qualifying teammate gets one `deaths_traded`, so that one kill can trade two deaths.
+- Post-round events deliberately remain eligible: a death after the round is decided can be traded, and a revenge kill after the round can trade an earlier death, as long as both events stay in this round and inside the window. This differs from opening duels, which cannot start after the round is decided.
+
+`deaths_traded` lives at the player top level beside `deaths` because it describes what happened to the player who died, not a kill they made. It is a count, and a round can add at most one per player because a player dies at most once in a round. Its CT/T split always uses the side that player held in that round, never the team they finished the match on. No separate rate is stored: consumers can derive `deaths_traded.total / deaths` when they need it.
 
 The 5-second window is a deliberate choice, not a value read out of the demo: HLTV states 5 seconds for Rating 3.0 ("two kills within 5 seconds") and Refrag documents the same for its Trades column. Other trackers differ — Leetify builds 4-second kill chains instead — so trade counts are not comparable between tools even when the label matches. If you are forking and your league counts trades differently, the window is the `tradeWindow` constant at the top of `cmd/demo_parser/round_tracker.go`.
+
+The count is in JSON, in CSV as `Deaths Traded` plus its CT/T columns, and in the `Trade stats` table that `--details` prints. The 11-column main table stays unchanged.
 
 ### Assist stats (`assist_stats`)
 

--- a/cmd/dataexport/player_export.go
+++ b/cmd/dataexport/player_export.go
@@ -21,7 +21,7 @@ func WritePlayersToFile(players map[uint64]*demoparser.DemoPlayer, saveType stri
 		defer csvFile.Close()
 
 		csvRecords := [][]string{
-			{"Name", "Kills", "Deaths", "K/D", "HS", "Assists", "Flash Assists", "Damage Given", "ADR", "KAST (%)", "Precision (%)", "Trade Kills", "Opening Kills", "Opening Deaths", "Opening Success (%)", "MVPs", "ACEs", "2K", "3K", "4K", "5K", "Clutches Won", "Rounds CT", "Rounds T", "Kills CT", "Kills T", "Deaths CT", "Deaths T", "ADR CT", "ADR T", "KAST CT (%)", "KAST T (%)", "Best Weapon"},
+			{"Name", "Kills", "Deaths", "K/D", "HS", "Assists", "Flash Assists", "Damage Given", "ADR", "KAST (%)", "Precision (%)", "Trade Kills", "Deaths Traded", "Opening Kills", "Opening Deaths", "Opening Success (%)", "MVPs", "ACEs", "2K", "3K", "4K", "5K", "Clutches Won", "Rounds CT", "Rounds T", "Kills CT", "Kills T", "Deaths CT", "Deaths T", "Deaths Traded CT", "Deaths Traded T", "ADR CT", "ADR T", "KAST CT (%)", "KAST T (%)", "Best Weapon"},
 		}
 		for _, player := range sortedByKills(players) {
 			csvRecords = append(csvRecords, []string{
@@ -37,6 +37,7 @@ func WritePlayersToFile(players map[uint64]*demoparser.DemoPlayer, saveType stri
 				fmt.Sprintf("%.1f", player.PlayerMapStats.KAST),
 				fmt.Sprintf("%.1f", player.KillStats.Precision*100),
 				fmt.Sprintf("%d", player.KillStats.TradeKills),
+				fmt.Sprintf("%d", player.DeathsTraded.Total),
 				fmt.Sprintf("%d", player.OpeningDuelStats.OpeningKills.Total),
 				fmt.Sprintf("%d", player.OpeningDuelStats.OpeningDeaths.Total),
 				fmt.Sprintf("%.1f", player.OpeningDuelStats.OpeningSuccessRate),
@@ -53,6 +54,8 @@ func WritePlayersToFile(players map[uint64]*demoparser.DemoPlayer, saveType stri
 				fmt.Sprintf("%d", player.SideStats.Kills.T),
 				fmt.Sprintf("%d", player.SideStats.Deaths.CT),
 				fmt.Sprintf("%d", player.SideStats.Deaths.T),
+				fmt.Sprintf("%d", player.DeathsTraded.CT),
+				fmt.Sprintf("%d", player.DeathsTraded.T),
 				fmt.Sprintf("%.1f", player.SideStats.ADR.CT),
 				fmt.Sprintf("%.1f", player.SideStats.ADR.T),
 				fmt.Sprintf("%.1f", player.SideStats.KAST.CT),

--- a/cmd/dataexport/table_print.go
+++ b/cmd/dataexport/table_print.go
@@ -71,6 +71,7 @@ func PrintCLIDataTable(playerToAnalyse map[uint64]*demoparser.DemoPlayer, mapDat
 // each in its own narrow table. Only shown with --details.
 func PrintCLIDetailTables(playerToAnalyse map[uint64]*demoparser.DemoPlayer) {
 	printMultiKillTable(playerToAnalyse)
+	printTradeTable(playerToAnalyse)
 	printSideSplitTable(playerToAnalyse)
 }
 
@@ -82,6 +83,25 @@ func countSplit(count demoparser.SideCount) string {
 // rateSplit formats a side-split rate as "ct / t".
 func rateSplit(rate demoparser.SideRate) string {
 	return fmt.Sprintf("%.1f / %.1f", rate.CT, rate.T)
+}
+
+// printTradeTable puts the two sides of a trade next to each other: the
+// kill that avenged a teammate and the player's own deaths that were
+// avenged. One kill can trade more than one death, so the totals may differ.
+func printTradeTable(playerToAnalyse map[uint64]*demoparser.DemoPlayer) {
+	t := table.NewWriter()
+	t.SetOutputMirror(os.Stdout)
+	t.SetTitle("Trade stats")
+	t.AppendHeader(table.Row{"Name", "Trade kills", "Deaths traded", "Deaths traded (CT / T)"})
+	for _, player := range sortedByKills(playerToAnalyse) {
+		t.AppendRow(table.Row{
+			player.Name,
+			player.KillStats.TradeKills,
+			player.DeathsTraded.Total,
+			countSplit(player.DeathsTraded),
+		})
+	}
+	t.Render()
 }
 
 // printSideSplitTable lists the core stats split by side. Rounds are in

--- a/cmd/demo_parser/demo_parser.go
+++ b/cmd/demo_parser/demo_parser.go
@@ -353,6 +353,9 @@ func (a *analyser) applyRoundOutcome(outcome roundOutcome) {
 			continue
 		}
 		p.SideStats.Rounds.count(side)
+		if outcome.deathsTraded[id] {
+			p.DeathsTraded.count(side)
+		}
 		if outcome.kast[id] {
 			addSide(a.kastRounds, id, side, 1)
 		}

--- a/cmd/demo_parser/round_tracker.go
+++ b/cmd/demo_parser/round_tracker.go
@@ -42,7 +42,7 @@ type roundOutcome struct {
 	opening      openingDuel
 	openingWon   bool // the opening killer's team won the round
 	participants map[uint64]common.Team
-	deathsTraded map[uint64]bool // players whose death was avenged inside the trade window
+	deathsTraded map[uint64]bool // players with a death avenged inside the trade window
 	kast         map[uint64]bool // players that got a Kill, Assist, Survived or were Traded
 }
 

--- a/cmd/demo_parser/round_tracker.go
+++ b/cmd/demo_parser/round_tracker.go
@@ -42,6 +42,7 @@ type roundOutcome struct {
 	opening      openingDuel
 	openingWon   bool // the opening killer's team won the round
 	participants map[uint64]common.Team
+	deathsTraded map[uint64]bool // players whose death was avenged inside the trade window
 	kast         map[uint64]bool // players that got a Kill, Assist, Survived or were Traded
 }
 
@@ -128,6 +129,9 @@ func (rt *roundTracker) kill(killer, victim uint64, killerTeam, victimTeam commo
 		if assister != 0 {
 			rt.assists[assister] = true
 		}
+		// Deliberately no rt.ending guard: deaths and revenge kills stay
+		// eligible until finalize, so a post-round death can still be
+		// avenged inside the window.
 		for _, d := range rt.deaths {
 			if d.killer == victim && d.victimTeam == killerTeam && at-d.at <= tradeWindow {
 				rt.traded[d.victim] = true
@@ -229,6 +233,7 @@ func (rt *roundTracker) finalize() roundOutcome {
 		opening:      rt.opening,
 		openingWon:   rt.opening.killer != 0 && rt.opening.killerTeam == rt.winner,
 		participants: rt.startAlive,
+		deathsTraded: make(map[uint64]bool),
 		kast:         make(map[uint64]bool),
 	}
 	for id, kills := range rt.enemyKills {
@@ -241,6 +246,9 @@ func (rt *roundTracker) finalize() roundOutcome {
 	}
 	for id := range rt.startAlive {
 		_, survived := rt.alive[id]
+		if rt.traded[id] {
+			outcome.deathsTraded[id] = true
+		}
 		if survived || rt.enemyKills[id] > 0 || rt.assists[id] || rt.traded[id] {
 			outcome.kast[id] = true
 		}

--- a/cmd/demo_parser/round_tracker_test.go
+++ b/cmd/demo_parser/round_tracker_test.go
@@ -277,6 +277,9 @@ func TestTradeKill(t *testing.T) {
 	}
 
 	outcome := endRound(rt, common.TeamCounterTerrorists)
+	if len(outcome.deathsTraded) != 1 || !outcome.deathsTraded[1] {
+		t.Errorf("deaths traded = %v, want only player 1 counted once", outcome.deathsTraded)
+	}
 	if !outcome.kast[1] {
 		t.Error("player 1's death was traded, so player 1 keeps KAST")
 	}
@@ -289,6 +292,73 @@ func TestKillOutsideTradeWindowIsNoTrade(t *testing.T) {
 	rt.kill(11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
 	if rt.kill(2, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(16)) {
 		t.Error("revenge kill 6s later should not be a trade")
+	}
+	if outcome := endRound(rt, common.TeamCounterTerrorists); len(outcome.deathsTraded) != 0 {
+		t.Errorf("death outside the trade window was counted as traded: %v", outcome.deathsTraded)
+	}
+}
+
+func TestPostRoundDeathCanBeTraded(t *testing.T) {
+	rt := newRoundTracker()
+	rt.startRound(fiveVsFive())
+
+	rt.markEnd(common.TeamCounterTerrorists)
+	rt.kill(11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
+	isTrade := rt.kill(2, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(13))
+
+	if !isTrade {
+		t.Error("post-round death avenged inside the window should be a trade")
+	}
+	if outcome := rt.finalize(); !outcome.deathsTraded[1] {
+		t.Errorf("post-round death was not marked as traded: %v", outcome.deathsTraded)
+	}
+}
+
+func TestOneTradeKillCanTradeTwoDeaths(t *testing.T) {
+	rt := newRoundTracker()
+	rt.startRound(fiveVsFive())
+
+	rt.kill(11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
+	rt.kill(11, 2, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(12))
+	tradeKills := 0
+	if rt.kill(3, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(14)) {
+		tradeKills++
+	}
+
+	outcome := endRound(rt, common.TeamTerrorists)
+	if tradeKills != 1 {
+		t.Errorf("trade kills = %d, want one revenge kill", tradeKills)
+	}
+	if len(outcome.deathsTraded) != 2 || !outcome.deathsTraded[1] || !outcome.deathsTraded[2] {
+		t.Errorf("deaths traded = %v, want players 1 and 2", outcome.deathsTraded)
+	}
+}
+
+func TestDeathsTradedFollowTheHalftimeSwap(t *testing.T) {
+	a := &analyser{
+		players:    map[uint64]*DemoPlayer{1: {SteamID: 1}},
+		kastRounds: make(map[uint64]SideCount),
+	}
+	rt := newRoundTracker()
+
+	// Player 1 starts on T, dies, and has that death avenged by player 2.
+	rt.startRound(map[uint64]common.Team{
+		1: common.TeamTerrorists, 2: common.TeamTerrorists, 11: common.TeamCounterTerrorists,
+	})
+	rt.kill(11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
+	rt.kill(2, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(13))
+	a.applyRoundOutcome(endRound(rt, common.TeamTerrorists))
+
+	// After halftime the same players swap sides and repeat the trade.
+	rt.startRound(map[uint64]common.Team{
+		1: common.TeamCounterTerrorists, 2: common.TeamCounterTerrorists, 11: common.TeamTerrorists,
+	})
+	rt.kill(11, 1, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(20))
+	rt.kill(2, 11, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(23))
+	a.applyRoundOutcome(endRound(rt, common.TeamCounterTerrorists))
+
+	if got, want := a.players[1].DeathsTraded, (SideCount{Total: 2, CT: 1, T: 1}); got != want {
+		t.Errorf("deaths traded = %+v, want %+v after the side swap", got, want)
 	}
 }
 

--- a/cmd/demo_parser/round_tracker_test.go
+++ b/cmd/demo_parser/round_tracker_test.go
@@ -202,6 +202,27 @@ func TestFreezeTimeJoinKeepsSideAndDoesNotRevive(t *testing.T) {
 	}
 }
 
+func TestFreezeTimeJoinerTradedDeathUsesJoinedSide(t *testing.T) {
+	rt := newRoundTracker()
+	rt.startRound(map[uint64]common.Team{
+		1: common.TeamTerrorists, 11: common.TeamCounterTerrorists,
+	})
+	rt.joinRound(map[uint64]common.Team{
+		1: common.TeamTerrorists, 11: common.TeamCounterTerrorists, 16: common.TeamCounterTerrorists,
+	})
+
+	rt.kill(1, 16, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10))
+	rt.kill(11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(13))
+	outcome := endRound(rt, common.TeamCounterTerrorists)
+
+	a := liveAnalyser()
+	a.players[16] = &DemoPlayer{SteamID: 16}
+	a.applyRoundOutcome(outcome)
+	if got, want := a.players[16].DeathsTraded, (SideCount{Total: 1, CT: 1}); got != want {
+		t.Errorf("freeze-time joiner's deaths traded = %+v, want %+v", got, want)
+	}
+}
+
 func TestClutchWon(t *testing.T) {
 	rt := newRoundTracker()
 	rt.startRound(fiveVsFive())
@@ -335,10 +356,8 @@ func TestOneTradeKillCanTradeTwoDeaths(t *testing.T) {
 }
 
 func TestDeathsTradedFollowTheHalftimeSwap(t *testing.T) {
-	a := &analyser{
-		players:    map[uint64]*DemoPlayer{1: {SteamID: 1}},
-		kastRounds: make(map[uint64]SideCount),
-	}
+	a := liveAnalyser()
+	a.players[1] = &DemoPlayer{SteamID: 1}
 	rt := newRoundTracker()
 
 	// Player 1 starts on T, dies, and has that death avenged by player 2.

--- a/cmd/demo_parser/testdata/golden_ancient.json
+++ b/cmd/demo_parser/testdata/golden_ancient.json
@@ -5,6 +5,11 @@
       "name": "bonK",
       "user_id": 4,
       "deaths": 4,
+      "deaths_traded": {
+        "total": 1,
+        "ct": 1,
+        "t": 0
+      },
       "kill_stats": {
         "total": 4,
         "headshots": 0,
@@ -78,6 +83,11 @@
       "name": "mattos-v",
       "user_id": 1,
       "deaths": 3,
+      "deaths_traded": {
+        "total": 0,
+        "ct": 0,
+        "t": 0
+      },
       "kill_stats": {
         "total": 9,
         "headshots": 5,
@@ -152,6 +162,11 @@
       "name": "CHARRADÃO DE FROZEN",
       "user_id": 9,
       "deaths": 7,
+      "deaths_traded": {
+        "total": 0,
+        "ct": 0,
+        "t": 0
+      },
       "kill_stats": {
         "total": 1,
         "headshots": 0,
@@ -224,6 +239,11 @@
       "name": "tandu",
       "user_id": 2,
       "deaths": 5,
+      "deaths_traded": {
+        "total": 2,
+        "ct": 2,
+        "t": 0
+      },
       "kill_stats": {
         "total": 0,
         "headshots": 0,
@@ -294,6 +314,11 @@
       "name": "botu360",
       "user_id": 0,
       "deaths": 4,
+      "deaths_traded": {
+        "total": 0,
+        "ct": 0,
+        "t": 0
+      },
       "kill_stats": {
         "total": 3,
         "headshots": 2,
@@ -367,6 +392,11 @@
       "name": "cmz-",
       "user_id": 3,
       "deaths": 5,
+      "deaths_traded": {
+        "total": 0,
+        "ct": 0,
+        "t": 0
+      },
       "kill_stats": {
         "total": 10,
         "headshots": 7,
@@ -443,6 +473,11 @@
       "name": "seloko-numcompensa",
       "user_id": 6,
       "deaths": 7,
+      "deaths_traded": {
+        "total": 1,
+        "ct": 0,
+        "t": 1
+      },
       "kill_stats": {
         "total": 6,
         "headshots": 3,
@@ -517,6 +552,11 @@
       "name": "! Ømegapr1v",
       "user_id": 5,
       "deaths": 8,
+      "deaths_traded": {
+        "total": 0,
+        "ct": 0,
+        "t": 0
+      },
       "kill_stats": {
         "total": 1,
         "headshots": 0,
@@ -589,6 +629,11 @@
       "name": "Nagi",
       "user_id": 7,
       "deaths": 2,
+      "deaths_traded": {
+        "total": 0,
+        "ct": 0,
+        "t": 0
+      },
       "kill_stats": {
         "total": 5,
         "headshots": 4,
@@ -662,6 +707,11 @@
       "name": "BushBandit",
       "user_id": 8,
       "deaths": 7,
+      "deaths_traded": {
+        "total": 0,
+        "ct": 0,
+        "t": 0
+      },
       "kill_stats": {
         "total": 3,
         "headshots": 1,

--- a/cmd/demo_parser/testdata/golden_mirage.json
+++ b/cmd/demo_parser/testdata/golden_mirage.json
@@ -5,6 +5,11 @@
       "name": "Подсосник blick'a",
       "user_id": 0,
       "deaths": 6,
+      "deaths_traded": {
+        "total": 2,
+        "ct": 0,
+        "t": 2
+      },
       "kill_stats": {
         "total": 11,
         "headshots": 4,
@@ -80,6 +85,11 @@
       "name": "miu miu",
       "user_id": 8,
       "deaths": 9,
+      "deaths_traded": {
+        "total": 1,
+        "ct": 1,
+        "t": 0
+      },
       "kill_stats": {
         "total": 3,
         "headshots": 2,
@@ -154,6 +164,11 @@
       "name": "Голова, глаза",
       "user_id": 2,
       "deaths": 8,
+      "deaths_traded": {
+        "total": 1,
+        "ct": 0,
+        "t": 1
+      },
       "kill_stats": {
         "total": 5,
         "headshots": 4,
@@ -227,6 +242,11 @@
       "name": "Dog",
       "user_id": 7,
       "deaths": 8,
+      "deaths_traded": {
+        "total": 0,
+        "ct": 0,
+        "t": 0
+      },
       "kill_stats": {
         "total": 6,
         "headshots": 1,
@@ -303,6 +323,11 @@
       "name": "IMI Negev",
       "user_id": 4,
       "deaths": 3,
+      "deaths_traded": {
+        "total": 1,
+        "ct": 0,
+        "t": 1
+      },
       "kill_stats": {
         "total": 4,
         "headshots": 4,
@@ -377,6 +402,11 @@
       "name": "NIGHTSOUL",
       "user_id": 1,
       "deaths": 6,
+      "deaths_traded": {
+        "total": 0,
+        "ct": 0,
+        "t": 0
+      },
       "kill_stats": {
         "total": 10,
         "headshots": 6,
@@ -451,6 +481,11 @@
       "name": "-ExΩtiC-",
       "user_id": 9,
       "deaths": 9,
+      "deaths_traded": {
+        "total": 1,
+        "ct": 1,
+        "t": 0
+      },
       "kill_stats": {
         "total": 8,
         "headshots": 2,
@@ -525,6 +560,11 @@
       "name": "123",
       "user_id": 3,
       "deaths": 5,
+      "deaths_traded": {
+        "total": 1,
+        "ct": 0,
+        "t": 1
+      },
       "kill_stats": {
         "total": 11,
         "headshots": 8,
@@ -598,6 +638,11 @@
       "name": "povergo",
       "user_id": 6,
       "deaths": 9,
+      "deaths_traded": {
+        "total": 0,
+        "ct": 0,
+        "t": 0
+      },
       "kill_stats": {
         "total": 4,
         "headshots": 2,
@@ -672,6 +717,11 @@
       "name": "Trahun \u003c3 V",
       "user_id": 5,
       "deaths": 10,
+      "deaths_traded": {
+        "total": 2,
+        "ct": 2,
+        "t": 0
+      },
       "kill_stats": {
         "total": 2,
         "headshots": 2,

--- a/cmd/demo_parser/types.go
+++ b/cmd/demo_parser/types.go
@@ -81,6 +81,7 @@ type DemoPlayer struct {
 	Name             string           `json:"name"`
 	UserID           int              `json:"user_id"`
 	Deaths           int              `json:"deaths"`
+	DeathsTraded     SideCount        `json:"deaths_traded"`
 	KillStats        KillStats        `json:"kill_stats"`
 	AssistStats      AssistStats      `json:"assist_stats"`
 	PlayerMapStats   PlayerMapStats   `json:"player_map_stats"`


### PR DESCRIPTION
## Summary

- Keep post-round deaths and revenge kills eligible for trades until the official round end, and make that rule explicit in code and the player-data contract.
- Export deaths_traded as a top-level SideCount with total, CT and T values.
- Add deaths traded to JSON, CSV and a compact Trade stats table under --details.
- Cover traded, untraded, post-round, one-kill/two-deaths, halftime-swap and freeze-time-joiner cases with plain-value unit tests.

## Decisions

- Issue #16 is folded into this PR because preserving the existing post-round behavior required only a code comment and documentation clarification; its golden checkpoint produced no changes.
- deaths_traded lives beside deaths because it describes the player who died, not a kill they made. A separate one-field stats block would add nesting without another concept.
- deaths_traded is a per-round count. The tracker stores one boolean per player, so a respawn round contributes at most one even if several deaths are traded.
- CT/T attribution comes from roundOutcome.participants for the round in which the player died.
- No rate is exported. deaths_traded.total / deaths is a per-death rate only in modes without mid-round respawns; in respawn modes its numerator remains per-round while deaths counts every death.
- --details stays boolean. Three compact overflow tables still fit its existing show-all-details contract; the 11-column main table remains unchanged.

## Verification

- make download-test-demos
- go test ./cmd/demo_parser -run TestProcessDemoGolden -update
- Golden diff read in full: 50 additions and 0 deletions per fixture, only deaths_traded objects.
- Team sanity check: trade kills / deaths traded are Ancient CT 3/3, T 1/1; Mirage CT 4/4, T 5/5.
- gofmt -l .
- go vet ./...
- REQUIRE_TEST_DEMO=1 go test ./...

Closes #14
Closes #16