### PR TITLE
fix(parser): align adjacent world damage with HLTV

### DIFF
--- a/_docs/HLTV_REGRESSION.md
+++ b/_docs/HLTV_REGRESSION.md
@@ -87,12 +87,13 @@ shown by HLTV and the CLI. HLTV KAST percentages are converted to integer
 qualifying-round counts with `round(percent * map rounds / 100)` before
 comparison.
 
-The single #39 ADR difference and all #38 KAST differences live together in
+All remaining expected differences are #38 KAST rows in
 `hltvExpectedDifferences`. Every row pins the map, SteamID64, metric, HLTV
 value, current tool value, and issue. A third value fails as a regression. If
 the parser reaches HLTV parity, the test also fails with a request to remove
-the stale exception and promote that row to strict parity. This harness does
-not change or relax the behavior owned by #38 or #39.
+the stale exception and promote that row to strict parity. ADR has no expected
+difference rows, so all 30 player-map ADR values use strict parity. This
+harness does not change or relax the behavior owned by #38.
 
 Rating 3.0 is approximate because HLTV's formula is proprietary. The harness
 therefore reports, but never asserts, exact rating parity: mean absolute error,

--- a/_docs/PLAYER_DATA.MD
+++ b/_docs/PLAYER_DATA.MD
@@ -46,7 +46,7 @@ The count is in JSON, in CSV as `Deaths Traded` plus its CT/T columns, and in th
 | --- | --- | --- |
 | Total | `total` | Assists on enemy kills, flash assists included. |
 | FlashedEnemies | `flashed_enemies` | Flash assists: the victim was blinded by this player's flashbang when killed. |
-| DamageGiven | `damage_given` | Health damage dealt to enemies. Team damage, self damage and bomb damage never count (HLTV convention). |
+| DamageGiven | `damage_given` | Health damage credited against enemies. Team damage, self damage and bomb damage never count (HLTV convention). An attacker-less World event is credited to the enemy who damaged the same victim in the same or immediately preceding demo frame; isolated World damage and match-end cleanup are excluded. |
 | ADR | `adr` | Average damage per round: `damage_given / total rounds of the match`. |
 
 ### Utility stats (`utility_stats`)

