### PR TITLE
fix(parser): align post-round C4 deaths with HLTV totals

### DIFF
--- a/_docs/PLAYER_DATA.MD
+++ b/_docs/PLAYER_DATA.MD
@@ -11,7 +11,7 @@ The `--save` flag writes every analysed player to a file. JSON contains all fiel
 | SteamID | `steam_id` | 64-bit SteamID of the player. |
 | Name | `name` | Last name the player used in the demo. |
 | UserID | `user_id` | Server user ID in this demo. |
-| Deaths | `deaths` | Deaths, including suicides and world deaths (fall damage, C4). |
+| Deaths | `deaths` | Deaths, including suicides, ordinary World deaths such as falls, and C4 deaths. A round-ending C4 blast can emit deaths after `RoundEnd`; they still count during `GamePhaseStartGamePhase`. A C4 death emitted after `RoundEnd` during `GamePhaseGameHalfEnded`, plus match-end World cleanup, is excluded. |
 | DeathsTraded | `deaths_traded` | Per-round traded-death count: `{total, ct, t}`. A round contributes once when at least one of the player's deaths was avenged inside the trade window. |
 
 ### Kill stats (`kill_stats`)
@@ -82,7 +82,7 @@ Each `GrenadeProjectileThrow` adds one use. `WeaponFire` is not counted, and war
 
 #### Unused utility value
 
-This is a cumulative value across deaths, not an average and not the largest inventory seen at one death. Every qualifying death contributes, including repeated deaths in respawn modes, suicides, bomb and fall deaths, and combat deaths after the round result. Automatic World cleanup after the round has already been decided is excluded.
+This is a cumulative value across death events, not an average and not the largest inventory seen at one death. Every qualifying event contributes, including repeated deaths in respawn modes, suicides, bomb and fall deaths, and combat deaths after the round result. A C4 event emitted after `RoundEnd` during `GamePhaseGameHalfEnded` still contributes here even though it is excluded from raw player death totals. Automatic World cleanup after the round has already been decided is excluded.
 
 Only standard grenade inventory is valued. Weapons, armour and game-mode equipment do not contribute. Quantity is `AmmoInMagazine + AmmoReserve`, which counts a second flashbang stored as reserve ammo. The pinned Mirage case in `TestProcessDemoGolden` explicitly verifies that the demoinfocs version used by this project still exposes the victim's pre-death inventory during `Kill`, without parsing the fixture a second time.
 
