### PR TITLE
Remove Git LFS fixture requirement

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-cmd/demo_parser/testdata/inferno-shotgun.dem filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,9 @@ jobs:
           path: |
             cmd/demo_parser/testdata/mirage.dem
             cmd/demo_parser/testdata/ancient.dem
-            cmd/demo_parser/testdata/inferno-shotgun.dem
           # Keyed on all fixture checksums, so changing any demo rolls
           # the cache instead of restoring a stale one.
-          key: test-demos-84a1a4191302bdd2a3bbb5a727842093744b1fb1a228aeec630369e44b622cb2-b29a9cb537a181deef97b15cfed10ee722a37999644a27bb2226fdd77a1337fc-095625b47c2cc6ace12414a6bbc987ea254904d969ae39fb95c7d54e085f7f93
+          key: test-demos-84a1a4191302bdd2a3bbb5a727842093744b1fb1a228aeec630369e44b622cb2-b29a9cb537a181deef97b15cfed10ee722a37999644a27bb2226fdd77a1337fc
       - name: Download test demo fixtures
         if: steps.demo-cache.outputs.cache-hit != 'true'
         run: make download-test-demos
@@ -31,5 +30,5 @@ jobs:
       - run: go build ./...
       - run: go test ./...
         env:
-          # Fail rather than skip if the fixture never made it into place.
+          # Fail rather than skip if a public fixture never made it into place.
           REQUIRE_TEST_DEMO: "1"

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ go.work.sum
 # Build output (see Makefile BUILD_DIR)
 build/
 
-# Ignore downloaded demos; Inferno is the Git LFS-backed exception.
-# See `make download-test-demos`.
+# Ignore downloaded and locally supplied demo fixtures.
+# See cmd/demo_parser/testdata/README.md.
 *.dem
-!cmd/demo_parser/testdata/inferno-shotgun.dem

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,8 @@ GOTEST := $(GOCMD) test
 PLATFORMS := windows linux darwin
 os = $(word 1, $@)
 
-# Integration test fixtures. All are real CS2 demos pinned by SHA-256.
-# Mirage and Ancient come from public upstream sources; Inferno is tracked
-# with Git LFS. Sources, licenses and attribution are in
-# cmd/demo_parser/testdata/README.md.
+# Public integration test fixtures. Both are real CS2 demos pinned by SHA-256.
+# Sources, licenses and attribution are in cmd/demo_parser/testdata/README.md.
 TESTDATA_DIR := cmd/demo_parser/testdata
 
 MIRAGE_DEMO_URL := https://raw.githubusercontent.com/LaihoE/demoparser/4131a4fc02fda291b22421c20e1ca33f149535a7/src/parser/test_demo.dem
@@ -67,9 +65,6 @@ test:
 
 # Fetch the demos the integration test runs against.
 download-test-demos:
-	@if ! git lfs version >/dev/null 2>&1; then echo "git-lfs is required to restore the Inferno fixture" >&2; exit 1; fi
-	@git lfs install --local >/dev/null
-	@git lfs pull --include="$(TESTDATA_DIR)/inferno-shotgun.dem" --exclude=""
 	@$(call fetch_demo,$(TESTDATA_DIR)/mirage.dem,$(MIRAGE_DEMO_URL),$(MIRAGE_DEMO_SHA256))
 	@$(call fetch_demo,$(TESTDATA_DIR)/ancient.dem,$(ANCIENT_DEMO_URL),$(ANCIENT_DEMO_SHA256))
 

--- a/cmd/demo_parser/integration_test.go
+++ b/cmd/demo_parser/integration_test.go
@@ -12,14 +12,15 @@ import (
 )
 
 // demoFixture is a real CS2 demo the parser is run against. The demos are
-// not committed to the repo (they are tens of megabytes); fetch them with
-// `make download-test-demos`. Each is pinned by SHA-256 so the bytes cannot
-// change underneath the golden files.
+// not committed to the repo. Public fixtures can be fetched with
+// `make download-test-demos`; Inferno must be supplied locally. Each is pinned
+// by SHA-256 so the bytes cannot change underneath the golden files.
 type demoFixture struct {
 	name                 string
 	demo                 string
 	sha256               string
 	golden               string
+	requiredInCI         bool
 	expectsUnusedUtility bool
 	expectsSideSwap      bool
 }