--- a/cmd/demo_parser/demo_parser.go
+++ b/cmd/demo_parser/demo_parser.go
@@ -23,6 +23,7 @@ type analyser struct {
 	sideDamage  map[uint64]SideCount // damage given, total and per side
 	openingWins map[uint64]int       // rounds won after taking the opening kill
 	lastHealth  map[uint64]int
+	worldSource map[uint64]worldDamageSource
 	flashEnds   map[uint64]time.Duration // latest known end of each player's blind interval
 	ecoKills    map[uint64]float64       // eco-adjusted kill points
 	ecoDamage   map[uint64]float64       // eco-adjusted damage given
@@ -34,6 +35,11 @@ type analyser struct {
 	gameMode    string
 }
 
+type worldDamageSource struct {
+	attacker *common.Player
+	frame    int
+}
+
 func newAnalyser(parser demoinfocs.Parser) *analyser {
 	return &analyser{
 		parser:      parser,
@@ -43,6 +49,7 @@ func newAnalyser(parser demoinfocs.Parser) *analyser {
 		sideDamage:  make(map[uint64]SideCount),
 		openingWins: make(map[uint64]int),
 		lastHealth:  make(map[uint64]int),
+		worldSource: make(map[uint64]worldDamageSource),
 		flashEnds:   make(map[uint64]time.Duration),
 		ecoKills:    make(map[uint64]float64),
 		ecoDamage:   make(map[uint64]float64),
@@ -193,6 +200,7 @@ func (a *analyser) onRoundStart(e events.RoundStart) {
 	// reset has to fall between it and the roster read for the new round.
 	a.applyRoundOutcome(a.tracker.finalize())
 	clear(a.roundTiers)
+	clear(a.worldSource)
 	a.tracker.startRound(a.playingRoster())
 }
 
@@ -320,32 +328,63 @@ func (a *analyser) onPlayerHurt(e events.PlayerHurt) {
 	realDamage := min(e.HealthDamageTaken, max(0, before-e.Health))
 	a.lastHealth[victimID] = e.Health
 
-	if e.Attacker == nil {
+	// In the #39 demo, a landing appears as an attacker-less World event one
+	// demo frame after an enemy hit, and HLTV includes its 5 HP in that
+	// attacker's ADR. demoinfocs also uses EqWorld as a fallback for unresolved
+	// empty-weapon events, so attribution additionally requires the landing's
+	// generic hit group, lack of armor damage, adjacent frame and same victim.
+	// Isolated World damage remains uncredited.
+	frame := a.parser.CurrentFrame()
+	source, hasSource := a.worldSource[victimID]
+	// A later pellet from the same blast can report no new health loss. Keep
+	// the blast as the source, but let every other intervening hurt invalidate it.
+	sameSourceOverlap := realDamage == 0 && e.Attacker != nil && hasSource &&
+		frame == source.frame && trackerID(e.Attacker) == trackerID(source.attacker)
+	if hasSource && !sameSourceOverlap {
+		delete(a.worldSource, victimID)
+	}
+	damageAttacker := e.Attacker
+	unattributedWorldDamage := realDamage > 0 && damageAttacker == nil &&
+		e.Weapon != nil && e.Weapon.Type == common.EqWorld &&
+		e.HitGroup == events.HitGroupGeneric && e.ArmorDamageTaken == 0
+	matchEndWorldCleanup := a.tracker.isPostRoundWorldCleanup(unattributedWorldDamage) &&
+		a.parser.GameState().GamePhase() == common.GamePhaseGameEnded
+	if unattributedWorldDamage && hasSource && !matchEndWorldCleanup &&
+		frame >= source.frame && frame-source.frame <= 1 {
+		damageAttacker = source.attacker
+	}
+
+	if damageAttacker == nil {
 		return
 	}
 	// Team damage and self damage never count towards damage given, and
 	// following HLTV convention neither does bomb damage (when the game
 	// credits the explosion to the planter).
-	if e.Attacker.SteamID64 == e.Player.SteamID64 || e.Attacker.Team == e.Player.Team {
+	if damageAttacker.SteamID64 == e.Player.SteamID64 || damageAttacker.Team == e.Player.Team {
 		return
 	}
 	if e.Weapon != nil && e.Weapon.Type == common.EqBomb {
 		return
 	}
-	if attacker := a.ensurePlayer(e.Attacker); attacker != nil {
-		attacker.AssistStats.DamageGiven += realDamage
-		addSide(a.sideDamage, attacker.SteamID, e.Attacker.Team, realDamage)
-		if e.Weapon != nil {
-			attacker.UtilityStats.UtilityDamage.add(e.Weapon.Type, realDamage)
-		}
-		// Zero-damage events are common (overlapping shotgun pellets, fully
-		// absorbed hits) and cannot change either total, so skip pricing
-		// their duel.
-		if realDamage > 0 {
-			a.ecoDamage[attacker.SteamID] += float64(realDamage) *
-				ecoDuelFactor(playerTier(e.Attacker.Inventory), playerTier(e.Player.Inventory))
-			a.tracker.damage(trackerID(e.Attacker), victimID, realDamage)
-		}
+	attackerStats := a.ensurePlayer(damageAttacker)
+	if attackerStats == nil {
+		return
+	}
+	if e.Attacker != nil && realDamage > 0 {
+		a.worldSource[victimID] = worldDamageSource{attacker: damageAttacker, frame: frame}
+	}
+	attackerStats.AssistStats.DamageGiven += realDamage
+	addSide(a.sideDamage, attackerStats.SteamID, damageAttacker.Team, realDamage)
+	if e.Weapon != nil {
+		attackerStats.UtilityStats.UtilityDamage.add(e.Weapon.Type, realDamage)
+	}
+	// Zero-damage events are common (overlapping shotgun pellets, fully
+	// absorbed hits) and cannot change either total, so skip pricing
+	// their duel.
+	if realDamage > 0 {
+		a.ecoDamage[attackerStats.SteamID] += float64(realDamage) *
+			ecoDuelFactor(playerTier(damageAttacker.Inventory), playerTier(e.Player.Inventory))
+		a.tracker.damage(trackerID(damageAttacker), victimID, realDamage)
 	}
 }
 

--- a/cmd/demo_parser/demo_parser_test.go
+++ b/cmd/demo_parser/demo_parser_test.go
@@ -16,10 +16,11 @@ import (
 // leave the embedded interfaces nil.
 type matchParser struct {
 	demoinfocs.Parser
-	playing     []*common.Player
-	warmup      bool
-	gamePhase   common.GamePhase
-	currentTime time.Duration
+	playing      []*common.Player
+	warmup       bool
+	gamePhase    common.GamePhase
+	currentTime  time.Duration
+	currentFrame int
 }
 
 func (p *matchParser) GameState() demoinfocs.GameState {
@@ -27,6 +28,8 @@ func (p *matchParser) GameState() demoinfocs.GameState {
 }
 
 func (p *matchParser) CurrentTime() time.Duration { return p.currentTime }
+
+func (p *matchParser) CurrentFrame() int { return p.currentFrame }
 
 type matchGameState struct {
 	demoinfocs.GameState
@@ -97,13 +100,26 @@ func botPlayer(userID int, name string, team common.Team) *common.Player {
 // hurt builds a PlayerHurt from an enemy shooter, where healthAfter is the
 // victim's health once the event has been applied.
 func hurt(weapon common.EquipmentType, damageTaken, healthAfter int) events.PlayerHurt {
+	return hurtEvent(
+		player(shooterID, "shooter", common.TeamTerrorists),
+		player(victimID, "victim", common.TeamCounterTerrorists),
+		weapon, damageTaken, healthAfter,
+	)
+}
+
+func hurtEvent(attacker, victim *common.Player, weapon common.EquipmentType, damageTaken, healthAfter int) events.PlayerHurt {
 	return events.PlayerHurt{
-		Player:            player(victimID, "victim", common.TeamCounterTerrorists),
-		Attacker:          player(shooterID, "shooter", common.TeamTerrorists),
+		Player:            victim,
+		Attacker:          attacker,
 		Weapon:            &common.Equipment{Type: weapon},
 		HealthDamageTaken: damageTaken,
 		Health:            healthAfter,
 	}
+}
+
+func hurtAtFrame(a *analyser, frame int, event events.PlayerHurt) {
+	a.parser.(*matchParser).currentFrame = frame
+	a.onPlayerHurt(event)
 }
 
 func damageGiven(a *analyser) int {
@@ -236,6 +252,132 @@ func TestSingleHitDamageIsCreditedInFull(t *testing.T) {
 
 	if got := damageGiven(a); got != 27 {
 		t.Errorf("damage given = %d, want 27", got)
+	}
+}
+
+// This mirrors the issue #39 sequence: a 15 HP shot, then an attacker-less
+// 5 HP World event for the same victim on the next recorded demo frame.
+func TestAdjacentWorldDamageCreditsPreviousEnemy(t *testing.T) {
+	a, shooter, victim := liveRound()
+	a.lastHealth[victimID] = 81
+
+	hurtAtFrame(a, 100, hurtEvent(shooter, victim, common.EqUSP, 15, 66))
+	hurtAtFrame(a, 101, hurtEvent(nil, victim, common.EqWorld, 5, 61))
+
+	got := a.players[shooterID]
+	if got.AssistStats.DamageGiven != 20 {
+		t.Errorf("damage given = %d, want 20", got.AssistStats.DamageGiven)
+	}
+	if got.UtilityStats.UtilityDamage != (UtilityDamageStats{}) {
+		t.Errorf("utility damage = %+v, want zero for shot and fall damage", got.UtilityStats.UtilityDamage)
+	}
+	if got := a.sideDamage[shooterID]; got != (SideCount{Total: 20, T: 20}) {
+		t.Errorf("side damage = %+v, want 20 on T side", got)
+	}
+	if got := a.ecoDamage[shooterID]; got != 20 {
+		t.Errorf("eco damage = %v, want 20 for two even-tier damage events", got)
+	}
+	if got := a.tracker.damageTo[victimID][shooterID]; got != 20 {
+		t.Errorf("rating assist damage = %d, want 20", got)
+	}
+}
+
+func TestZeroRealDamageDoesNotEraseWorldDamageSource(t *testing.T) {
+	a, shooter, victim := liveRound()
+	a.lastHealth[victimID] = 81
+
+	hurtAtFrame(a, 100, hurtEvent(shooter, victim, common.EqNova, 15, 66))
+	// Another pellet reports damage against the same resulting health, so it
+	// removed no additional HP and must not erase the blast's attribution.
+	hurtAtFrame(a, 100, hurtEvent(shooter, victim, common.EqNova, 15, 66))
+	hurtAtFrame(a, 101, hurtEvent(nil, victim, common.EqWorld, 5, 61))
+
+	if got := damageGiven(a); got != 20 {
+		t.Errorf("damage given = %d, want 20", got)
+	}
+}
+
+func TestWorldDamageRequiresAdjacentEnemySource(t *testing.T) {
+	tests := []struct {
+		name       string
+		withSource bool
+		worldFrame int
+		want       int
+	}{
+		{name: "isolated World event", worldFrame: 101, want: 0},
+		{name: "source is two frames old", withSource: true, worldFrame: 102, want: 15},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			a, shooter, victim := liveRound()
+			a.lastHealth[victimID] = 81
+			if test.withSource {
+				hurtAtFrame(a, 100, hurtEvent(shooter, victim, common.EqUSP, 15, 66))
+			} else {
+				a.lastHealth[victimID] = 66
+			}
+			hurtAtFrame(a, test.worldFrame, hurtEvent(nil, victim, common.EqWorld, 5, 61))
+
+			if got := damageGiven(a); got != test.want {
+				t.Errorf("damage given = %d, want %d", got, test.want)
+			}
+		})
+	}
+}
+
+func TestWorldFallbackWithHitGroupDoesNotCreditPreviousEnemy(t *testing.T) {
+	a, shooter, victim := liveRound()
+	a.lastHealth[victimID] = 81
+	hurtAtFrame(a, 100, hurtEvent(shooter, victim, common.EqUSP, 15, 66))
+
+	unresolvedHit := hurtEvent(nil, victim, common.EqWorld, 5, 61)
+	unresolvedHit.HitGroup = events.HitGroupChest
+	hurtAtFrame(a, 101, unresolvedHit)
+
+	if got := damageGiven(a); got != 15 {
+		t.Errorf("damage given = %d, want only the resolved 15 HP hit", got)
+	}
+}
+
+func TestInterveningTeamDamageClearsWorldDamageSource(t *testing.T) {
+	a, shooter, victim := liveRound()
+	teammate := player(3, "teammate", common.TeamCounterTerrorists)
+	a.lastHealth[victimID] = 81
+
+	hurtAtFrame(a, 100, hurtEvent(shooter, victim, common.EqUSP, 15, 66))
+	hurtAtFrame(a, 101, hurtEvent(teammate, victim, common.EqM4A4, 7, 59))
+	hurtAtFrame(a, 101, hurtEvent(nil, victim, common.EqWorld, 5, 54))
+
+	if got := damageGiven(a); got != 15 {
+		t.Errorf("damage given = %d, want only the initial 15", got)
+	}
+}
+
+func TestRoundStartClearsWorldDamageSource(t *testing.T) {
+	a, shooter, victim := liveRound()
+	a.lastHealth[victimID] = 81
+	hurtAtFrame(a, 100, hurtEvent(shooter, victim, common.EqUSP, 15, 66))
+
+	a.onRoundStart(events.RoundStart{})
+	a.lastHealth[victimID] = 100
+	hurtAtFrame(a, 101, hurtEvent(nil, victim, common.EqWorld, 5, 95))
+
+	if got := damageGiven(a); got != 15 {
+		t.Errorf("damage given = %d, want only the prior round's 15", got)
+	}
+}
+
+func TestMatchEndWorldCleanupDoesNotCreditDamage(t *testing.T) {
+	a, shooter, victim := liveRound()
+	a.lastHealth[victimID] = 81
+	hurtAtFrame(a, 100, hurtEvent(shooter, victim, common.EqUSP, 15, 66))
+
+	a.parser.(*matchParser).gamePhase = common.GamePhaseGameEnded
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
+	hurtAtFrame(a, 101, hurtEvent(nil, victim, common.EqWorld, 5, 61))
+
+	if got := damageGiven(a); got != 15 {
+		t.Errorf("damage given = %d, want only the pre-cleanup 15", got)
 	}
 }
 

--- a/cmd/demo_parser/hltv_regression_test.go
+++ b/cmd/demo_parser/hltv_regression_test.go
@@ -79,7 +79,6 @@ var hltvExpectedDifferences = []hltvExpectedDifference{
 	{MapName: "inferno", SteamID: 76561198050779850, Metric: kastMetric, HLTVValue: "14/22 (63.6%)", ToolValue: "16/22 (72.7%)", Issue: 38},
 	{MapName: "inferno", SteamID: 76561198127259887, Metric: kastMetric, HLTVValue: "14/22 (63.6%)", ToolValue: "15/22 (68.2%)", Issue: 38},
 	{MapName: "inferno", SteamID: 76561198081702155, Metric: kastMetric, HLTVValue: "15/22 (68.2%)", ToolValue: "16/22 (72.7%)", Issue: 38},
-	{MapName: "inferno", SteamID: 76561198108660703, Metric: adrMetric, HLTVValue: "95.1", ToolValue: "94.9", Issue: 39},
 	{MapName: "inferno", SteamID: 76561198044112269, Metric: kastMetric, HLTVValue: "16/22 (72.7%)", ToolValue: "18/22 (81.8%)", Issue: 38},
 	{MapName: "inferno", SteamID: 76561199048086137, Metric: kastMetric, HLTVValue: "18/22 (81.8%)", ToolValue: "17/22 (77.3%)", Issue: 38},
 	{MapName: "inferno", SteamID: 76561198226777692, Metric: kastMetric, HLTVValue: "15/22 (68.2%)", ToolValue: "16/22 (72.7%)", Issue: 38},
@@ -313,8 +312,11 @@ func validateHLTVOracle(t *testing.T, oracle hltvOracle) {
 			t.Fatalf("expected difference %s/%d/%s has identical HLTV and tool values %q",
 				difference.MapName, difference.SteamID, difference.Metric, difference.HLTVValue)
 		}
-		if (difference.Metric == adrMetric && difference.Issue != 39) ||
-			(difference.Metric == kastMetric && difference.Issue != 38) {
+		if difference.Metric != kastMetric {
+			t.Fatalf("expected difference %s/%d uses unsupported metric %q; only issue #38 KAST differences are allowed",
+				difference.MapName, difference.SteamID, difference.Metric)
+		}
+		if difference.Issue != 38 {
 			t.Fatalf("expected difference %s/%d/%s points to issue #%d", difference.MapName,
 				difference.SteamID, difference.Metric, difference.Issue)
 		}


### PR DESCRIPTION
## Summary

- attribute attacker-less World damage to the prior enemy only for the same victim in the same or immediately preceding demo frame
- keep shotgun overlap, real-health caps, and team, self, bomb, isolated World, and match-end cleanup exclusions intact
- remove the Inferno zune ADR exception from the HLTV harness and document strict ADR parity

## Root cause

On Inferno round 13, zune dealt 15 USP-S damage to ADK at demo frame 105678. One frame later, ADK landed and took 5 damage in an attacker-less World event before zune finished the kill. The parser calculated the real 5 HP loss but discarded it because the event had no attacker.

The event trace showed the victim moving from airborne to grounded across those frames. The other two attacker-less World hurts across the three regression demos were isolated and remain uncredited. Broadly counting actual health loss produced 2111 damage and broke all 30 ADR rows, confirming that the existing reported-damage and health-cap rule must remain.

## Implementation

The analyser tracks the latest qualifying enemy damage source per victim. An attacker-less World event inherits that source only when it has the observed landing shape, is frame-adjacent for the same victim, and is not match-end cleanup. Same-frame zero-real-damage shotgun pellets preserve the source; other intervening hurts and round starts invalidate it.

Attributed damage flows through total damage, side damage, eco-adjusted damage, and rating assist tracking while remaining excluded from utility damage.

## Result

- zune damage: 2088 -> 2093
- zune Inferno ADR: 94.9 -> 95.1
- kills: 30/30
- deaths: 30/30
- ADR: 30/30
- KAST: 17/30, unchanged with only the existing #38 differences
- Rating 3.0 quality unchanged: MAE 0.125, RMSE 0.166, bias -0.086, Spearman 0.976

## Verification

- `go test -count=1 ./...`
- `go vet ./...`
- `git diff --check`
- independent Inferno HLTV regression subtest
- complete three-map HLTV regression harness

Closes #39