### PR TITLE
Exclude match-end World cleanup deaths from player totals

### DIFF
--- a/cmd/demo_parser/demo_parser.go
+++ b/cmd/demo_parser/demo_parser.go
@@ -232,14 +232,18 @@ func (a *analyser) onKill(e events.Kill) {
 	// state to distinguish cleanup from World deaths that still count. Bomb
 	// kills stay separate from both.
 	byWorld := (e.Killer == nil || suicide) && (e.Weapon == nil || e.Weapon.Type == common.EqWorld)
+	postRoundWorld := a.tracker.isPostRoundWorldCleanup(byWorld)
+	matchEndWorldCleanup := postRoundWorld &&
+		a.parser.GameState().GamePhase() == common.GamePhaseGameEnded
 
 	if victim := a.ensurePlayer(e.Victim); victim != nil {
-		victim.Deaths++
-		victim.SideStats.Deaths.count(e.Victim.Team)
-		// A World cleanup after the round is decided is not a player's
-		// decision to die with utility. Combat, suicide, fall, bomb and other
-		// post-round deaths still contribute.
-		if !a.tracker.isPostRoundWorldCleanup(byWorld) {
+		// Only a World event after the full game ended is engine cleanup.
+		// Ordinary post-round falls and World suicides remain real deaths.
+		if !matchEndWorldCleanup {
+			victim.Deaths++
+			victim.SideStats.Deaths.count(e.Victim.Team)
+		}
+		if !postRoundWorld {
 			victim.UtilityStats.UnusedUtilityValue += unusedUtilityValue(e.Victim.Inventory)
 		}
 	}

--- a/cmd/demo_parser/testdata/golden_ancient.json
+++ b/cmd/demo_parser/testdata/golden_ancient.json
@@ -4,7 +4,7 @@
       "steam_id": 76561198032044481,
       "name": "bonK",
       "user_id": 4,
-      "deaths": 4,
+      "deaths": 3,
       "deaths_traded": {
         "total": 1,
         "ct": 1,
@@ -64,8 +64,8 @@
           "t": 0
         },
         "deaths": {
-          "total": 4,
-          "ct": 4,
+          "total": 3,
+          "ct": 3,
           "t": 0
         },
         "adr": {
@@ -112,7 +112,7 @@
       "steam_id": 76561198071075349,
       "name": "mattos-v",
       "user_id": 1,
-      "deaths": 3,
+      "deaths": 2,
       "deaths_traded": {
         "total": 0,
         "ct": 0,
@@ -173,8 +173,8 @@
           "t": 0
         },
         "deaths": {
-          "total": 3,
-          "ct": 3,
+          "total": 2,
+          "ct": 2,
           "t": 0
         },
         "adr": {
@@ -221,7 +221,7 @@
       "steam_id": 76561198307159112,
       "name": "CHARRADÃO DE FROZEN",
       "user_id": 9,
-      "deaths": 7,
+      "deaths": 6,
       "deaths_traded": {
         "total": 0,
         "ct": 0,
@@ -280,9 +280,9 @@
           "t": 1
         },
         "deaths": {
-          "total": 7,
+          "total": 6,
           "ct": 0,
-          "t": 7
+          "t": 6
         },
         "adr": {
           "ct": 0,
@@ -328,7 +328,7 @@
       "steam_id": 76561198387460920,
       "name": "tandu",
       "user_id": 2,
-      "deaths": 5,
+      "deaths": 4,
       "deaths_traded": {
         "total": 2,
         "ct": 2,
@@ -385,8 +385,8 @@
           "t": 0
         },
         "deaths": {
-          "total": 5,
-          "ct": 5,
+          "total": 4,
+          "ct": 4,
           "t": 0
         },
         "adr": {
@@ -433,7 +433,7 @@
       "steam_id": 76561198826243397,
       "name": "botu360",
       "user_id": 0,
-      "deaths": 4,
+      "deaths": 3,
       "deaths_traded": {
         "total": 0,
         "ct": 0,
@@ -493,8 +493,8 @@
           "t": 0
         },
         "deaths": {
-          "total": 4,
-          "ct": 4,
+          "total": 3,
+          "ct": 3,
           "t": 0
         },
         "adr": {
@@ -541,7 +541,7 @@
       "steam_id": 76561198966281369,
       "name": "cmz-",
       "user_id": 3,
-      "deaths": 5,
+      "deaths": 4,
       "deaths_traded": {
         "total": 0,
         "ct": 0,
@@ -604,8 +604,8 @@
           "t": 0
         },
         "deaths": {
-          "total": 5,
-          "ct": 5,
+          "total": 4,
+          "ct": 4,
           "t": 0
         },
         "adr": {
@@ -652,7 +652,7 @@
       "steam_id": 76561199102419525,
       "name": "seloko-numcompensa",
       "user_id": 6,
-      "deaths": 7,
+      "deaths": 6,
       "deaths_traded": {
         "total": 1,
         "ct": 0,
@@ -713,9 +713,9 @@
           "t": 6
         },
         "deaths": {
-          "total": 7,
+          "total": 6,
           "ct": 0,
-          "t": 7
+          "t": 6
         },
         "adr": {
           "ct": 0,
@@ -761,7 +761,7 @@
       "steam_id": 76561199271102802,
       "name": "! Ømegapr1v",
       "user_id": 5,
-      "deaths": 8,
+      "deaths": 7,
       "deaths_traded": {
         "total": 0,
         "ct": 0,
@@ -820,9 +820,9 @@
           "t": 1
         },
         "deaths": {
-          "total": 8,
+          "total": 7,
           "ct": 0,
-          "t": 8
+          "t": 7
         },
         "adr": {
           "ct": 0,
@@ -976,7 +976,7 @@
       "steam_id": 76561199558715190,
       "name": "BushBandit",
       "user_id": 8,
-      "deaths": 7,
+      "deaths": 6,
       "deaths_traded": {
         "total": 0,
         "ct": 0,
@@ -1036,9 +1036,9 @@
           "t": 3
         },
         "deaths": {
-          "total": 7,
+          "total": 6,
           "ct": 0,
-          "t": 7
+          "t": 6
         },
         "adr": {
           "ct": 0,

--- a/cmd/demo_parser/testdata/golden_inferno_shotgun.json
+++ b/cmd/demo_parser/testdata/golden_inferno_shotgun.json
@@ -672,7 +672,7 @@
       "steam_id": 76561199064030155,
       "name": "Biel Mexânico",
       "user_id": 5,
-      "deaths": 14,
+      "deaths": 13,
       "deaths_traded": {
         "total": 4,
         "ct": 3,
@@ -734,8 +734,8 @@
           "t": 11
         },
         "deaths": {
-          "total": 14,
-          "ct": 7,
+          "total": 13,
+          "ct": 6,
           "t": 7
         },
         "adr": {
@@ -893,7 +893,7 @@
       "steam_id": 76561199575273990,
       "name": "S1nner",
       "user_id": 6,
-      "deaths": 15,
+      "deaths": 14,
       "deaths_traded": {
         "total": 2,
         "ct": 0,
@@ -957,8 +957,8 @@
           "t": 10
         },
         "deaths": {
-          "total": 15,
-          "ct": 6,
+          "total": 14,
+          "ct": 5,
           "t": 9
         },
         "adr": {

--- a/cmd/demo_parser/testdata/golden_mirage.json
+++ b/cmd/demo_parser/testdata/golden_mirage.json
@@ -4,7 +4,7 @@
       "steam_id": 76561197964020430,
       "name": "Подсосник blick'a",
       "user_id": 0,
-      "deaths": 6,
+      "deaths": 5,
       "deaths_traded": {
         "total": 2,
         "ct": 0,
@@ -66,9 +66,9 @@
           "t": 11
         },
         "deaths": {
-          "total": 6,
+          "total": 5,
           "ct": 0,
-          "t": 6
+          "t": 5
         },
         "adr": {
           "ct": 0,
@@ -114,7 +114,7 @@
       "steam_id": 76561198073049527,
       "name": "miu miu",
       "user_id": 8,
-      "deaths": 9,
+      "deaths": 8,
       "deaths_traded": {
         "total": 1,
         "ct": 1,
@@ -175,8 +175,8 @@
           "t": 0
         },
         "deaths": {
-          "total": 9,
-          "ct": 9,
+          "total": 8,
+          "ct": 8,
           "t": 0
         },
         "adr": {
@@ -223,7 +223,7 @@
       "steam_id": 76561198118803912,
       "name": "Голова, глаза",
       "user_id": 2,
-      "deaths": 8,
+      "deaths": 7,
       "deaths_traded": {
         "total": 1,
         "ct": 0,
@@ -283,9 +283,9 @@
           "t": 5
         },
         "deaths": {
-          "total": 8,
+          "total": 7,
           "ct": 0,
-          "t": 8
+          "t": 7
         },
         "adr": {
           "ct": 0,
@@ -331,7 +331,7 @@
       "steam_id": 76561198194694750,
       "name": "Dog",
       "user_id": 7,
-      "deaths": 8,
+      "deaths": 7,
       "deaths_traded": {
         "total": 0,
         "ct": 0,
@@ -394,8 +394,8 @@
           "t": 0
         },
         "deaths": {
-          "total": 8,
-          "ct": 8,
+          "total": 7,
+          "ct": 7,
           "t": 0
         },
         "adr": {
@@ -442,7 +442,7 @@
       "steam_id": 76561198202353993,
       "name": "IMI Negev",
       "user_id": 4,
-      "deaths": 3,
+      "deaths": 2,
       "deaths_traded": {
         "total": 1,
         "ct": 0,
@@ -503,9 +503,9 @@
           "t": 4
         },
         "deaths": {
-          "total": 3,
+          "total": 2,
           "ct": 0,
-          "t": 3
+          "t": 2
         },
         "adr": {
           "ct": 0,
@@ -551,7 +551,7 @@
       "steam_id": 76561198244754626,
       "name": "NIGHTSOUL",
       "user_id": 1,
-      "deaths": 6,
+      "deaths": 5,
       "deaths_traded": {
         "total": 0,
         "ct": 0,
@@ -612,9 +612,9 @@
           "t": 10
         },
         "deaths": {
-          "total": 6,
+          "total": 5,
           "ct": 0,
-          "t": 6
+          "t": 5
         },
         "adr": {
           "ct": 0,
@@ -660,7 +660,7 @@
       "steam_id": 76561198258044111,
       "name": "-ExΩtiC-",
       "user_id": 9,
-      "deaths": 9,
+      "deaths": 8,
       "deaths_traded": {
         "total": 1,
         "ct": 1,
@@ -721,8 +721,8 @@
           "t": 0
         },
         "deaths": {
-          "total": 9,
-          "ct": 9,
+          "total": 8,
+          "ct": 8,
           "t": 0
         },
         "adr": {
@@ -769,7 +769,7 @@
       "steam_id": 76561198265366770,
       "name": "123",
       "user_id": 3,
-      "deaths": 5,
+      "deaths": 4,
       "deaths_traded": {
         "total": 1,
         "ct": 0,
@@ -829,9 +829,9 @@
           "t": 11
         },
         "deaths": {
-          "total": 5,
+          "total": 4,
           "ct": 0,
-          "t": 5
+          "t": 4
         },
         "adr": {
           "ct": 0,
@@ -986,7 +986,7 @@
       "steam_id": 76561198324843075,
       "name": "Trahun \u003c3 V",
       "user_id": 5,
-      "deaths": 10,
+      "deaths": 9,
       "deaths_traded": {
         "total": 2,
         "ct": 2,
@@ -1046,8 +1046,8 @@
           "t": 0
         },
         "deaths": {
-          "total": 10,
-          "ct": 10,
+          "total": 9,
+          "ct": 9,
           "t": 0
         },
         "adr": {

--- a/cmd/demo_parser/utility_test.go
+++ b/cmd/demo_parser/utility_test.go
@@ -282,7 +282,7 @@ func TestUnusedUtilityValueUsesInventoryQuantity(t *testing.T) {
 	}
 }
 
-func TestUnusedUtilityCountsEveryQualifyingDeathCause(t *testing.T) {
+func TestDeathsAndUnusedUtilityCountEveryQualifyingDeathCause(t *testing.T) {
 	tests := []struct {
 		name string
 		kill events.Kill
@@ -305,8 +305,15 @@ func TestUnusedUtilityCountsEveryQualifyingDeathCause(t *testing.T) {
 
 			a.onKill(tt.kill)
 
-			if got := a.players[victimID].UtilityStats.UnusedUtilityValue; got != 50 {
-				t.Errorf("unused utility value = %d, want 50", got)
+			got := a.players[victimID]
+			if got.Deaths != 1 {
+				t.Errorf("deaths = %d, want 1", got.Deaths)
+			}
+			if want := (SideCount{Total: 1, CT: 1}); got.SideStats.Deaths != want {
+				t.Errorf("side deaths = %+v, want %+v", got.SideStats.Deaths, want)
+			}
+			if got.UtilityStats.UnusedUtilityValue != 50 {
+				t.Errorf("unused utility value = %d, want 50", got.UtilityStats.UnusedUtilityValue)
 			}
 		})
 	}
@@ -319,6 +326,7 @@ func TestUnusedUtilityCountsRepeatedAndPostRoundCombatDeaths(t *testing.T) {
 
 	a.onKill(combatDeath)
 	a.onKill(combatDeath)
+	a.parser.(*matchParser).gamePhase = common.GamePhaseGameEnded
 	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
 	a.onKill(combatDeath)
 	a.onKill(events.Kill{Killer: victim, Victim: victim, Weapon: &common.Equipment{Type: common.EqWorld}})
@@ -328,10 +336,45 @@ func TestUnusedUtilityCountsRepeatedAndPostRoundCombatDeaths(t *testing.T) {
 	a.onKill(events.Kill{Killer: victim, Victim: victim, Weapon: &common.Equipment{Type: common.EqWorld}})
 
 	got := a.players[victimID]
-	if got.Deaths != 5 {
-		t.Errorf("deaths = %d, want 5", got.Deaths)
+	if got.Deaths != 3 {
+		t.Errorf("deaths = %d, want 3", got.Deaths)
+	}
+	if want := (SideCount{Total: 3, CT: 3}); got.SideStats.Deaths != want {
+		t.Errorf("side deaths = %+v, want %+v", got.SideStats.Deaths, want)
 	}
 	if got.UtilityStats.UnusedUtilityValue != 900 {
 		t.Errorf("unused utility value = %d, want 900", got.UtilityStats.UnusedUtilityValue)
+	}
+}
+
+func TestMatchEndWorldCleanupDoesNotCountDeath(t *testing.T) {
+	a, _, victim := liveRound()
+	a.parser.(*matchParser).gamePhase = common.GamePhaseGameEnded
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
+
+	a.onKill(events.Kill{Killer: victim, Victim: victim, Weapon: &common.Equipment{Type: common.EqWorld}})
+
+	got := a.players[victimID]
+	if got.Deaths != 0 {
+		t.Errorf("deaths = %d, want 0", got.Deaths)
+	}
+	if got.SideStats.Deaths != (SideCount{}) {
+		t.Errorf("side deaths = %+v, want none", got.SideStats.Deaths)
+	}
+}
+
+func TestPostRoundWorldDeathCountsBeforeMatchEnd(t *testing.T) {
+	a, _, victim := liveRound()
+	a.parser.(*matchParser).gamePhase = common.GamePhaseStartGamePhase
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
+
+	a.onKill(events.Kill{Killer: victim, Victim: victim, Weapon: &common.Equipment{Type: common.EqWorld}})
+
+	got := a.players[victimID]
+	if got.Deaths != 1 {
+		t.Errorf("deaths = %d, want 1", got.Deaths)
+	}
+	if want := (SideCount{Total: 1, CT: 1}); got.SideStats.Deaths != want {
+		t.Errorf("side deaths = %+v, want %+v", got.SideStats.Deaths, want)
 	}
 }


### PR DESCRIPTION
## Summary

- exclude match-end `World` cleanup events from raw and side death totals only after the full game enters `GamePhaseGameEnded`
- preserve ordinary post-round World and fall deaths, unused-utility handling, survival/KAST, trades, combat exit frags, and post-round C4 behavior
- update focused lifecycle coverage and checksum-backed goldens for the intended death-counter changes

## Root cause

`onKill` incremented `DemoPlayer.Deaths` and `SideStats.Deaths` before consulting the existing round-level World cleanup classification. Round completion alone is not sufficient for player-facing death totals because legitimate World-attributed deaths can occur between `RoundEnd` and `RoundEndOfficial` during an ordinary round.

Death exclusion now requires both a decided round and `GamePhaseGameEnded`. The existing round-level predicate continues to own unused-utility and survival/KAST behavior.

## Tests

- cover combat, suicide, fall/World, and bomb deaths that must still count
- cover ordinary post-round World deaths separately from full-match cleanup
- cover cleanup both before and after `RoundEndOfficial`
- verify raw deaths, side deaths, and unused utility independently
- update goldens only where cleanup exclusion changes raw and side death counters

## Demo verification

All three supplied Rooster vs Mindfreak demos were checksum-verified and parsed:

| Map | Rounds | Players | Score | Result |
| --- | ---: | ---: | ---: | --- |
| Inferno | 22 | 10 | 9-13 | expected stats preserved |
| Anubis | 19 | 10 | 6-13 | only the post-round C4 death tracked by #30 remains |
| Mirage | 23 | 10 | 10-13 | `void` now reports 15 kills, 10 deaths, and 71.7 ADR |

HLTV parity is now 30/30 exact kill rows, 29/30 exact death rows, and 29/30 exact ADR rows. The remaining ADR difference is the pre-existing Inferno `zune` value of 94.9 versus 95.1.

## Verification

- `gofmt -w cmd/demo_parser/demo_parser.go cmd/demo_parser/utility_test.go`
- `go test -count=1 ./...`
- `go vet ./...`
- `git diff --check`

Closes #33
