### PR TITLE
Exclude coaching controllers from analysed player data

### DIFF
--- a/cmd/demo_parser/demo_parser.go
+++ b/cmd/demo_parser/demo_parser.go
@@ -103,11 +103,26 @@ func (a *analyser) registerHandlers() {
 	a.parser.RegisterEventHandler(a.onDisconnect)
 }
 
+// isCoachingController reports whether p is affiliated with a side as a
+// coach rather than as a competitor. Such controllers still have a T/CT
+// Team and a live player pawn, but m_iCoachingTeam is non-zero while they
+// are coaching.
+func isCoachingController(p *common.Player) bool {
+	if p == nil || p.Entity == nil {
+		return false
+	}
+	coachingTeam, ok := p.Entity.PropertyValue("m_iCoachingTeam")
+	// A serializer can expose the property before its value arrives. Treat
+	// that as unavailable rather than evidence that the player is a coach.
+	team, set := coachingTeam.Any.(int32)
+	return ok && set && common.Team(team) != common.TeamUnassigned
+}
+
 // ensurePlayer returns the stats entry for p, creating it on first sight.
 // Lazy creation covers demos where recording started after players
 // connected, so no PlayerConnect event is ever seen for them.
 func (a *analyser) ensurePlayer(p *common.Player) *DemoPlayer {
-	if p == nil || p.IsBot || p.SteamID64 == 0 {
+	if p == nil || p.IsBot || p.SteamID64 == 0 || isCoachingController(p) {
 		return nil
 	}
 	dp, ok := a.players[p.SteamID64]
@@ -157,9 +172,13 @@ func (a *analyser) playingRoster() map[uint64]common.Team {
 		if p.Team != common.TeamTerrorists && p.Team != common.TeamCounterTerrorists {
 			continue
 		}
-		roster[trackerID(p)] = p.Team
-		a.lastHealth[trackerID(p)] = p.Health()
-		a.roundTiers[trackerID(p)] = playerTier(p.Inventory)
+		if isCoachingController(p) {
+			continue
+		}
+		id := trackerID(p)
+		roster[id] = p.Team
+		a.lastHealth[id] = p.Health()
+		a.roundTiers[id] = playerTier(p.Inventory)
 		a.ensurePlayer(p)
 	}
 	return roster
@@ -191,14 +210,15 @@ func (a *analyser) onRoundFreezetimeEnd(e events.RoundFreezetimeEnd) {
 // onBombPlanted feeds the round tracker the bomb state its round-swing
 // win-probability model conditions on.
 func (a *analyser) onBombPlanted(e events.BombPlanted) {
-	if a.inWarmupOrPregame() {
+	if a.inWarmupOrPregame() || isCoachingController(e.Player) {
 		return
 	}
 	a.tracker.plantBomb()
 }
 
 func (a *analyser) onKill(e events.Kill) {
-	if a.inWarmupOrPregame() || e.Victim == nil {
+	if a.inWarmupOrPregame() || e.Victim == nil ||
+		isCoachingController(e.Victim) || isCoachingController(e.Killer) {
 		return
 	}
 
@@ -253,7 +273,8 @@ func (a *analyser) onKill(e events.Kill) {
 	}
 
 	var assisterID uint64
-	if !teamkill && e.Assister != nil && e.Assister.Team != e.Victim.Team {
+	if !teamkill && e.Assister != nil &&
+		e.Assister.Team != e.Victim.Team && !isCoachingController(e.Assister) {
 		assisterID = trackerID(e.Assister)
 		if assister := a.ensurePlayer(e.Assister); assister != nil {
 			assister.AssistStats.Total++
@@ -272,7 +293,8 @@ func (a *analyser) onKill(e events.Kill) {
 }
 
 func (a *analyser) onPlayerHurt(e events.PlayerHurt) {
-	if a.inWarmupOrPregame() || e.Player == nil {
+	if a.inWarmupOrPregame() || e.Player == nil ||
+		isCoachingController(e.Player) || isCoachingController(e.Attacker) {
 		return
 	}
 
@@ -318,7 +340,8 @@ func (a *analyser) onPlayerHurt(e events.PlayerHurt) {
 }
 
 func (a *analyser) onPlayerFlashed(e events.PlayerFlashed) {
-	if a.inWarmupOrPregame() || e.Player == nil {
+	if a.inWarmupOrPregame() || e.Player == nil ||
+		isCoachingController(e.Player) || isCoachingController(e.Attacker) {
 		return
 	}
 	addedBlindTime := a.addedFlashTime(e.Player, e.FlashDuration())

--- a/cmd/demo_parser/demo_parser_test.go
+++ b/cmd/demo_parser/demo_parser_test.go
@@ -8,6 +8,7 @@ import (
 	demoinfocs "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
 	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
 	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
+	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
 )
 
 // The handlers under test only ask the parser for round state, who is
@@ -62,6 +63,32 @@ func player(id uint64, name string, team common.Team) *common.Player {
 	return &common.Player{SteamID64: id, UserID: int(id), Name: name, Team: team}
 }
 
+type matchEntity struct {
+	st.Entity
+	properties map[string]st.PropertyValue
+}
+
+func (e matchEntity) PropertyValue(name string) (st.PropertyValue, bool) {
+	value, ok := e.properties[name]
+	return value, ok
+}
+
+func (e matchEntity) PropertyValueMust(name string) st.PropertyValue {
+	if value, ok := e.properties[name]; ok {
+		return value
+	}
+	panic("missing test entity property: " + name)
+}
+
+func playerWithCoachingTeam(id uint64, name string, team, coachingTeam common.Team) *common.Player {
+	p := player(id, name, team)
+	p.Entity = matchEntity{properties: map[string]st.PropertyValue{
+		"m_iCoachingTeam": {Any: int32(coachingTeam)},
+		"m_iMVPs":         {Any: int32(0)},
+	}}
+	return p
+}
+
 // botPlayer builds a bot, whose SteamID64 is always 0 like every other bot's.
 func botPlayer(userID int, name string, team common.Team) *common.Player {
 	return &common.Player{IsBot: true, UserID: userID, Name: name, Team: team}
@@ -85,6 +112,105 @@ func damageGiven(a *analyser) int {
 		return 0
 	}
 	return p.AssistStats.DamageGiven
+}
+
+func TestPlayingRosterExcludesCoachingController(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		team common.Team
+	}{
+		{name: "terrorist", team: common.TeamTerrorists},
+		{name: "counter-terrorist", team: common.TeamCounterTerrorists},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			const coachID = uint64(3)
+			competitor := player(shooterID, "competitor", common.TeamTerrorists)
+			coach := playerWithCoachingTeam(coachID, "coach", test.team, test.team)
+			a := liveAnalyser(competitor, coach)
+
+			roster := a.playingRoster()
+
+			if _, ok := roster[coachID]; ok {
+				t.Error("coaching controller was included in the round roster")
+			}
+			if _, ok := roster[shooterID]; !ok {
+				t.Error("competitor was excluded from the round roster")
+			}
+			if _, ok := a.players[coachID]; ok {
+				t.Error("coaching controller was exported as a player")
+			}
+
+			a.syncScoreboardMVPs()
+			if _, ok := a.players[coachID]; ok {
+				t.Error("scoreboard MVP sync exported the coaching controller")
+			}
+		})
+	}
+}
+
+func TestUnsetCoachingTeamKeepsPlayerEligible(t *testing.T) {
+	competitor := player(shooterID, "competitor", common.TeamTerrorists)
+	competitor.Entity = matchEntity{properties: map[string]st.PropertyValue{
+		"m_iCoachingTeam": {},
+	}}
+	a := liveAnalyser(competitor)
+
+	if a.ensurePlayer(competitor) == nil {
+		t.Error("player with an unset coaching team was excluded")
+	}
+}
+
+func TestCoachingControllerEventsDoNotAffectCompetitiveRound(t *testing.T) {
+	competitor := player(shooterID, "competitor", common.TeamTerrorists)
+	opponent := player(victimID, "opponent", common.TeamCounterTerrorists)
+	tCoach := playerWithCoachingTeam(3, "t-coach", common.TeamTerrorists, common.TeamTerrorists)
+	ctCoach := playerWithCoachingTeam(4, "ct-coach", common.TeamCounterTerrorists, common.TeamCounterTerrorists)
+	a := liveAnalyser(competitor, opponent, tCoach, ctCoach)
+	a.onRoundStart(events.RoundStart{})
+	a.lastHealth[victimID] = 100
+
+	a.onPlayerHurt(events.PlayerHurt{
+		Player: ctCoach, Attacker: competitor, Weapon: &common.Equipment{Type: common.EqAK47},
+		HealthDamageTaken: 40, Health: 60,
+	})
+	a.onPlayerHurt(events.PlayerHurt{
+		Player: opponent, Attacker: tCoach, Weapon: &common.Equipment{Type: common.EqAK47},
+		HealthDamageTaken: 40, Health: 60,
+	})
+	a.onKill(events.Kill{
+		Killer: competitor, Victim: ctCoach, Weapon: &common.Equipment{Type: common.EqAK47},
+	})
+	a.onKill(events.Kill{
+		Killer: tCoach, Victim: opponent, Weapon: &common.Equipment{Type: common.EqAK47},
+	})
+	a.onBombPlanted(events.BombPlanted{BombEvent: events.BombEvent{Player: tCoach}})
+
+	if got := a.players[shooterID].KillStats.Total; got != 0 {
+		t.Errorf("competitor kills = %d, want 0", got)
+	}
+	if got := a.players[shooterID].AssistStats.DamageGiven; got != 0 {
+		t.Errorf("competitor damage = %d, want 0", got)
+	}
+	if got := a.players[victimID].Deaths; got != 0 {
+		t.Errorf("opponent deaths = %d, want 0", got)
+	}
+	if got := a.lastHealth[victimID]; got != 100 {
+		t.Errorf("opponent tracked health = %d, want 100", got)
+	}
+	if a.tracker.bombPlanted {
+		t.Error("coach plant changed the competitive round state")
+	}
+
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
+	a.onRoundEndOfficial(events.RoundEndOfficial{})
+	for _, id := range []uint64{shooterID, victimID} {
+		if got := a.players[id].SideStats.Rounds.Total; got != 1 {
+			t.Errorf("player %d rounds = %d, want 1", id, got)
+		}
+		if got := a.kastRounds[id].Total; got != 1 {
+			t.Errorf("player %d KAST rounds = %d, want 1", id, got)
+		}
+	}
 }
 
 // One shotgun blast lands several pellets on the same tick, and each pellet
@@ -436,7 +562,7 @@ func TestSideAdrAndKastDivideByRoundsOnThatSide(t *testing.T) {
 // count has to move with them or the rates divide by nothing.
 func TestFreezeTimeJoinerPlaysTheRound(t *testing.T) {
 	holder := player(shooterID, "holder", common.TeamCounterTerrorists)
-	joiner := player(victimID, "joiner", common.TeamSpectators)
+	joiner := playerWithCoachingTeam(victimID, "joiner", common.TeamSpectators, common.TeamUnassigned)
 	a := liveAnalyser(holder, joiner)
 
 	a.onRoundStart(events.RoundStart{})


### PR DESCRIPTION
## Summary

- use `m_iCoachingTeam` to exclude team-assigned coaching controllers from exported players and round rosters
- ignore coach-involved gameplay events before they can change competitor or round-tracker statistics
- treat missing or unset coaching values as unavailable, preserving legitimate competitors, substitutes, reconnects, and freeze-time joins

## Tests

- `gofmt` on the changed Go files
- `go test -count=1 ./...`
- `go vet ./...`
- parsed all three supplied Rooster vs Mindfreak demos

## Demo verification

| Map | Total rounds | Exported competitors |
| --- | ---: | ---: |
| Inferno | 22 | 10 |
| Anubis | 19 | 10 |
| Mirage | 23 | 10 |

`Coach|evelyn3` is absent from every map, and every real full-match player has rounds equal to the map total. Golden fixtures were not changed.

## Scope

Post-round death differences tracked by #30 and #33 remain untouched. The current HLTV comparison remains 30/30 matching kill totals, 28/30 matching death totals, and 29/30 matching ADR values.

Closes #25
