### PR TITLE
Exclude pre-match knife rounds from player and round statistics

### DIFF
--- a/cmd/demo_parser/demo_parser.go
+++ b/cmd/demo_parser/demo_parser.go
@@ -138,8 +138,12 @@ func trackerID(p *common.Player) uint64 {
 	return uint64(p.UserID) | 1<<62
 }
 
-func (a *analyser) inWarmup() bool {
-	return a.parser.GameState().IsWarmupPeriod()
+func (a *analyser) inWarmupOrPregame() bool {
+	state := a.parser.GameState()
+	// Tournament knife rounds can report match-started and non-warmup while
+	// the game rules still identify them as pregame. Rejecting that phase
+	// keeps the following 0:0 competitive round without relying on its order.
+	return state.IsWarmupPeriod() || state.GamePhase() == common.GamePhasePregame
 }
 
 // playingRoster reads the players currently on a side into the shape the
@@ -162,7 +166,7 @@ func (a *analyser) playingRoster() map[uint64]common.Team {
 }
 
 func (a *analyser) onRoundStart(e events.RoundStart) {
-	if a.inWarmup() {
+	if a.inWarmupOrPregame() {
 		return
 	}
 	// Close the previous round in case its official end was never seen.
@@ -178,7 +182,7 @@ func (a *analyser) onRoundStart(e events.RoundStart) {
 // opens, so without this they play a round that counts them nowhere: their
 // kills, deaths and damage land on a side whose round count never moved.
 func (a *analyser) onRoundFreezetimeEnd(e events.RoundFreezetimeEnd) {
-	if a.inWarmup() {
+	if a.inWarmupOrPregame() {
 		return
 	}
 	a.tracker.joinRound(a.playingRoster())
@@ -187,14 +191,14 @@ func (a *analyser) onRoundFreezetimeEnd(e events.RoundFreezetimeEnd) {
 // onBombPlanted feeds the round tracker the bomb state its round-swing
 // win-probability model conditions on.
 func (a *analyser) onBombPlanted(e events.BombPlanted) {
-	if a.inWarmup() {
+	if a.inWarmupOrPregame() {
 		return
 	}
 	a.tracker.plantBomb()
 }
 
 func (a *analyser) onKill(e events.Kill) {
-	if a.inWarmup() || e.Victim == nil {
+	if a.inWarmupOrPregame() || e.Victim == nil {
 		return
 	}
 
@@ -268,7 +272,7 @@ func (a *analyser) onKill(e events.Kill) {
 }
 
 func (a *analyser) onPlayerHurt(e events.PlayerHurt) {
-	if a.inWarmup() || e.Player == nil {
+	if a.inWarmupOrPregame() || e.Player == nil {
 		return
 	}
 
@@ -314,7 +318,7 @@ func (a *analyser) onPlayerHurt(e events.PlayerHurt) {
 }
 
 func (a *analyser) onPlayerFlashed(e events.PlayerFlashed) {
-	if a.inWarmup() || e.Player == nil {
+	if a.inWarmupOrPregame() || e.Player == nil {
 		return
 	}
 	addedBlindTime := a.addedFlashTime(e.Player, e.FlashDuration())
@@ -338,7 +342,7 @@ func (a *analyser) onPlayerFlashed(e events.PlayerFlashed) {
 }
 
 func (a *analyser) onGrenadeProjectileThrow(e events.GrenadeProjectileThrow) {
-	if a.inWarmup() || e.Projectile == nil {
+	if a.inWarmupOrPregame() || e.Projectile == nil {
 		return
 	}
 	if thrower := a.ensurePlayer(e.Projectile.Thrower); thrower != nil {
@@ -347,7 +351,7 @@ func (a *analyser) onGrenadeProjectileThrow(e events.GrenadeProjectileThrow) {
 }
 
 func (a *analyser) onRoundMVP(e events.RoundMVPAnnouncement) {
-	if a.inWarmup() {
+	if a.inWarmupOrPregame() {
 		return
 	}
 	if player := a.ensurePlayer(e.Player); player != nil {
@@ -362,6 +366,9 @@ func (a *analyser) onDisconnect(e events.PlayerDisconnected) {
 }
 
 func (a *analyser) onRoundEnd(e events.RoundEnd) {
+	if a.inWarmupOrPregame() {
+		return
+	}
 	a.syncScoreboardMVPs()
 	a.tracker.markEnd(e.Winner)
 }

--- a/cmd/demo_parser/demo_parser_test.go
+++ b/cmd/demo_parser/demo_parser_test.go
@@ -10,29 +10,33 @@ import (
 	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
 )
 
-// The handlers under test only ask the parser whether the demo is in
-// warmup, who is playing, and what time it is, so these stubs answer those
-// three questions and leave the embedded interfaces nil.
+// The handlers under test only ask the parser for round state, who is
+// playing, and the current time, so these stubs answer those questions and
+// leave the embedded interfaces nil.
 type matchParser struct {
 	demoinfocs.Parser
 	playing     []*common.Player
 	warmup      bool
+	gamePhase   common.GamePhase
 	currentTime time.Duration
 }
 
 func (p *matchParser) GameState() demoinfocs.GameState {
-	return matchGameState{playing: p.playing, warmup: p.warmup}
+	return matchGameState{playing: p.playing, warmup: p.warmup, gamePhase: p.gamePhase}
 }
 
 func (p *matchParser) CurrentTime() time.Duration { return p.currentTime }
 
 type matchGameState struct {
 	demoinfocs.GameState
-	playing []*common.Player
-	warmup  bool
+	playing   []*common.Player
+	warmup    bool
+	gamePhase common.GamePhase
 }
 
 func (g matchGameState) IsWarmupPeriod() bool { return g.warmup }
+
+func (g matchGameState) GamePhase() common.GamePhase { return g.gamePhase }
 
 func (g matchGameState) Participants() demoinfocs.Participants {
 	return matchParticipants{playing: g.playing}
@@ -175,6 +179,116 @@ func TestPostRoundDeathBeforeOfficialEndCancelsKast(t *testing.T) {
 	// finalized at all rather than the whole outcome being dropped.
 	if got := a.kastRounds[shooterID].Total; got != 1 {
 		t.Errorf("shooter kast rounds = %d, want 1", got)
+	}
+}
+
+func TestPregameKnifeRoundIsExcludedBeforeFirstScoredRound(t *testing.T) {
+	shooter := player(shooterID, "shooter", common.TeamTerrorists)
+	victim := player(victimID, "victim", common.TeamCounterTerrorists)
+	assister := player(3, "assister", common.TeamTerrorists)
+	parser := &matchParser{
+		playing:   []*common.Player{shooter, victim},
+		gamePhase: common.GamePhasePregame,
+	}
+	a := newAnalyser(parser)
+	knife := &common.Equipment{Type: common.EqKnife}
+
+	a.onRoundStart(events.RoundStart{})
+	a.onRoundFreezetimeEnd(events.RoundFreezetimeEnd{})
+	a.onBombPlanted(events.BombPlanted{})
+	a.onPlayerHurt(events.PlayerHurt{
+		Player: victim, Attacker: shooter, Weapon: knife, HealthDamageTaken: 100, Health: 0,
+	})
+	a.onKill(events.Kill{
+		Killer: shooter, Victim: victim, Assister: assister, Weapon: knife, IsHeadshot: true,
+	})
+	a.onPlayerFlashed(events.PlayerFlashed{Player: victim, Attacker: shooter})
+	a.onGrenadeProjectileThrow(grenadeThrow(shooter, common.EqFlash))
+	a.onRoundMVP(events.RoundMVPAnnouncement{Player: shooter})
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
+	a.onRoundEndOfficial(events.RoundEndOfficial{})
+
+	if len(a.players) != 0 {
+		t.Fatalf("pregame round created player statistics: %+v", a.players)
+	}
+
+	parser.gamePhase = common.GamePhaseStartGamePhase
+	a.onRoundStart(events.RoundStart{})
+	hurtBy(a, shooter, victim, 30)
+	a.onKill(events.Kill{
+		Killer: shooter, Victim: victim, Weapon: &common.Equipment{Type: common.EqAK47},
+	})
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
+	a.onRoundEndOfficial(events.RoundEndOfficial{})
+
+	gotShooter := a.players[shooterID]
+	if gotShooter.KillStats.Total != 1 || gotShooter.AssistStats.DamageGiven != 30 {
+		t.Errorf("scored-round kills/damage = %d/%d, want 1/30",
+			gotShooter.KillStats.Total, gotShooter.AssistStats.DamageGiven)
+	}
+	if gotShooter.SideStats.Rounds.Total != 1 {
+		t.Errorf("scored rounds = %d, want 1", gotShooter.SideStats.Rounds.Total)
+	}
+	if gotShooter.OpeningDuelStats.OpeningKills.Total != 1 {
+		t.Errorf("opening kills = %d, want 1", gotShooter.OpeningDuelStats.OpeningKills.Total)
+	}
+	if gotShooter.PlayerMapStats.MVPs != 0 || gotShooter.UtilityStats.GrenadesThrown.Total != 0 {
+		t.Errorf("pregame MVP/grenade leaked into stats: MVPs=%d grenades=%d",
+			gotShooter.PlayerMapStats.MVPs, gotShooter.UtilityStats.GrenadesThrown.Total)
+	}
+	gotVictim := a.players[victimID]
+	if gotVictim.Deaths != 1 || gotVictim.SideStats.Rounds.Total != 1 {
+		t.Errorf("scored-round deaths/rounds = %d/%d, want 1/1",
+			gotVictim.Deaths, gotVictim.SideStats.Rounds.Total)
+	}
+}
+
+func TestDemoStartingWithCompetitiveRoundKeepsFirstRound(t *testing.T) {
+	shooter := player(shooterID, "shooter", common.TeamTerrorists)
+	victim := player(victimID, "victim", common.TeamCounterTerrorists)
+	parser := &matchParser{
+		playing:   []*common.Player{shooter, victim},
+		gamePhase: common.GamePhaseStartGamePhase,
+	}
+	a := newAnalyser(parser)
+
+	playRound(a, common.TeamTerrorists, events.Kill{
+		Killer: shooter, Victim: victim, Weapon: &common.Equipment{Type: common.EqAK47},
+	})
+
+	if got := a.players[shooterID].KillStats.Total; got != 1 {
+		t.Errorf("kills = %d, want 1", got)
+	}
+	if got := a.players[shooterID].SideStats.Rounds.Total; got != 1 {
+		t.Errorf("rounds = %d, want 1", got)
+	}
+	if got := a.players[victimID].Deaths; got != 1 {
+		t.Errorf("deaths = %d, want 1", got)
+	}
+}
+
+func TestNextRoundFinalizesDecidedRoundWithoutOfficialEndOnce(t *testing.T) {
+	a, shooter, victim := liveRound()
+	a.onKill(events.Kill{
+		Killer: shooter, Victim: victim, Weapon: &common.Equipment{Type: common.EqAK47},
+	})
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
+	a.onRoundStart(events.RoundStart{})
+
+	if got := a.players[shooterID].SideStats.Rounds.Total; got != 1 {
+		t.Fatalf("rounds after fallback finalization = %d, want 1", got)
+	}
+	if got := a.players[shooterID].OpeningDuelStats.OpeningKills.Total; got != 1 {
+		t.Fatalf("opening kills after fallback finalization = %d, want 1", got)
+	}
+
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamCounterTerrorists})
+	a.onRoundEndOfficial(events.RoundEndOfficial{})
+	if got := a.players[shooterID].SideStats.Rounds.Total; got != 2 {
+		t.Errorf("rounds after the next official end = %d, want 2", got)
+	}
+	if got := a.players[shooterID].OpeningDuelStats.OpeningKills.Total; got != 1 {
+		t.Errorf("first round was finalized more than once: opening kills = %d", got)
 	}
 }
 


### PR DESCRIPTION
## Root cause

The parser ignored warmup events, but tournament knife rounds are reported as non-warmup and match-started. The game rules still expose them as `GamePhasePregame`, so their kills, damage, MVPs, utility, and round participation flowed into player totals.

## Changes

- Treat `GamePhasePregame` like warmup in every player and round statistic handler.
- Preserve the following 0:0 competitive round by checking match phase instead of round position, score, or weapon.
- Add regression coverage for a pregame knife round, a demo starting directly in competitive play, and fallback finalization when `RoundEndOfficial` is absent.

Changed files:

- `cmd/demo_parser/demo_parser.go`
- `cmd/demo_parser/demo_parser_test.go`

## Validation

- `gofmt -w cmd/demo_parser/demo_parser.go cmd/demo_parser/demo_parser_test.go`
- `go test -count=1 ./...`
- Re-parsed all three supplied demos: every full competitor now has `side_stats.rounds.total == map_data.total_rounds` (Inferno 22/22, Anubis 19/19, Mirage 23/23).

## Remaining HLTV differences

After removing knife-round contamination, kills match for 30/30 players, deaths for 28/30, and ADR for 29/30. Coach filtering remains tracked in #25, post-round deaths remain tracked in #30 and #33, and KAST/rating differences are unchanged and outside this issue.

Closes #26