### PR TITLE
Add utility stats for flashes, damage, usage, and unused value

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ analyse [flags]
 - `-p, --players <players>`: A list of players to analyse. This should be provided as a comma-separated list of player names.
 - `-s, --save`: Flag to save the demo player's data.
 - `--save-type <type>`: Type of file to save the data. Options are `json` and `csv`. The default is `json`.
-- `--details`: Print the extra stat tables that do not fit the main one: multi-kill rounds, trades and CT/T side splits.
+- `--details`: Print the extra stat tables that do not fit the main one: multi-kill rounds, trades, CT/T side splits, utility effectiveness and grenades thrown.
 
 #### Options
 

--- a/_docs/PLAYER_DATA.MD
+++ b/_docs/PLAYER_DATA.MD
@@ -49,6 +49,58 @@ The count is in JSON, in CSV as `Deaths Traded` plus its CT/T columns, and in th
 | DamageGiven | `damage_given` | Health damage dealt to enemies. Team damage, self damage and bomb damage never count (HLTV convention). |
 | ADR | `adr` | Average damage per round: `damage_given / total rounds of the match`. |
 
+### Utility stats (`utility_stats`)
+
+Match-wide use and effectiveness of the six standard purchasable grenades: flashbang, smoke, HE, molotov, incendiary and decoy. Game-mode equipment such as snowballs, breach charges and bump mines is excluded. The first version has no CT/T split, per-round rate or self-flash field.
+
+| Field | JSON key | Description |
+| --- | --- | --- |
+| EnemiesFlashed | `enemies_flashed` | Enemy `PlayerFlashed` events attributed to this player. This counts events, so flashing the same enemy twice adds two. |
+| FriendsFlashed | `friends_flashed` | Teammate `PlayerFlashed` events attributed to this player. Self-flashes are excluded. |
+| EnemyFlashTimeSeconds | `enemy_flash_time_seconds` | Sum of new blind time added by enemy flash events, in seconds. When a blinded player is re-flashed, already-covered time is not counted twice. |
+| AverageEnemyFlashTimeSeconds | `average_enemy_flash_time_seconds` | `enemy_flash_time_seconds / enemies_flashed`, or 0 when no enemy was flashed. It is derived after parsing so the count and total duration remain the source values. |
+| UtilityDamage | `utility_damage` | Actual enemy health removed by damaging utility: `{total, he, fire}`. See [utility damage](#utility-damage). |
+| GrenadesThrown | `grenades_thrown` | Uses of standard grenades: `{total, flash, smoke, he, molotov, incendiary, decoy}`. See [grenades thrown](#grenades-thrown). |
+| UnusedUtilityValue | `unused_utility_value` | Cumulative purchase value of standard grenades carried at qualifying deaths. See [unused utility value](#unused-utility-value). |
+
+Flash assists remain at `assist_stats.flashed_enemies`; `utility_stats` does not duplicate them. The `Utility effectiveness` table shown by `--details` places that existing count beside the new flash, damage and unused-value fields.
+
+#### Utility damage
+
+Utility damage reuses the same per-event real-health cap as `assist_stats.damage_given`. It never exceeds either the damage reported for the event or the victim's actual health drop. Self damage, team damage and bomb damage are excluded from both totals.
+
+- `he` counts HE grenade damage.
+- `fire` combines molotov and incendiary damage. Inferno hurt events do not reliably identify which fire grenade created the flames, although their throw counts remain separate.
+- `total` is `he + fire`.
+- Gun damage and direct projectile chip damage from otherwise non-damaging grenades do not count.
+
+Smoke and decoy therefore have use counts but no invented effectiveness value.
+
+#### Grenades thrown
+
+Each `GrenadeProjectileThrow` adds one use. `WeaponFire` is not counted, and warmup events are ignored. `total` is the sum of the six named counts. If demoinfocs cannot resolve a projectile model, the analyser recovers the type from the thrower's active inventory item when possible. Smoke and decoy are represented by throws only.
+
+#### Unused utility value
+
+This is a cumulative value across deaths, not an average and not the largest inventory seen at one death. Every qualifying death contributes, including repeated deaths in respawn modes, suicides, bomb and fall deaths, and combat deaths after the round result. Automatic World cleanup after the round has already been decided is excluded.
+
+Only standard grenade inventory is valued. Weapons, armour and game-mode equipment do not contribute. Quantity is `AmmoInMagazine + AmmoReserve`, which counts a second flashbang stored as reserve ammo. The pinned Mirage case in `TestProcessDemoGolden` explicitly verifies that the demoinfocs version used by this project still exposes the victim's pre-death inventory during `Kill`, without parsing the fixture a second time.
+
+`Equipment` has no price API, so `cmd/demo_parser/utility.go` owns one explicit price table. It uses normal Competitive buy-menu prices from the August 2026 CS2 economy:
+
+| Grenade | Price |
+| --- | ---: |
+| Flashbang | $200 |
+| Smoke | $300 |
+| HE | $300 |
+| Molotov | $400 |
+| Incendiary | $500 |
+| Decoy | $50 |
+
+Every entry is unit-tested. Update the table and this convention together if Valve changes the economy.
+
+All utility scalars are appended to CSV after the existing columns. `--details` adds `Utility effectiveness` and `Grenades thrown` tables; the 11-column main table is unchanged.
+
 ### Map stats (`player_map_stats`)
 
 | Field | JSON key | Description |

--- a/cmd/dataexport/player_export.go
+++ b/cmd/dataexport/player_export.go
@@ -21,7 +21,7 @@ func WritePlayersToFile(players map[uint64]*demoparser.DemoPlayer, saveType stri
 		defer csvFile.Close()
 
 		csvRecords := [][]string{
-			{"Name", "Kills", "Deaths", "K/D", "HS", "Assists", "Flash Assists", "Damage Given", "ADR", "KAST (%)", "Precision (%)", "Trade Kills", "Deaths Traded", "Opening Kills", "Opening Deaths", "Opening Success (%)", "MVPs", "ACEs", "2K", "3K", "4K", "5K", "Clutches Won", "Rounds CT", "Rounds T", "Kills CT", "Kills T", "Deaths CT", "Deaths T", "Deaths Traded CT", "Deaths Traded T", "ADR CT", "ADR T", "KAST CT (%)", "KAST T (%)", "Best Weapon"},
+			{"Name", "Kills", "Deaths", "K/D", "HS", "Assists", "Flash Assists", "Damage Given", "ADR", "KAST (%)", "Precision (%)", "Trade Kills", "Deaths Traded", "Opening Kills", "Opening Deaths", "Opening Success (%)", "MVPs", "ACEs", "2K", "3K", "4K", "5K", "Clutches Won", "Rounds CT", "Rounds T", "Kills CT", "Kills T", "Deaths CT", "Deaths T", "Deaths Traded CT", "Deaths Traded T", "ADR CT", "ADR T", "KAST CT (%)", "KAST T (%)", "Best Weapon", "Enemies Flashed", "Friends Flashed", "Enemy Flash Time (s)", "Average Enemy Flash Time (s)", "Utility Damage Total", "HE Utility Damage", "Fire Utility Damage", "Grenades Thrown Total", "Flashbangs Thrown", "Smokes Thrown", "HE Grenades Thrown", "Molotovs Thrown", "Incendiaries Thrown", "Decoys Thrown", "Unused Utility Value"},
 		}
 		for _, player := range sortedByKills(players) {
 			csvRecords = append(csvRecords, []string{
@@ -61,6 +61,21 @@ func WritePlayersToFile(players map[uint64]*demoparser.DemoPlayer, saveType stri
 				fmt.Sprintf("%.1f", player.SideStats.KAST.CT),
 				fmt.Sprintf("%.1f", player.SideStats.KAST.T),
 				demoparser.GetPlayerBestWeapon(player.KillStats.WeaponsKills),
+				fmt.Sprintf("%d", player.UtilityStats.EnemiesFlashed),
+				fmt.Sprintf("%d", player.UtilityStats.FriendsFlashed),
+				fmt.Sprintf("%.1f", player.UtilityStats.EnemyFlashTimeSeconds),
+				fmt.Sprintf("%.1f", player.UtilityStats.AverageEnemyFlashTimeSeconds),
+				fmt.Sprintf("%d", player.UtilityStats.UtilityDamage.Total),
+				fmt.Sprintf("%d", player.UtilityStats.UtilityDamage.HE),
+				fmt.Sprintf("%d", player.UtilityStats.UtilityDamage.Fire),
+				fmt.Sprintf("%d", player.UtilityStats.GrenadesThrown.Total),
+				fmt.Sprintf("%d", player.UtilityStats.GrenadesThrown.Flash),
+				fmt.Sprintf("%d", player.UtilityStats.GrenadesThrown.Smoke),
+				fmt.Sprintf("%d", player.UtilityStats.GrenadesThrown.HE),
+				fmt.Sprintf("%d", player.UtilityStats.GrenadesThrown.Molotov),
+				fmt.Sprintf("%d", player.UtilityStats.GrenadesThrown.Incendiary),
+				fmt.Sprintf("%d", player.UtilityStats.GrenadesThrown.Decoy),
+				fmt.Sprintf("%d", player.UtilityStats.UnusedUtilityValue),
 			})
 		}
 

--- a/cmd/dataexport/table_print.go
+++ b/cmd/dataexport/table_print.go
@@ -3,6 +3,7 @@ package dataexport
 import (
 	"cmp"
 	"fmt"
+	"io"
 	"maps"
 	"os"
 	"slices"
@@ -70,9 +71,12 @@ func PrintCLIDataTable(playerToAnalyse map[uint64]*demoparser.DemoPlayer, mapDat
 // PrintCLIDetailTables prints the stats that do not fit the main table,
 // each in its own narrow table. Only shown with --details.
 func PrintCLIDetailTables(playerToAnalyse map[uint64]*demoparser.DemoPlayer) {
-	printMultiKillTable(playerToAnalyse)
-	printTradeTable(playerToAnalyse)
-	printSideSplitTable(playerToAnalyse)
+	players := sortedByKills(playerToAnalyse)
+	printMultiKillTable(players, os.Stdout)
+	printTradeTable(players, os.Stdout)
+	printSideSplitTable(players, os.Stdout)
+	printUtilityEffectivenessTable(players, os.Stdout)
+	printGrenadesThrownTable(players, os.Stdout)
 }
 
 // countSplit formats a side-split count as "ct / t".
@@ -88,12 +92,12 @@ func rateSplit(rate demoparser.SideRate) string {
 // printTradeTable puts the two sides of a trade next to each other: the
 // kill that avenged a teammate and the player's own deaths that were
 // avenged. One kill can trade more than one death, so the totals may differ.
-func printTradeTable(playerToAnalyse map[uint64]*demoparser.DemoPlayer) {
+func printTradeTable(players []*demoparser.DemoPlayer, output io.Writer) {
 	t := table.NewWriter()
-	t.SetOutputMirror(os.Stdout)
+	t.SetOutputMirror(output)
 	t.SetTitle("Trade stats")
 	t.AppendHeader(table.Row{"Name", "Trade kills", "Deaths traded", "Deaths traded (CT / T)"})
-	for _, player := range sortedByKills(playerToAnalyse) {
+	for _, player := range players {
 		t.AppendRow(table.Row{
 			player.Name,
 			player.KillStats.TradeKills,
@@ -107,12 +111,12 @@ func printTradeTable(playerToAnalyse map[uint64]*demoparser.DemoPlayer) {
 // printSideSplitTable lists the core stats split by side. Rounds are in
 // there because per-side ADR and KAST are divided by them, which makes a
 // lopsided split worth seeing next to the rates it produced.
-func printSideSplitTable(playerToAnalyse map[uint64]*demoparser.DemoPlayer) {
+func printSideSplitTable(players []*demoparser.DemoPlayer, output io.Writer) {
 	t := table.NewWriter()
-	t.SetOutputMirror(os.Stdout)
+	t.SetOutputMirror(output)
 	t.SetTitle("Side splits (CT / T)")
 	t.AppendHeader(table.Row{"Name", "Rounds", "Kills", "Deaths", "ADR", "KAST (%)"})
-	for _, player := range sortedByKills(playerToAnalyse) {
+	for _, player := range players {
 		side := player.SideStats
 		t.AppendRow(table.Row{
 			player.Name,
@@ -128,14 +132,58 @@ func printSideSplitTable(playerToAnalyse map[uint64]*demoparser.DemoPlayer) {
 
 // printMultiKillTable lists the multi-kill rounds per player. The buckets
 // are exclusive, so each round shows up in exactly one column.
-func printMultiKillTable(playerToAnalyse map[uint64]*demoparser.DemoPlayer) {
+func printMultiKillTable(players []*demoparser.DemoPlayer, output io.Writer) {
 	t := table.NewWriter()
-	t.SetOutputMirror(os.Stdout)
+	t.SetOutputMirror(output)
 	t.SetTitle("Multi-kill rounds")
 	t.AppendHeader(table.Row{"Name", "2K", "3K", "4K", "5K"})
-	for _, player := range sortedByKills(playerToAnalyse) {
+	for _, player := range players {
 		multiKills := player.PlayerMapStats.MultiKills
 		t.AppendRow(table.Row{player.Name, multiKills.K2, multiKills.K3, multiKills.K4, multiKills.K5})
+	}
+	t.Render()
+}
+
+func printUtilityEffectivenessTable(players []*demoparser.DemoPlayer, output io.Writer) {
+	t := table.NewWriter()
+	t.SetOutputMirror(output)
+	t.SetTitle("Utility effectiveness")
+	t.AppendHeader(table.Row{"Name", "Flash assists", "Enemies flashed", "Friends flashed", "Enemy time (s)", "Avg enemy time (s)", "Damage", "HE", "Fire", "Unused value"})
+	for _, player := range players {
+		utility := player.UtilityStats
+		t.AppendRow(table.Row{
+			player.Name,
+			player.AssistStats.FlashedEnemies,
+			utility.EnemiesFlashed,
+			utility.FriendsFlashed,
+			fmt.Sprintf("%.2f", utility.EnemyFlashTimeSeconds),
+			fmt.Sprintf("%.2f", utility.AverageEnemyFlashTimeSeconds),
+			utility.UtilityDamage.Total,
+			utility.UtilityDamage.HE,
+			utility.UtilityDamage.Fire,
+			utility.UnusedUtilityValue,
+		})
+	}
+	t.Render()
+}
+
+func printGrenadesThrownTable(players []*demoparser.DemoPlayer, output io.Writer) {
+	t := table.NewWriter()
+	t.SetOutputMirror(output)
+	t.SetTitle("Grenades thrown")
+	t.AppendHeader(table.Row{"Name", "Total", "Flash", "Smoke", "HE", "Molotov", "Incendiary", "Decoy"})
+	for _, player := range players {
+		grenades := player.UtilityStats.GrenadesThrown
+		t.AppendRow(table.Row{
+			player.Name,
+			grenades.Total,
+			grenades.Flash,
+			grenades.Smoke,
+			grenades.HE,
+			grenades.Molotov,
+			grenades.Incendiary,
+			grenades.Decoy,
+		})
 	}
 	t.Render()
 }

--- a/cmd/dataexport/utility_export_test.go
+++ b/cmd/dataexport/utility_export_test.go
@@ -1,0 +1,116 @@
+package dataexport
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	demoparser "github.com/taua-almeida/cs2-analyser-tool/cmd/demo_parser"
+)
+
+func utilityPlayer() *demoparser.DemoPlayer {
+	return &demoparser.DemoPlayer{
+		SteamID: 1,
+		Name:    "utility-player",
+		KillStats: demoparser.KillStats{
+			Total:        1,
+			WeaponsKills: map[string]int{"AK-47": 1},
+		},
+		AssistStats: demoparser.AssistStats{FlashedEnemies: 2},
+		UtilityStats: demoparser.UtilityStats{
+			EnemiesFlashed:               3,
+			FriendsFlashed:               4,
+			EnemyFlashTimeSeconds:        5.25,
+			AverageEnemyFlashTimeSeconds: 1.75,
+			UtilityDamage:                demoparser.UtilityDamageStats{Total: 60, HE: 40, Fire: 20},
+			GrenadesThrown:               demoparser.GrenadesThrownStats{Total: 21, Flash: 1, Smoke: 2, HE: 3, Molotov: 4, Incendiary: 5, Decoy: 6},
+			UnusedUtilityValue:           700,
+		},
+	}
+}
+
+func TestJSONExportsUtilityStatsAndExistingFlashAssists(t *testing.T) {
+	t.Chdir(t.TempDir())
+	want := utilityPlayer()
+
+	fileName, err := WritePlayersToFile(map[uint64]*demoparser.DemoPlayer{want.SteamID: want}, "json")
+	if err != nil {
+		t.Fatalf("writing JSON: %v", err)
+	}
+	data, err := os.ReadFile(fileName)
+	if err != nil {
+		t.Fatalf("reading JSON: %v", err)
+	}
+	var players map[uint64]*demoparser.DemoPlayer
+	if err := json.Unmarshal(data, &players); err != nil {
+		t.Fatalf("unmarshalling JSON: %v", err)
+	}
+	got := players[want.SteamID]
+	if got == nil {
+		t.Fatal("exported player missing")
+	}
+	if got.AssistStats.FlashedEnemies != 2 {
+		t.Errorf("flash assists = %d, want 2", got.AssistStats.FlashedEnemies)
+	}
+	if !reflect.DeepEqual(got.UtilityStats, want.UtilityStats) {
+		t.Errorf("utility stats = %+v, want %+v", got.UtilityStats, want.UtilityStats)
+	}
+}
+
+func TestCSVAppendsStableUtilityColumns(t *testing.T) {
+	t.Chdir(t.TempDir())
+	player := utilityPlayer()
+
+	fileName, err := WritePlayersToFile(map[uint64]*demoparser.DemoPlayer{player.SteamID: player}, "csv")
+	if err != nil {
+		t.Fatalf("writing CSV: %v", err)
+	}
+	f, err := os.Open(fileName)
+	if err != nil {
+		t.Fatalf("opening CSV: %v", err)
+	}
+	defer f.Close()
+	records, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		t.Fatalf("reading CSV: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("CSV records = %d, want header and one player", len(records))
+	}
+
+	legacyHeader := []string{"Name", "Kills", "Deaths", "K/D", "HS", "Assists", "Flash Assists", "Damage Given", "ADR", "KAST (%)", "Precision (%)", "Trade Kills", "Deaths Traded", "Opening Kills", "Opening Deaths", "Opening Success (%)", "MVPs", "ACEs", "2K", "3K", "4K", "5K", "Clutches Won", "Rounds CT", "Rounds T", "Kills CT", "Kills T", "Deaths CT", "Deaths T", "Deaths Traded CT", "Deaths Traded T", "ADR CT", "ADR T", "KAST CT (%)", "KAST T (%)", "Best Weapon"}
+	utilityHeader := []string{"Enemies Flashed", "Friends Flashed", "Enemy Flash Time (s)", "Average Enemy Flash Time (s)", "Utility Damage Total", "HE Utility Damage", "Fire Utility Damage", "Grenades Thrown Total", "Flashbangs Thrown", "Smokes Thrown", "HE Grenades Thrown", "Molotovs Thrown", "Incendiaries Thrown", "Decoys Thrown", "Unused Utility Value"}
+	wantHeader := append(append([]string{}, legacyHeader...), utilityHeader...)
+	if !reflect.DeepEqual(records[0], wantHeader) {
+		t.Errorf("CSV header = %q, want %q", records[0], wantHeader)
+	}
+	wantUtilityValues := []string{"3", "4", "5.2", "1.8", "60", "40", "20", "21", "1", "2", "3", "4", "5", "6", "700"}
+	if got := records[1][len(legacyHeader):]; !reflect.DeepEqual(got, wantUtilityValues) {
+		t.Errorf("CSV utility values = %q, want %q", got, wantUtilityValues)
+	}
+}
+
+func TestUtilityDetailTables(t *testing.T) {
+	player := utilityPlayer()
+	players := map[uint64]*demoparser.DemoPlayer{player.SteamID: player}
+	sorted := sortedByKills(players)
+
+	var effectiveness strings.Builder
+	printUtilityEffectivenessTable(sorted, &effectiveness)
+	for _, text := range []string{"Utility effectiveness", "Flash assists", "Enemies flashed", "Unused value", "utility-player"} {
+		if !strings.Contains(strings.ToLower(effectiveness.String()), strings.ToLower(text)) {
+			t.Errorf("utility effectiveness table missing %q:\n%s", text, effectiveness.String())
+		}
+	}
+
+	var throws strings.Builder
+	printGrenadesThrownTable(sorted, &throws)
+	for _, text := range []string{"Grenades thrown", "Flash", "Smoke", "Incendiary", "Decoy", "utility-player"} {
+		if !strings.Contains(strings.ToLower(throws.String()), strings.ToLower(text)) {
+			t.Errorf("grenades thrown table missing %q:\n%s", text, throws.String())
+		}
+	}
+}

--- a/cmd/demo_parser/demo_parser.go
+++ b/cmd/demo_parser/demo_parser.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"time"
 
 	demoinfocs "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
 	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
@@ -22,6 +23,7 @@ type analyser struct {
 	sideDamage  map[uint64]SideCount // damage given, total and per side
 	openingWins map[uint64]int       // rounds won after taking the opening kill
 	lastHealth  map[uint64]int
+	flashEnds   map[uint64]time.Duration // latest known end of each player's blind interval
 	mapData     MapData
 	gameMode    string
 }
@@ -41,6 +43,7 @@ func ProcessDemo(demoPath string) (*ProcessedDemo, error) {
 		sideDamage:  make(map[uint64]SideCount),
 		openingWins: make(map[uint64]int),
 		lastHealth:  make(map[uint64]int),
+		flashEnds:   make(map[uint64]time.Duration),
 	}
 	defer a.parser.Close()
 
@@ -75,6 +78,8 @@ func (a *analyser) registerHandlers() {
 	a.parser.RegisterEventHandler(a.onRoundFreezetimeEnd)
 	a.parser.RegisterEventHandler(a.onKill)
 	a.parser.RegisterEventHandler(a.onPlayerHurt)
+	a.parser.RegisterEventHandler(a.onPlayerFlashed)
+	a.parser.RegisterEventHandler(a.onGrenadeProjectileThrow)
 	a.parser.RegisterEventHandler(a.onRoundMVP)
 	a.parser.RegisterEventHandler(a.onRoundEnd)
 	a.parser.RegisterEventHandler(a.onRoundEndOfficial)
@@ -161,16 +166,28 @@ func (a *analyser) onKill(e events.Kill) {
 		return
 	}
 
-	if victim := a.ensurePlayer(e.Victim); victim != nil {
-		victim.Deaths++
-		victim.SideStats.Deaths.count(e.Victim.Team)
-	}
-
 	// Suicides and world deaths (fall damage, C4) have no killer to credit.
 	// Bots all report SteamID64 0, so identity has to go through trackerID
 	// (which gives each bot a distinct ID) or two different bots trading
 	// kills would misread as one bot suiciding on itself.
 	suicide := e.Killer != nil && trackerID(e.Killer) == trackerID(e.Victim)
+	// World kills can carry the victim as their own killer in CS2 demos
+	// (mid-round disconnects, match-end cleanup). The tracker uses the round
+	// state to distinguish cleanup from World deaths that still count. Bomb
+	// kills stay separate from both.
+	byWorld := (e.Killer == nil || suicide) && (e.Weapon == nil || e.Weapon.Type == common.EqWorld)
+
+	if victim := a.ensurePlayer(e.Victim); victim != nil {
+		victim.Deaths++
+		victim.SideStats.Deaths.count(e.Victim.Team)
+		// A World cleanup after the round is decided is not a player's
+		// decision to die with utility. Combat, suicide, fall, bomb and other
+		// post-round deaths still contribute.
+		if !a.tracker.isPostRoundWorldCleanup(byWorld) {
+			victim.UtilityStats.UnusedUtilityValue += unusedUtilityValue(e.Victim.Inventory)
+		}
+	}
+
 	var killerID uint64
 	var killerTeam common.Team
 	if e.Killer != nil && !suicide {
@@ -205,10 +222,6 @@ func (a *analyser) onKill(e events.Kill) {
 		}
 	}
 
-	// World kills carry the victim as their own killer in CS2 demos
-	// (mid-round disconnects, match-end cleanup), so suicides by World
-	// count as artificial deaths too. Bomb kills stay real deaths.
-	byWorld := (e.Killer == nil || suicide) && (e.Weapon == nil || e.Weapon.Type == common.EqWorld)
 	isTrade := a.tracker.kill(killerID, trackerID(e.Victim), killerTeam, e.Victim.Team, assisterID, byWorld, a.parser.CurrentTime())
 	if isTrade && !teamkill {
 		if killer := a.ensurePlayer(e.Killer); killer != nil {
@@ -249,6 +262,42 @@ func (a *analyser) onPlayerHurt(e events.PlayerHurt) {
 	if attacker := a.ensurePlayer(e.Attacker); attacker != nil {
 		attacker.AssistStats.DamageGiven += realDamage
 		addSide(a.sideDamage, attacker.SteamID, e.Attacker.Team, realDamage)
+		if e.Weapon != nil {
+			attacker.UtilityStats.UtilityDamage.add(e.Weapon.Type, realDamage)
+		}
+	}
+}
+
+func (a *analyser) onPlayerFlashed(e events.PlayerFlashed) {
+	if a.inWarmup() || e.Player == nil {
+		return
+	}
+	addedBlindTime := a.addedFlashTime(e.Player, e.FlashDuration())
+	if e.Attacker == nil {
+		return
+	}
+	if trackerID(e.Player) == trackerID(e.Attacker) {
+		return
+	}
+
+	attacker := a.ensurePlayer(e.Attacker)
+	if attacker == nil {
+		return
+	}
+	if e.Player.Team == e.Attacker.Team {
+		attacker.UtilityStats.FriendsFlashed++
+		return
+	}
+	attacker.UtilityStats.EnemiesFlashed++
+	attacker.UtilityStats.EnemyFlashTimeSeconds += addedBlindTime.Seconds()
+}
+
+func (a *analyser) onGrenadeProjectileThrow(e events.GrenadeProjectileThrow) {
+	if a.inWarmup() || e.Projectile == nil {
+		return
+	}
+	if thrower := a.ensurePlayer(e.Projectile.Thrower); thrower != nil {
+		thrower.UtilityStats.GrenadesThrown.add(projectileGrenadeType(e.Projectile))
 	}
 }
 
@@ -398,8 +447,9 @@ func perRound(value, rounds int) float64 {
 }
 
 // derive computes the per-player stats that need the finished match:
-// precision, ADR, KAST and the side splits of the last two. It is separate
-// from finalise so tests can drive it with a round count instead of a demo.
+// precision, ADR, KAST, average enemy flash time and the side splits of ADR
+// and KAST. It is separate from finalise so tests can drive it with a round
+// count instead of a demo.
 func (a *analyser) derive(totalRounds int) {
 	for id, p := range a.players {
 		if p.KillStats.Total > 0 {
@@ -427,6 +477,9 @@ func (a *analyser) derive(totalRounds int) {
 		}
 		if kills := p.OpeningDuelStats.OpeningKills.Total; kills > 0 {
 			p.OpeningDuelStats.OpeningSuccessRate = 100 * float64(a.openingWins[id]) / float64(kills)
+		}
+		if flashes := p.UtilityStats.EnemiesFlashed; flashes > 0 {
+			p.UtilityStats.AverageEnemyFlashTimeSeconds = p.UtilityStats.EnemyFlashTimeSeconds / float64(flashes)
 		}
 	}
 }

--- a/cmd/demo_parser/demo_parser_test.go
+++ b/cmd/demo_parser/demo_parser_test.go
@@ -15,19 +15,24 @@ import (
 // three questions and leave the embedded interfaces nil.
 type matchParser struct {
 	demoinfocs.Parser
-	playing []*common.Player
+	playing     []*common.Player
+	warmup      bool
+	currentTime time.Duration
 }
 
-func (p *matchParser) GameState() demoinfocs.GameState { return matchGameState{playing: p.playing} }
+func (p *matchParser) GameState() demoinfocs.GameState {
+	return matchGameState{playing: p.playing, warmup: p.warmup}
+}
 
-func (*matchParser) CurrentTime() time.Duration { return 0 }
+func (p *matchParser) CurrentTime() time.Duration { return p.currentTime }
 
 type matchGameState struct {
 	demoinfocs.GameState
 	playing []*common.Player
+	warmup  bool
 }
 
-func (matchGameState) IsWarmupPeriod() bool { return false }
+func (g matchGameState) IsWarmupPeriod() bool { return g.warmup }
 
 func (g matchGameState) Participants() demoinfocs.Participants {
 	return matchParticipants{playing: g.playing}
@@ -49,6 +54,7 @@ func liveAnalyser(playing ...*common.Player) *analyser {
 		sideDamage:  make(map[uint64]SideCount),
 		openingWins: make(map[uint64]int),
 		lastHealth:  make(map[uint64]int),
+		flashEnds:   make(map[uint64]time.Duration),
 	}
 }
 

--- a/cmd/demo_parser/integration_test.go
+++ b/cmd/demo_parser/integration_test.go
@@ -16,10 +16,11 @@ import (
 // `make download-test-demos`. Each is pinned by SHA-256 so the bytes cannot
 // change underneath the golden files.
 type demoFixture struct {
-	name   string
-	demo   string
-	sha256 string
-	golden string
+	name                 string
+	demo                 string
+	sha256               string
+	golden               string
+	expectsUnusedUtility bool
 }
 
 // The two fixtures cover the two ways a CS2 demo reports round MVPs, which
@@ -42,10 +43,11 @@ type demoFixture struct {
 //     is TestSideStatsFollowTheHalftimeSwap's job.
 var demoFixtures = []demoFixture{
 	{
-		name:   "mirage_round_mvp_events",
-		demo:   "testdata/mirage.dem",
-		sha256: "84a1a4191302bdd2a3bbb5a727842093744b1fb1a228aeec630369e44b622cb2",
-		golden: "testdata/golden_mirage.json",
+		name:                 "mirage_round_mvp_events",
+		demo:                 "testdata/mirage.dem",
+		sha256:               "84a1a4191302bdd2a3bbb5a727842093744b1fb1a228aeec630369e44b622cb2",
+		golden:               "testdata/golden_mirage.json",
+		expectsUnusedUtility: true,
 	},
 	{
 		name:   "ancient_scoreboard_mvps",
@@ -91,6 +93,21 @@ func TestProcessDemoGolden(t *testing.T) {
 			result, err := ProcessDemo(f.demo)
 			if err != nil {
 				t.Fatalf("ProcessDemo: %v", err)
+			}
+			if f.expectsUnusedUtility {
+				// A positive aggregate proves Kill still exposes pre-death
+				// grenade inventory. The golden below pins every exact value;
+				// this assertion documents the prerequisite independently.
+				observed := false
+				for _, player := range result.Players {
+					if player.UtilityStats.UnusedUtilityValue > 0 {
+						observed = true
+						break
+					}
+				}
+				if !observed {
+					t.Fatal("fixture produced no unused utility; Kill may no longer expose pre-death inventory")
+				}
 			}
 
 			got, err := json.MarshalIndent(result, "", "  ")

--- a/cmd/demo_parser/round_tracker.go
+++ b/cmd/demo_parser/round_tracker.go
@@ -51,7 +51,7 @@ type roundOutcome struct {
 // drive it without a demo file.
 type roundTracker struct {
 	live       bool
-	ending     bool
+	decided    bool
 	winner     common.Team
 	startAlive map[uint64]common.Team
 	alive      map[uint64]common.Team
@@ -69,7 +69,7 @@ func newRoundTracker() *roundTracker {
 
 func (rt *roundTracker) startRound(alive map[uint64]common.Team) {
 	rt.live = true
-	rt.ending = false
+	rt.decided = false
 	rt.winner = common.TeamUnassigned
 	rt.startAlive = make(map[uint64]common.Team, len(alive))
 	rt.alive = make(map[uint64]common.Team, len(alive))
@@ -122,14 +122,14 @@ func (rt *roundTracker) kill(killer, victim uint64, killerTeam, victimTeam commo
 		// suicides and world deaths never open a round, and once the round
 		// is decided nothing can (a bomb explosion or exit frag in an
 		// otherwise killless round is not an entry).
-		if rt.opening.killer == 0 && !rt.ending {
+		if rt.opening.killer == 0 && !rt.decided {
 			rt.opening = openingDuel{killer: killer, victim: victim, killerTeam: killerTeam, victimTeam: victimTeam}
 		}
 		rt.enemyKills[killer]++
 		if assister != 0 {
 			rt.assists[assister] = true
 		}
-		// Deliberately no rt.ending guard: deaths and revenge kills stay
+		// Deliberately no rt.decided guard: deaths and revenge kills stay
 		// eligible until finalize, so a post-round death can still be
 		// avenged inside the window.
 		for _, d := range rt.deaths {
@@ -144,17 +144,24 @@ func (rt *roundTracker) kill(killer, victim uint64, killerTeam, victimTeam commo
 	// Dying before the round officially ends cancels survival, including to
 	// the post-round bomb explosion (HLTV convention). Only match-end world
 	// cleanup kills are ignored once the round is decided.
-	if !(rt.ending && byWorld) {
+	if !rt.isPostRoundWorldCleanup(byWorld) {
 		rt.remove(victim)
 	}
 	return isTrade
+}
+
+// isPostRoundWorldCleanup identifies engine cleanup deaths after the round
+// result is known. The decision remains available after finalize because CS2
+// can dispatch cleanup kills after RoundEndOfficial; startRound clears it.
+func (rt *roundTracker) isPostRoundWorldCleanup(byWorld bool) bool {
+	return rt.decided && byWorld
 }
 
 // disconnect handles a player leaving mid-round: they count as dead for
 // the round, unless the round is already decided (players leaving after
 // the final whistle keep their survival).
 func (rt *roundTracker) disconnect(player uint64) {
-	if rt.ending {
+	if rt.decided {
 		return
 	}
 	rt.remove(player)
@@ -174,7 +181,7 @@ func (rt *roundTracker) remove(player uint64) {
 // one enemy. The candidacy sticks for the rest of the round. Once the round
 // is decided, post-round deaths cannot start a clutch anymore.
 func (rt *roundTracker) updateClutchCandidates() {
-	if rt.ending {
+	if rt.decided {
 		return
 	}
 	for _, team := range bothTeams {
@@ -213,7 +220,7 @@ func (rt *roundTracker) markEnd(winner common.Team) {
 	if !rt.live {
 		return
 	}
-	rt.ending = true
+	rt.decided = true
 	rt.winner = winner
 }
 
@@ -224,7 +231,6 @@ func (rt *roundTracker) finalize() roundOutcome {
 		return roundOutcome{}
 	}
 	rt.live = false
-	rt.ending = false
 
 	outcome := roundOutcome{
 		played:       true,

--- a/cmd/demo_parser/testdata/golden_ancient.json
+++ b/cmd/demo_parser/testdata/golden_ancient.json
@@ -76,6 +76,27 @@
           "ct": 87.5,
           "t": 0
         }
+      },
+      "utility_stats": {
+        "enemies_flashed": 0,
+        "friends_flashed": 0,
+        "enemy_flash_time_seconds": 0,
+        "average_enemy_flash_time_seconds": 0,
+        "utility_damage": {
+          "total": 12,
+          "he": 12,
+          "fire": 0
+        },
+        "grenades_thrown": {
+          "total": 10,
+          "flash": 1,
+          "smoke": 2,
+          "he": 3,
+          "molotov": 0,
+          "incendiary": 4,
+          "decoy": 0
+        },
+        "unused_utility_value": 500
       }
     },
     "76561198071075349": {
@@ -155,6 +176,27 @@
           "ct": 100,
           "t": 0
         }
+      },
+      "utility_stats": {
+        "enemies_flashed": 1,
+        "friends_flashed": 2,
+        "enemy_flash_time_seconds": 4.592928256,
+        "average_enemy_flash_time_seconds": 4.592928256,
+        "utility_damage": {
+          "total": 38,
+          "he": 6,
+          "fire": 32
+        },
+        "grenades_thrown": {
+          "total": 12,
+          "flash": 2,
+          "smoke": 1,
+          "he": 4,
+          "molotov": 0,
+          "incendiary": 5,
+          "decoy": 0
+        },
+        "unused_utility_value": 800
       }
     },
     "76561198307159112": {
@@ -232,6 +274,27 @@
           "ct": 0,
           "t": 37.5
         }
+      },
+      "utility_stats": {
+        "enemies_flashed": 0,
+        "friends_flashed": 0,
+        "enemy_flash_time_seconds": 0,
+        "average_enemy_flash_time_seconds": 0,
+        "utility_damage": {
+          "total": 0,
+          "he": 0,
+          "fire": 0
+        },
+        "grenades_thrown": {
+          "total": 1,
+          "flash": 0,
+          "smoke": 0,
+          "he": 1,
+          "molotov": 0,
+          "incendiary": 0,
+          "decoy": 0
+        },
+        "unused_utility_value": 200
       }
     },
     "76561198387460920": {
@@ -307,6 +370,27 @@
           "ct": 87.5,
           "t": 0
         }
+      },
+      "utility_stats": {
+        "enemies_flashed": 0,
+        "friends_flashed": 1,
+        "enemy_flash_time_seconds": 0,
+        "average_enemy_flash_time_seconds": 0,
+        "utility_damage": {
+          "total": 31,
+          "he": 17,
+          "fire": 14
+        },
+        "grenades_thrown": {
+          "total": 11,
+          "flash": 1,
+          "smoke": 2,
+          "he": 4,
+          "molotov": 0,
+          "incendiary": 4,
+          "decoy": 0
+        },
+        "unused_utility_value": 1000
       }
     },
     "76561198826243397": {
@@ -385,6 +469,27 @@
           "ct": 75,
           "t": 0
         }
+      },
+      "utility_stats": {
+        "enemies_flashed": 0,
+        "friends_flashed": 0,
+        "enemy_flash_time_seconds": 0,
+        "average_enemy_flash_time_seconds": 0,
+        "utility_damage": {
+          "total": 0,
+          "he": 0,
+          "fire": 0
+        },
+        "grenades_thrown": {
+          "total": 10,
+          "flash": 3,
+          "smoke": 4,
+          "he": 2,
+          "molotov": 0,
+          "incendiary": 1,
+          "decoy": 0
+        },
+        "unused_utility_value": 800
       }
     },
     "76561198966281369": {
@@ -466,6 +571,27 @@
           "ct": 100,
           "t": 0
         }
+      },
+      "utility_stats": {
+        "enemies_flashed": 2,
+        "friends_flashed": 1,
+        "enemy_flash_time_seconds": 0.77198016,
+        "average_enemy_flash_time_seconds": 0.38599008,
+        "utility_damage": {
+          "total": 106,
+          "he": 64,
+          "fire": 42
+        },
+        "grenades_thrown": {
+          "total": 17,
+          "flash": 2,
+          "smoke": 5,
+          "he": 5,
+          "molotov": 0,
+          "incendiary": 4,
+          "decoy": 1
+        },
+        "unused_utility_value": 1100
       }
     },
     "76561199102419525": {
@@ -545,6 +671,27 @@
           "ct": 0,
           "t": 62.5
         }
+      },
+      "utility_stats": {
+        "enemies_flashed": 3,
+        "friends_flashed": 2,
+        "enemy_flash_time_seconds": 9.445946880000001,
+        "average_enemy_flash_time_seconds": 3.1486489600000005,
+        "utility_damage": {
+          "total": 1,
+          "he": 0,
+          "fire": 1
+        },
+        "grenades_thrown": {
+          "total": 5,
+          "flash": 1,
+          "smoke": 2,
+          "he": 0,
+          "molotov": 2,
+          "incendiary": 0,
+          "decoy": 0
+        },
+        "unused_utility_value": 1400
       }
     },
     "76561199271102802": {
@@ -622,6 +769,27 @@
           "ct": 0,
           "t": 25
         }
+      },
+      "utility_stats": {
+        "enemies_flashed": 9,
+        "friends_flashed": 2,
+        "enemy_flash_time_seconds": 19.08780096,
+        "average_enemy_flash_time_seconds": 2.1208667733333333,
+        "utility_damage": {
+          "total": 0,
+          "he": 0,
+          "fire": 0
+        },
+        "grenades_thrown": {
+          "total": 6,
+          "flash": 6,
+          "smoke": 0,
+          "he": 0,
+          "molotov": 0,
+          "incendiary": 0,
+          "decoy": 0
+        },
+        "unused_utility_value": 1300
       }
     },
     "76561199311359933": {
@@ -700,6 +868,27 @@
           "ct": 0,
           "t": 66.66666666666666
         }
+      },
+      "utility_stats": {
+        "enemies_flashed": 0,
+        "friends_flashed": 0,
+        "enemy_flash_time_seconds": 0,
+        "average_enemy_flash_time_seconds": 0,
+        "utility_damage": {
+          "total": 11,
+          "he": 11,
+          "fire": 0
+        },
+        "grenades_thrown": {
+          "total": 1,
+          "flash": 0,
+          "smoke": 0,
+          "he": 1,
+          "molotov": 0,
+          "incendiary": 0,
+          "decoy": 0
+        },
+        "unused_utility_value": 800
       }
     },
     "76561199558715190": {
@@ -778,6 +967,27 @@
           "ct": 0,
           "t": 62.5
         }
+      },
+      "utility_stats": {
+        "enemies_flashed": 4,
+        "friends_flashed": 1,
+        "enemy_flash_time_seconds": 8.175325088000001,
+        "average_enemy_flash_time_seconds": 2.0438312720000003,
+        "utility_damage": {
+          "total": 0,
+          "he": 0,
+          "fire": 0
+        },
+        "grenades_thrown": {
+          "total": 2,
+          "flash": 2,
+          "smoke": 0,
+          "he": 0,
+          "molotov": 0,
+          "incendiary": 0,
+          "decoy": 0
+        },
+        "unused_utility_value": 2400
       }
     }
   },

--- a/cmd/demo_parser/testdata/golden_mirage.json
+++ b/cmd/demo_parser/testdata/golden_mirage.json
@@ -78,6 +78,27 @@
           "ct": 0,
           "t": 100
         }
+      },
+      "utility_stats": {
+        "enemies_flashed": 2,
+        "friends_flashed": 3,
+        "enemy_flash_time_seconds": 2.755166144,
+        "average_enemy_flash_time_seconds": 1.377583072,
+        "utility_damage": {
+          "total": 119,
+          "he": 113,
+          "fire": 6
+        },
+        "grenades_thrown": {
+          "total": 19,
+          "flash": 5,
+          "smoke": 8,
+          "he": 4,
+          "molotov": 2,
+          "incendiary": 0,
+          "decoy": 0
+        },
+        "unused_utility_value": 0
       }
     },
     "76561198073049527": {
@@ -157,6 +178,27 @@
           "ct": 70,
           "t": 0
         }
+      },
+      "utility_stats": {
+        "enemies_flashed": 4,
+        "friends_flashed": 0,
+        "enemy_flash_time_seconds": 11.901029056,
+        "average_enemy_flash_time_seconds": 2.975257264,
+        "utility_damage": {
+          "total": 64,
+          "he": 0,
+          "fire": 64
+        },
+        "grenades_thrown": {
+          "total": 7,
+          "flash": 1,
+          "smoke": 2,
+          "he": 3,
+          "molotov": 0,
+          "incendiary": 1,
+          "decoy": 0
+        },
+        "unused_utility_value": 500
       }
     },
     "76561198118803912": {
@@ -235,6 +277,27 @@
           "ct": 0,
           "t": 80
         }
+      },
+      "utility_stats": {
+        "enemies_flashed": 4,
+        "friends_flashed": 1,
+        "enemy_flash_time_seconds": 6.541550751999999,
+        "average_enemy_flash_time_seconds": 1.6353876879999998,
+        "utility_damage": {
+          "total": 60,
+          "he": 60,
+          "fire": 0
+        },
+        "grenades_thrown": {
+          "total": 19,
+          "flash": 4,
+          "smoke": 4,
+          "he": 6,
+          "molotov": 5,
+          "incendiary": 0,
+          "decoy": 0
+        },
+        "unused_utility_value": 0
       }
     },
     "76561198194694750": {
@@ -316,6 +379,27 @@
           "ct": 50,
           "t": 0
         }
+      },
+      "utility_stats": {
+        "enemies_flashed": 0,
+        "friends_flashed": 0,
+        "enemy_flash_time_seconds": 0,
+        "average_enemy_flash_time_seconds": 0,
+        "utility_damage": {
+          "total": 7,
+          "he": 7,
+          "fire": 0
+        },
+        "grenades_thrown": {
+          "total": 5,
+          "flash": 0,
+          "smoke": 2,
+          "he": 3,
+          "molotov": 0,
+          "incendiary": 0,
+          "decoy": 0
+        },
+        "unused_utility_value": 1400
       }
     },
     "76561198202353993": {
@@ -395,6 +479,27 @@
           "ct": 0,
           "t": 90
         }
+      },
+      "utility_stats": {
+        "enemies_flashed": 7,
+        "friends_flashed": 5,
+        "enemy_flash_time_seconds": 14.339694272000001,
+        "average_enemy_flash_time_seconds": 2.0485277531428574,
+        "utility_damage": {
+          "total": 0,
+          "he": 0,
+          "fire": 0
+        },
+        "grenades_thrown": {
+          "total": 25,
+          "flash": 9,
+          "smoke": 5,
+          "he": 6,
+          "molotov": 5,
+          "incendiary": 0,
+          "decoy": 0
+        },
+        "unused_utility_value": 800
       }
     },
     "76561198244754626": {
@@ -474,6 +579,27 @@
           "ct": 0,
           "t": 90
         }
+      },
+      "utility_stats": {
+        "enemies_flashed": 2,
+        "friends_flashed": 2,
+        "enemy_flash_time_seconds": 4.755892928,
+        "average_enemy_flash_time_seconds": 2.377946464,
+        "utility_damage": {
+          "total": 117,
+          "he": 105,
+          "fire": 12
+        },
+        "grenades_thrown": {
+          "total": 25,
+          "flash": 7,
+          "smoke": 6,
+          "he": 6,
+          "molotov": 6,
+          "incendiary": 0,
+          "decoy": 0
+        },
+        "unused_utility_value": 0
       }
     },
     "76561198258044111": {
@@ -553,6 +679,27 @@
           "ct": 60,
           "t": 0
         }
+      },
+      "utility_stats": {
+        "enemies_flashed": 1,
+        "friends_flashed": 0,
+        "enemy_flash_time_seconds": 1.006990912,
+        "average_enemy_flash_time_seconds": 1.006990912,
+        "utility_damage": {
+          "total": 59,
+          "he": 59,
+          "fire": 0
+        },
+        "grenades_thrown": {
+          "total": 7,
+          "flash": 2,
+          "smoke": 1,
+          "he": 3,
+          "molotov": 0,
+          "incendiary": 1,
+          "decoy": 0
+        },
+        "unused_utility_value": 1900
       }
     },
     "76561198265366770": {
@@ -631,6 +778,27 @@
           "ct": 0,
           "t": 100
         }
+      },
+      "utility_stats": {
+        "enemies_flashed": 4,
+        "friends_flashed": 9,
+        "enemy_flash_time_seconds": 10.522374079999999,
+        "average_enemy_flash_time_seconds": 2.6305935199999997,
+        "utility_damage": {
+          "total": 80,
+          "he": 8,
+          "fire": 72
+        },
+        "grenades_thrown": {
+          "total": 29,
+          "flash": 15,
+          "smoke": 7,
+          "he": 2,
+          "molotov": 5,
+          "incendiary": 0,
+          "decoy": 0
+        },
+        "unused_utility_value": 200
       }
     },
     "76561198280975787": {
@@ -710,6 +878,27 @@
           "ct": 33.33333333333333,
           "t": 0
         }
+      },
+      "utility_stats": {
+        "enemies_flashed": 6,
+        "friends_flashed": 4,
+        "enemy_flash_time_seconds": 8.738488511999998,
+        "average_enemy_flash_time_seconds": 1.4564147519999997,
+        "utility_damage": {
+          "total": 0,
+          "he": 0,
+          "fire": 0
+        },
+        "grenades_thrown": {
+          "total": 11,
+          "flash": 5,
+          "smoke": 4,
+          "he": 0,
+          "molotov": 0,
+          "incendiary": 2,
+          "decoy": 0
+        },
+        "unused_utility_value": 400
       }
     },
     "76561198324843075": {
@@ -788,6 +977,27 @@
           "ct": 70,
           "t": 0
         }
+      },
+      "utility_stats": {
+        "enemies_flashed": 0,
+        "friends_flashed": 0,
+        "enemy_flash_time_seconds": 0,
+        "average_enemy_flash_time_seconds": 0,
+        "utility_damage": {
+          "total": 52,
+          "he": 52,
+          "fire": 0
+        },
+        "grenades_thrown": {
+          "total": 3,
+          "flash": 0,
+          "smoke": 1,
+          "he": 1,
+          "molotov": 0,
+          "incendiary": 1,
+          "decoy": 0
+        },
+        "unused_utility_value": 200
       }
     }
   },

--- a/cmd/demo_parser/types.go
+++ b/cmd/demo_parser/types.go
@@ -76,6 +76,39 @@ type OpeningDuelStats struct {
 	OpeningSuccessRate float64   `json:"opening_success_rate"`
 }
 
+// UtilityDamageStats counts real enemy health removed by standard damaging
+// grenades. Fire combines molotov and incendiary damage because the originating
+// grenade cannot be recovered reliably from inferno hurt events.
+type UtilityDamageStats struct {
+	Total int `json:"total"`
+	HE    int `json:"he"`
+	Fire  int `json:"fire"`
+}
+
+// GrenadesThrownStats counts one use per standard grenade projectile created.
+// Total is maintained with the six mutually exclusive type counters.
+type GrenadesThrownStats struct {
+	Total      int `json:"total"`
+	Flash      int `json:"flash"`
+	Smoke      int `json:"smoke"`
+	HE         int `json:"he"`
+	Molotov    int `json:"molotov"`
+	Incendiary int `json:"incendiary"`
+	Decoy      int `json:"decoy"`
+}
+
+// UtilityStats holds match-wide flash, damage, usage, and unused-inventory
+// measurements. Flash counts are events rather than unique affected players.
+type UtilityStats struct {
+	EnemiesFlashed               int                 `json:"enemies_flashed"`
+	FriendsFlashed               int                 `json:"friends_flashed"`
+	EnemyFlashTimeSeconds        float64             `json:"enemy_flash_time_seconds"`
+	AverageEnemyFlashTimeSeconds float64             `json:"average_enemy_flash_time_seconds"`
+	UtilityDamage                UtilityDamageStats  `json:"utility_damage"`
+	GrenadesThrown               GrenadesThrownStats `json:"grenades_thrown"`
+	UnusedUtilityValue           int                 `json:"unused_utility_value"`
+}
+
 type DemoPlayer struct {
 	SteamID          uint64           `json:"steam_id"`
 	Name             string           `json:"name"`
@@ -87,6 +120,7 @@ type DemoPlayer struct {
 	PlayerMapStats   PlayerMapStats   `json:"player_map_stats"`
 	OpeningDuelStats OpeningDuelStats `json:"opening_duel_stats"`
 	SideStats        SideStats        `json:"side_stats"`
+	UtilityStats     UtilityStats     `json:"utility_stats"`
 }
 
 type MapData struct {

--- a/cmd/demo_parser/utility.go
+++ b/cmd/demo_parser/utility.go
@@ -1,0 +1,120 @@
+package demoparser
+
+import (
+	"time"
+
+	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
+)
+
+// standardGrenadePrices holds normal Competitive purchase prices from the
+// CS2 economy in August 2026. Equipment exposes inventory quantity but no
+// price, so game economy changes must be reflected here explicitly.
+var standardGrenadePrices = map[common.EquipmentType]int{
+	common.EqFlash:      200,
+	common.EqSmoke:      300,
+	common.EqHE:         300,
+	common.EqMolotov:    400,
+	common.EqIncendiary: 500,
+	common.EqDecoy:      50,
+}
+
+func isStandardGrenade(equipmentType common.EquipmentType) bool {
+	_, ok := standardGrenadePrices[equipmentType]
+	return ok
+}
+
+// projectileGrenadeType returns the standard grenade represented by a throw.
+// demoinfocs normally resolves the projectile model; when that lookup misses,
+// the grenade is still the thrower's active inventory item at dispatch time.
+// Known game-mode-only equipment is returned unchanged so add can ignore it.
+func projectileGrenadeType(projectile *common.GrenadeProjectile) common.EquipmentType {
+	if projectile == nil {
+		return common.EqUnknown
+	}
+	if projectile.WeaponInstance != nil && projectile.WeaponInstance.Type != common.EqUnknown {
+		return projectile.WeaponInstance.Type
+	}
+	if projectile.Thrower == nil {
+		return common.EqUnknown
+	}
+	active := projectile.Thrower.Inventory[projectile.Thrower.ActiveWeaponID()]
+	if active != nil && isStandardGrenade(active.Type) {
+		return active.Type
+	}
+	return common.EqUnknown
+}
+
+// unusedUtilityValue prices only the six standard purchasable grenades in an
+// inventory. Magazine plus reserve represents stacked flashbangs correctly.
+func unusedUtilityValue(inventory map[int]*common.Equipment) int {
+	value := 0
+	for _, equipment := range inventory {
+		if equipment == nil {
+			continue
+		}
+		price, ok := standardGrenadePrices[equipment.Type]
+		if !ok {
+			continue
+		}
+		quantity := equipment.AmmoInMagazine() + equipment.AmmoReserve()
+		value += price * quantity
+	}
+	return value
+}
+
+// addedFlashTime returns only the part of the reported blind interval that
+// extends beyond blind time already observed for this player. PlayerFlashed's
+// duration is the player's current m_flFlashDuration, so summing it directly
+// would count the overlap again when a blinded player is re-flashed.
+func (a *analyser) addedFlashTime(player *common.Player, reported time.Duration) time.Duration {
+	now := a.parser.CurrentTime()
+	newEnd := now + max(reported, 0)
+	playerID := trackerID(player)
+	previousEnd := a.flashEnds[playerID]
+	if newEnd <= previousEnd {
+		return 0
+	}
+	a.flashEnds[playerID] = newEnd
+	if previousEnd > now {
+		return newEnd - previousEnd
+	}
+	return newEnd - now
+}
+
+// add credits capped enemy health damage to the utility type that caused it.
+// Fire combines molotov and incendiary damage because hurt events do not
+// reliably preserve which grenade created an inferno.
+func (stats *UtilityDamageStats) add(equipmentType common.EquipmentType, damage int) {
+	switch equipmentType {
+	case common.EqHE:
+		stats.HE += damage
+	case common.EqMolotov, common.EqIncendiary:
+		stats.Fire += damage
+	default:
+		return
+	}
+	stats.Total += damage
+}
+
+// add counts one resolved throw of a standard purchasable grenade. Warmup and
+// player attribution are handled by the event handler before this method.
+func (stats *GrenadesThrownStats) add(equipmentType common.EquipmentType) {
+	if !isStandardGrenade(equipmentType) {
+		return
+	}
+	stats.Total++
+	switch equipmentType {
+	case common.EqFlash:
+		stats.Flash++
+	case common.EqSmoke:
+		stats.Smoke++
+	case common.EqHE:
+		stats.HE++
+	case common.EqMolotov:
+		stats.Molotov++
+	case common.EqIncendiary:
+		stats.Incendiary++
+	case common.EqDecoy:
+		stats.Decoy++
+	}
+}

--- a/cmd/demo_parser/utility_test.go
+++ b/cmd/demo_parser/utility_test.go
@@ -1,0 +1,337 @@
+package demoparser
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
+	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
+	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+)
+
+type flashTestProvider struct{}
+
+func (flashTestProvider) IngameTick() int                              { return 0 }
+func (flashTestProvider) TickRate() float64                            { return 64 }
+func (flashTestProvider) FindPlayerByHandle(uint64) *common.Player     { return nil }
+func (flashTestProvider) FindPlayerByPawnHandle(uint64) *common.Player { return nil }
+func (flashTestProvider) FindWeaponByEntityID(int) *common.Equipment   { return nil }
+func (flashTestProvider) FindEntityByHandle(uint64) st.Entity          { return nil }
+
+func flashedPlayer(id uint64, name string, team common.Team, duration float32) *common.Player {
+	p := common.NewPlayer(flashTestProvider{})
+	p.SteamID64 = id
+	p.UserID = int(id)
+	p.Name = name
+	p.Team = team
+	p.FlashDuration = duration
+	return p
+}
+
+func TestFlashStatsAttributeEventsAndDeriveAverage(t *testing.T) {
+	attacker := flashedPlayer(shooterID, "attacker", common.TeamTerrorists, 0)
+	enemy := flashedPlayer(victimID, "enemy", common.TeamCounterTerrorists, 1.5)
+	friend := flashedPlayer(3, "friend", common.TeamTerrorists, 2)
+	a := liveAnalyser(attacker, enemy, friend)
+
+	a.onPlayerFlashed(events.PlayerFlashed{Player: enemy, Attacker: attacker})
+	a.parser.(*matchParser).currentTime = 2 * time.Second
+	enemy.FlashDuration = 2.5
+	a.onPlayerFlashed(events.PlayerFlashed{Player: enemy, Attacker: attacker})
+	a.onPlayerFlashed(events.PlayerFlashed{Player: friend, Attacker: attacker})
+	attacker.FlashDuration = 4
+	a.onPlayerFlashed(events.PlayerFlashed{Player: attacker, Attacker: attacker})
+	a.derive(0)
+
+	got := a.players[shooterID].UtilityStats
+	if got.EnemiesFlashed != 2 {
+		t.Errorf("enemies flashed = %d, want 2", got.EnemiesFlashed)
+	}
+	if got.FriendsFlashed != 1 {
+		t.Errorf("friends flashed = %d, want 1", got.FriendsFlashed)
+	}
+	if !closeTo(got.EnemyFlashTimeSeconds, 4) {
+		t.Errorf("enemy flash time = %v, want 4", got.EnemyFlashTimeSeconds)
+	}
+	if !closeTo(got.AverageEnemyFlashTimeSeconds, 2) {
+		t.Errorf("average enemy flash time = %v, want 2", got.AverageEnemyFlashTimeSeconds)
+	}
+}
+
+func TestRepeatedFlashCountsOnlyNewBlindTime(t *testing.T) {
+	attacker := flashedPlayer(shooterID, "attacker", common.TeamTerrorists, 0)
+	enemy := flashedPlayer(victimID, "enemy", common.TeamCounterTerrorists, 4)
+	a := liveAnalyser(attacker, enemy)
+
+	a.onPlayerFlashed(events.PlayerFlashed{Player: enemy, Attacker: attacker})
+	a.parser.(*matchParser).currentTime = 2 * time.Second
+	a.onPlayerFlashed(events.PlayerFlashed{Player: enemy, Attacker: attacker})
+	a.derive(0)
+
+	got := a.players[shooterID].UtilityStats
+	if got.EnemiesFlashed != 2 {
+		t.Errorf("enemies flashed = %d, want 2 events", got.EnemiesFlashed)
+	}
+	if !closeTo(got.EnemyFlashTimeSeconds, 6) {
+		t.Errorf("enemy flash time = %v, want 6 seconds of non-overlapping blind time", got.EnemyFlashTimeSeconds)
+	}
+	if !closeTo(got.AverageEnemyFlashTimeSeconds, 3) {
+		t.Errorf("average enemy flash time = %v, want 3", got.AverageEnemyFlashTimeSeconds)
+	}
+}
+
+func TestAverageEnemyFlashTimeIsZeroWithoutEnemyFlashes(t *testing.T) {
+	a := liveAnalyser()
+	a.players[shooterID] = &DemoPlayer{SteamID: shooterID}
+
+	a.derive(0)
+
+	if got := a.players[shooterID].UtilityStats.AverageEnemyFlashTimeSeconds; got != 0 {
+		t.Errorf("average enemy flash time = %v, want 0", got)
+	}
+}
+
+func TestFlashStatsIgnoreWarmup(t *testing.T) {
+	attacker := flashedPlayer(shooterID, "attacker", common.TeamTerrorists, 0)
+	enemy := flashedPlayer(victimID, "enemy", common.TeamCounterTerrorists, 2)
+	a := liveAnalyser(attacker, enemy)
+	a.parser.(*matchParser).warmup = true
+
+	a.onPlayerFlashed(events.PlayerFlashed{Player: enemy, Attacker: attacker})
+
+	if len(a.players) != 0 {
+		t.Errorf("players created during warmup = %d, want 0", len(a.players))
+	}
+}
+
+func TestFlashAssistKeepsExistingJSONKey(t *testing.T) {
+	data, err := json.Marshal(DemoPlayer{AssistStats: AssistStats{FlashedEnemies: 3}})
+	if err != nil {
+		t.Fatalf("marshalling player: %v", err)
+	}
+	jsonText := string(data)
+	if !strings.Contains(jsonText, `"assist_stats":{"total":0,"flashed_enemies":3`) {
+		t.Errorf("flash assists missing from assist_stats: %s", jsonText)
+	}
+	if got := strings.Count(jsonText, `"flashed_enemies"`); got != 1 {
+		t.Errorf("flashed_enemies key count = %d, want 1", got)
+	}
+}
+
+func utilityHurt(a *analyser, attacker, victim *common.Player, equipmentType common.EquipmentType, reported, before, after int) {
+	a.lastHealth[trackerID(victim)] = before
+	a.onPlayerHurt(events.PlayerHurt{
+		Player:            victim,
+		Attacker:          attacker,
+		Weapon:            &common.Equipment{Type: equipmentType},
+		HealthDamageTaken: reported,
+		Health:            after,
+	})
+}
+
+func TestUtilityDamageUsesRealEnemyHealthRemoved(t *testing.T) {
+	attacker := player(shooterID, "attacker", common.TeamTerrorists)
+	a := liveAnalyser(attacker)
+
+	// The HE reports 80, but the victim only loses 10 real health.
+	utilityHurt(a, attacker, player(10, "he", common.TeamCounterTerrorists), common.EqHE, 80, 100, 90)
+	utilityHurt(a, attacker, player(11, "molotov", common.TeamCounterTerrorists), common.EqMolotov, 12, 100, 88)
+	utilityHurt(a, attacker, player(12, "incendiary", common.TeamCounterTerrorists), common.EqIncendiary, 8, 100, 92)
+
+	got := a.players[shooterID].UtilityStats.UtilityDamage
+	want := UtilityDamageStats{Total: 30, HE: 10, Fire: 20}
+	if got != want {
+		t.Errorf("utility damage = %+v, want %+v", got, want)
+	}
+}
+
+func TestUtilityDamageExcludesOtherWeaponsTeamSelfAndBombDamage(t *testing.T) {
+	attacker := player(shooterID, "attacker", common.TeamTerrorists)
+	enemy := player(victimID, "enemy", common.TeamCounterTerrorists)
+	teammate := player(3, "teammate", common.TeamTerrorists)
+	a := liveAnalyser(attacker, enemy, teammate)
+
+	utilityHurt(a, attacker, enemy, common.EqAK47, 20, 100, 80)
+	utilityHurt(a, attacker, enemy, common.EqFlash, 5, 100, 95)
+	utilityHurt(a, attacker, teammate, common.EqHE, 20, 100, 80)
+	utilityHurt(a, attacker, attacker, common.EqHE, 20, 100, 80)
+	utilityHurt(a, attacker, enemy, common.EqBomb, 20, 100, 80)
+
+	got := a.players[shooterID]
+	if got.UtilityStats.UtilityDamage != (UtilityDamageStats{}) {
+		t.Errorf("utility damage = %+v, want zero", got.UtilityStats.UtilityDamage)
+	}
+	if got.AssistStats.DamageGiven != 25 {
+		t.Errorf("damage given = %d, want 25 from the gun and flash projectile hits", got.AssistStats.DamageGiven)
+	}
+}
+
+func grenadeThrow(thrower *common.Player, equipmentType common.EquipmentType) events.GrenadeProjectileThrow {
+	return events.GrenadeProjectileThrow{Projectile: &common.GrenadeProjectile{
+		Thrower:        thrower,
+		WeaponInstance: &common.Equipment{Type: equipmentType},
+	}}
+}
+
+func TestGrenadesThrownCountsEachStandardType(t *testing.T) {
+	thrower := player(shooterID, "thrower", common.TeamTerrorists)
+	a := liveAnalyser(thrower)
+
+	for _, equipmentType := range []common.EquipmentType{
+		common.EqFlash,
+		common.EqSmoke,
+		common.EqHE,
+		common.EqMolotov,
+		common.EqIncendiary,
+		common.EqDecoy,
+		common.EqSnowball,
+	} {
+		a.onGrenadeProjectileThrow(grenadeThrow(thrower, equipmentType))
+	}
+
+	got := a.players[shooterID].UtilityStats.GrenadesThrown
+	want := GrenadesThrownStats{Total: 6, Flash: 1, Smoke: 1, HE: 1, Molotov: 1, Incendiary: 1, Decoy: 1}
+	if got != want {
+		t.Errorf("grenades thrown = %+v, want %+v", got, want)
+	}
+}
+
+func TestGrenadesThrownRecoversUnknownModelFromActiveInventory(t *testing.T) {
+	thrower := player(shooterID, "thrower", common.TeamTerrorists)
+	// A plain test player has no pawn entity, so ActiveWeaponID is zero. The
+	// real parser's inventory uses the live active entity ID in the same way.
+	thrower.Inventory = map[int]*common.Equipment{0: {Type: common.EqFlash}}
+	a := liveAnalyser(thrower)
+
+	a.onGrenadeProjectileThrow(grenadeThrow(thrower, common.EqUnknown))
+
+	want := GrenadesThrownStats{Total: 1, Flash: 1}
+	if got := a.players[shooterID].UtilityStats.GrenadesThrown; got != want {
+		t.Errorf("grenades thrown = %+v, want %+v", got, want)
+	}
+}
+
+func TestGrenadeThrowsIgnoreWarmup(t *testing.T) {
+	thrower := player(shooterID, "thrower", common.TeamTerrorists)
+	a := liveAnalyser(thrower)
+	a.parser.(*matchParser).warmup = true
+
+	a.onGrenadeProjectileThrow(grenadeThrow(thrower, common.EqFlash))
+
+	if len(a.players) != 0 {
+		t.Errorf("players created during warmup = %d, want 0", len(a.players))
+	}
+}
+
+type reserveEntity struct {
+	st.Entity
+	reserve int
+}
+
+func (e reserveEntity) Property(name string) st.Property {
+	if name != "m_pReserveAmmo.0000" {
+		return nil
+	}
+	return reserveProperty{reserve: e.reserve}
+}
+
+type reserveProperty struct {
+	st.Property
+	reserve int
+}
+
+func (p reserveProperty) Value() st.PropertyValue {
+	return st.PropertyValue{Any: int32(p.reserve)}
+}
+
+func TestStandardGrenadePrices(t *testing.T) {
+	want := map[common.EquipmentType]int{
+		common.EqFlash:      200,
+		common.EqSmoke:      300,
+		common.EqHE:         300,
+		common.EqMolotov:    400,
+		common.EqIncendiary: 500,
+		common.EqDecoy:      50,
+	}
+	if len(standardGrenadePrices) != len(want) {
+		t.Fatalf("price table has %d entries, want %d", len(standardGrenadePrices), len(want))
+	}
+	for equipmentType, price := range want {
+		if got := standardGrenadePrices[equipmentType]; got != price {
+			t.Errorf("%s price = %d, want %d", equipmentType, got, price)
+		}
+	}
+}
+
+func TestUnusedUtilityValueUsesInventoryQuantity(t *testing.T) {
+	inventory := map[int]*common.Equipment{
+		1: {Type: common.EqFlash, Entity: reserveEntity{reserve: 1}},
+		2: {Type: common.EqSmoke},
+		3: {Type: common.EqHE},
+		4: {Type: common.EqMolotov},
+		5: {Type: common.EqIncendiary},
+		6: {Type: common.EqDecoy},
+		7: {Type: common.EqAK47},
+	}
+
+	// Two flashes plus one of every other standard grenade.
+	if got, want := unusedUtilityValue(inventory), 1950; got != want {
+		t.Errorf("unused utility value = %d, want %d", got, want)
+	}
+}
+
+func TestUnusedUtilityCountsEveryQualifyingDeathCause(t *testing.T) {
+	tests := []struct {
+		name string
+		kill events.Kill
+	}{
+		{name: "combat", kill: events.Kill{Killer: player(shooterID, "killer", common.TeamTerrorists), Weapon: &common.Equipment{Type: common.EqAK47}}},
+		{name: "suicide", kill: events.Kill{Weapon: &common.Equipment{Type: common.EqAK47}}},
+		{name: "fall", kill: events.Kill{Weapon: &common.Equipment{Type: common.EqWorld}}},
+		{name: "bomb", kill: events.Kill{Weapon: &common.Equipment{Type: common.EqBomb}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			victim := player(victimID, "victim", common.TeamCounterTerrorists)
+			victim.Inventory = map[int]*common.Equipment{1: {Type: common.EqDecoy}}
+			a := liveAnalyser(victim)
+			a.onRoundStart(events.RoundStart{})
+			tt.kill.Victim = victim
+			if tt.name == "suicide" {
+				tt.kill.Killer = victim
+			}
+
+			a.onKill(tt.kill)
+
+			if got := a.players[victimID].UtilityStats.UnusedUtilityValue; got != 50 {
+				t.Errorf("unused utility value = %d, want 50", got)
+			}
+		})
+	}
+}
+
+func TestUnusedUtilityCountsRepeatedAndPostRoundCombatDeaths(t *testing.T) {
+	a, killer, victim := liveRound()
+	victim.Inventory = map[int]*common.Equipment{1: {Type: common.EqSmoke}}
+	combatDeath := events.Kill{Killer: killer, Victim: victim, Weapon: &common.Equipment{Type: common.EqAK47}}
+
+	a.onKill(combatDeath)
+	a.onKill(combatDeath)
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
+	a.onKill(combatDeath)
+	a.onKill(events.Kill{Killer: victim, Victim: victim, Weapon: &common.Equipment{Type: common.EqWorld}})
+	a.onRoundEndOfficial(events.RoundEndOfficial{})
+	// CS2 can dispatch the match cleanup after RoundEndOfficial. Finalizing
+	// the tracker must not erase the fact that this World death is cleanup.
+	a.onKill(events.Kill{Killer: victim, Victim: victim, Weapon: &common.Equipment{Type: common.EqWorld}})
+
+	got := a.players[victimID]
+	if got.Deaths != 5 {
+		t.Errorf("deaths = %d, want 5", got.Deaths)
+	}
+	if got.UtilityStats.UnusedUtilityValue != 900 {
+		t.Errorf("unused utility value = %d, want 900", got.UtilityStats.UnusedUtilityValue)
+	}
+}


### PR DESCRIPTION
## Summary

- add per-player flash, utility-damage, grenade-usage, and unused-utility statistics
- export the new fields through JSON, CSV, and the detail tables
- cover parser behavior with focused unit tests and SHA-pinned golden fixtures

## Testing

- REQUIRE_TEST_DEMO=1 go test ./... -count=1
- go vet ./...
- go build ./...

Closes #6