@@ -44,13 +45,15 @@ var demoFixtures = []demoFixture{
 		demo:                 "testdata/mirage.dem",
 		sha256:               "84a1a4191302bdd2a3bbb5a727842093744b1fb1a228aeec630369e44b622cb2",
 		golden:               "testdata/golden_mirage.json",
+		requiredInCI:         true,
 		expectsUnusedUtility: true,
 	},
 	{
-		name:   "ancient_scoreboard_mvps",
-		demo:   "testdata/ancient.dem",
-		sha256: "b29a9cb537a181deef97b15cfed10ee722a37999644a27bb2226fdd77a1337fc",
-		golden: "testdata/golden_ancient.json",
+		name:         "ancient_scoreboard_mvps",
+		demo:         "testdata/ancient.dem",
+		sha256:       "b29a9cb537a181deef97b15cfed10ee722a37999644a27bb2226fdd77a1337fc",
+		golden:       "testdata/golden_ancient.json",
+		requiredInCI: true,
 	},
 	{
 		name:            "inferno_shotgun_halftime_and_freeze_join",
@@ -80,24 +83,17 @@ func TestProcessDemoGolden(t *testing.T) {
 				// fails to land in the expected place is a red build
 				// rather than a skip that leaves the integration test
 				// unrun and unnoticed.
-				if os.Getenv("REQUIRE_TEST_DEMO") != "" {
+				if f.requiredInCI && os.Getenv("REQUIRE_TEST_DEMO") != "" {
 					t.Fatalf("fixture %s is missing and REQUIRE_TEST_DEMO is set", f.demo)
 				}
-				t.Skipf("fixture %s not present, run `make download-test-demos` to fetch it", f.demo)
+				t.Skipf("fixture %s not present; see testdata/README.md", f.demo)
 			}
 			if err != nil {
 				t.Fatalf("reading fixture: %v", err)
 			}
-			if len(demoBytes) < 1024 &&
-				strings.HasPrefix(string(demoBytes), "version https://git-lfs.github.com/spec/v1\n") {
-				if os.Getenv("REQUIRE_TEST_DEMO") != "" {
-					t.Fatalf("fixture %s is still a Git LFS pointer; run `make download-test-demos`", f.demo)
-				}
-				t.Skipf("fixture %s is still a Git LFS pointer, run `make download-test-demos`", f.demo)
-			}
 			sum := sha256.Sum256(demoBytes)
 			if got := hex.EncodeToString(sum[:]); got != f.sha256 {
-				t.Fatalf("fixture %s has sha256 %s, want %s; delete it and run `make download-test-demos` again",
+				t.Fatalf("fixture %s has sha256 %s, want %s; replace it with the expected demo",
 					f.demo, got, f.sha256)
 			}
 

--- a/cmd/demo_parser/testdata/README.md
+++ b/cmd/demo_parser/testdata/README.md
@@ -1,17 +1,14 @@
 # Integration test fixtures
 
-The golden files here are checked in. Mirage and Ancient are downloaded from
-their public sources; Inferno is stored with Git LFS. Restore all three with:
+The golden files here are checked in. Restore the two public demo fixtures with:
 
 ```sh
 make download-test-demos
 ```
 
-[Install Git LFS](https://git-lfs.com/) before running the target.
-
-All demos are pinned by SHA-256 in `integration_test.go`; checksums for the
-two downloaded fixtures are repeated in the `Makefile`. Without the demo
-bytes, `go test ./...` skips the affected integration subtest.
+All demos are pinned by SHA-256 in `integration_test.go`; checksums for the two
+downloaded fixtures are repeated in the `Makefile`. Without the demo bytes,
+`go test ./...` skips the affected integration subtest.
 
 ## mirage.dem
 
@@ -43,9 +40,10 @@ overlapping pellet damage. It also crosses halftime and contains one player
 joining a side between `RoundStart` and the end of freeze time.
 
 - Original Valve replay: `match730_003835545804819398890_1582373632_202`
-- Source: tracked in this repository with Git LFS
-- Redistribution: approved by the repository owner, including the player
-  names and Steam IDs present in the replay and golden output
+- Source: optional local fixture; the repository does not distribute the demo
+- Setup: place the exact replay at `cmd/demo_parser/testdata/inferno-shotgun.dem`
+- Golden output redistribution is approved by the repository owner, including
+  the player names and Steam IDs it contains
 - Size: 288,711,083 bytes
 - SHA-256: `095625b47c2cc6ace12414a6bbc987ea254904d969ae39fb95c7d54e085f7f93`
 

--- a/cmd/demo_parser/testdata/inferno-shotgun.dem
+++ b/cmd/demo_parser/testdata/inferno-shotgun.dem
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:095625b47c2cc6ace12414a6bbc987ea254904d969ae39fb95c7d54e085f7f93
-size 288711083


### PR DESCRIPTION
## Summary
- remove the Git LFS pointer, attributes, and setup commands for the Inferno demo
- keep Inferno as a checksum-validated optional local fixture
- require and cache only the two publicly downloadable demo fixtures in CI

## Test plan
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] verify Inferno skips when absent with `REQUIRE_TEST_DEMO=1`
- [x] verify `make -n download-test-demos` contains no Git LFS commands
- [x] verify `git pull` completes without Git LFS