@@ -109,7 +109,7 @@ All utility scalars are appended to CSV after the existing columns. `--details` 
 | ACEs | `aces` | Rounds with 5 or more enemy kills. |
 | MultiKills | `multi_kills` | Multi-kill rounds bucketed by kill count: `{k2, k3, k4, k5}`. See [multi-kill rounds](#multi-kill-rounds). |
 | ClutchesWon | `clutches_won` | Rounds won after being the last player alive on the team against at least one enemy (1v1 counts). Winning by defuse or time counts — no kills required. |
-| KAST | `kast` | Percentage of the match's rounds with a Kill, Assist, Survival or Traded death (a teammate killed your killer within 5 seconds). Dying before the round officially ends cancels survival — including exit frags and the bomb going off after the whistle (HLTV convention). Match-end cleanup kills do not count. |
+| KAST | `kast` | Percentage of the match's rounds with a Kill, Assist, Survival or Traded death (a teammate killed your killer within 5 seconds). `RoundEnd` does not award survival immediately: exit frags and C4 deaths before `RoundEndOfficial` still cancel it. This round/KAST treatment is separate from raw death totals, where a C4 event emitted after `RoundEnd` during `GamePhaseGameHalfEnded` is excluded. Match-end World cleanup does not cancel survival. |
 
 #### Multi-kill rounds
 

--- a/cmd/demo_parser/demo_parser.go
+++ b/cmd/demo_parser/demo_parser.go
@@ -233,13 +233,19 @@ func (a *analyser) onKill(e events.Kill) {
 	// kills stay separate from both.
 	byWorld := (e.Killer == nil || suicide) && (e.Weapon == nil || e.Weapon.Type == common.EqWorld)
 	postRoundWorld := a.tracker.isPostRoundWorldCleanup(byWorld)
+	gamePhase := a.parser.GameState().GamePhase()
 	matchEndWorldCleanup := postRoundWorld &&
-		a.parser.GameState().GamePhase() == common.GamePhaseGameEnded
+		gamePhase == common.GamePhaseGameEnded
+	postRoundBombDeath := a.tracker.isPostRound() &&
+		gamePhase == common.GamePhaseGameHalfEnded &&
+		e.Weapon != nil && e.Weapon.Type == common.EqBomb
 
 	if victim := a.ensurePlayer(e.Victim); victim != nil {
-		// Only a World event after the full game ended is engine cleanup.
-		// Ordinary post-round falls and World suicides remain real deaths.
-		if !matchEndWorldCleanup {
+		// HLTV omits C4 deaths after the round and game phase have both
+		// closed. Bomb deaths emitted just after a round-ending explosion
+		// during the active phase still count. Only match-end World events
+		// are cleanup; ordinary post-round falls and World suicides count.
+		if !postRoundBombDeath && !matchEndWorldCleanup {
 			victim.Deaths++
 			victim.SideStats.Deaths.count(e.Victim.Team)
 		}

--- a/cmd/demo_parser/demo_parser_test.go
+++ b/cmd/demo_parser/demo_parser_test.go
@@ -289,6 +289,63 @@ func TestSurvivorsGetKastWhenTheRoundEndsOfficially(t *testing.T) {
 	}
 }
 
+func TestPostRoundBombDeathDoesNotCountRawDeath(t *testing.T) {
+	a, _, victim := liveRound()
+	victim.Inventory = map[int]*common.Equipment{1: {Type: common.EqSmoke}}
+	a.parser.(*matchParser).gamePhase = common.GamePhaseGameHalfEnded
+	a.onRoundEnd(events.RoundEnd{
+		Winner: common.TeamTerrorists,
+		Reason: events.RoundEndReasonTargetBombed,
+	})
+
+	a.onKill(events.Kill{Victim: victim, Weapon: &common.Equipment{Type: common.EqBomb}})
+
+	got := a.players[victimID]
+	if got.Deaths != 0 {
+		t.Errorf("deaths = %d, want 0", got.Deaths)
+	}
+	if got.SideStats.Deaths != (SideCount{}) {
+		t.Errorf("side deaths = %+v, want none", got.SideStats.Deaths)
+	}
+	if got.UtilityStats.UnusedUtilityValue != 300 {
+		t.Errorf("unused utility value = %d, want 300", got.UtilityStats.UnusedUtilityValue)
+	}
+}
+
+func TestRoundEndingBombDeathCountsRawDeathDuringActiveGamePhase(t *testing.T) {
+	a, _, victim := liveRound()
+	a.parser.(*matchParser).gamePhase = common.GamePhaseStartGamePhase
+	a.onRoundEnd(events.RoundEnd{
+		Winner: common.TeamTerrorists,
+		Reason: events.RoundEndReasonTargetBombed,
+	})
+
+	a.onKill(events.Kill{Victim: victim, Weapon: &common.Equipment{Type: common.EqBomb}})
+
+	got := a.players[victimID]
+	if got.Deaths != 1 {
+		t.Errorf("deaths = %d, want 1", got.Deaths)
+	}
+	if want := (SideCount{Total: 1, CT: 1}); got.SideStats.Deaths != want {
+		t.Errorf("side deaths = %+v, want %+v", got.SideStats.Deaths, want)
+	}
+}
+
+func TestPostRoundBombDeathStillCancelsSurvivalKast(t *testing.T) {
+	a, _, victim := liveRound()
+	a.parser.(*matchParser).gamePhase = common.GamePhaseGameHalfEnded
+	a.onRoundEnd(events.RoundEnd{
+		Winner: common.TeamTerrorists,
+		Reason: events.RoundEndReasonTargetBombed,
+	})
+	a.onKill(events.Kill{Victim: victim, Weapon: &common.Equipment{Type: common.EqBomb}})
+	a.onRoundEndOfficial(events.RoundEndOfficial{})
+
+	if got := a.kastRounds[victimID].Total; got != 0 {
+		t.Errorf("victim KAST rounds = %d, want 0: the bomb death still cancels survival", got)
+	}
+}
+
 func TestPostRoundDeathBeforeOfficialEndCancelsKast(t *testing.T) {
 	a, shooter, victim := liveRound()
 

--- a/cmd/demo_parser/round_tracker.go
+++ b/cmd/demo_parser/round_tracker.go
@@ -188,8 +188,9 @@ func (rt *roundTracker) kill(killer, victim uint64, killerTeam, victimTeam commo
 
 	rt.deaths = append(rt.deaths, deathRecord{killer: killer, victim: victim, victimTeam: victimTeam, at: at})
 	// Dying before the round officially ends cancels survival, including to
-	// the post-round bomb explosion (HLTV convention). Only match-end world
-	// cleanup kills are ignored once the round is decided — and because
+	// the post-round bomb explosion. Raw death totals are handled separately
+	// by the analyser. Only match-end world cleanup kills are ignored once
+	// the round is decided — and because
 	// their victim keeps survival, they settle no 40-damage assists either:
 	// damage into a survivor is no assist. Every real death settles them,
 	// whatever caused it; enemy damage into a player finished by the bomb or
@@ -240,11 +241,19 @@ func (rt *roundTracker) aliveCounts() (tAlive, ctAlive int) {
 	return tAlive, ctAlive
 }
 
-// isPostRoundWorldCleanup identifies engine cleanup deaths after the round
-// result is known. The decision remains available after finalize because CS2
-// can dispatch cleanup kills after RoundEndOfficial; startRound clears it.
+// isPostRound reports whether RoundEnd has decided the current or most
+// recently finalized round. The decision remains available after finalize
+// because CS2 can dispatch death events after RoundEndOfficial; startRound
+// clears it.
+func (rt *roundTracker) isPostRound() bool {
+	return rt.decided
+}
+
+// isPostRoundWorldCleanup identifies World events after the round result is
+// known. The analyser separately checks the game phase before excluding one
+// from raw death totals.
 func (rt *roundTracker) isPostRoundWorldCleanup(byWorld bool) bool {
-	return rt.decided && byWorld
+	return rt.isPostRound() && byWorld
 }
 
 // disconnect handles a player leaving mid-round: they count as dead for

--- a/cmd/demo_parser/round_tracker_test.go
+++ b/cmd/demo_parser/round_tracker_test.go
@@ -490,8 +490,8 @@ func TestPostRoundBombDeathCancelsSurvival(t *testing.T) {
 	rt.startRound(fiveVsFive())
 	rt.markEnd(common.TeamCounterTerrorists)
 
-	// Dying to the bomb explosion counts as dying in the round (HLTV
-	// convention), even though the kill event lands after the whistle.
+	// The event still cancels survival. Raw totals apply their separate
+	// round/game-phase rule in the analyser.
 	rt.kill(0, 1, common.TeamUnassigned, common.TeamTerrorists, 0, false, at(70))
 
 	if outcome := rt.finalize(); outcome.kast[1] {


### PR DESCRIPTION
## Summary

- exclude the observed post-round C4 event from `DemoPlayer.Deaths` and `SideStats.Deaths` when `RoundEnd` has fired and the game is in `GamePhaseGameHalfEnded`
- continue processing the event through unused-utility accounting and `roundTracker.kill` so survival/KAST, trades, and rating inputs retain their existing behavior
- document the exact raw-death boundary separately from round/KAST semantics

## Why

On Anubis, `RoundEnd` occurs at `24m49.765s` and zune's `EqBomb` death follows at `24m49.797s` after the game phase has ended. The raw death counters previously incremented unconditionally, producing 16-15 instead of HLTV's 16-14.

Other legitimate round-ending C4 deaths on Inferno and Mirage also arrive after `RoundEnd`, but during `GamePhaseStartGamePhase`. The phase check preserves those deaths instead of broadly suppressing every post-`RoundEnd` bomb event.

The scope deliberately matches the observed half-ended sequence; it does not infer unverified match-end or overtime C4 behavior.

## Tests

- post-round C4 death during `GamePhaseGameHalfEnded` does not increment raw or side deaths
- the excluded raw event still contributes unused utility and cancels survival KAST
- round-ending C4 deaths during the active game phase still count
- existing post-round combat, match-end World cleanup, trade, utility, and tracker behavior remains covered

## Verification

- `gofmt` on changed Go files
- `go test -count=1 ./...`
- `go vet ./...`
- parsed all three supplied Rooster vs Mindfreak demos
- Anubis zune: 16 kills, 14 deaths; KAST unchanged at 78.9%
- parity: kills 30/30, deaths 30/30, ADR 29/30
- remaining ADR mismatch: Inferno zune, 94.9 versus HLTV 95.1
- no golden changes

Closes #30
