### PR TITLE
fix(parser): apply round facts only to scored rounds

### DIFF
--- a/_docs/HLTV_REGRESSION.md
+++ b/_docs/HLTV_REGRESSION.md
@@ -1,19 +1,17 @@
 # HLTV regression harness
 
-`TestHLTVRegression` checks parser output for HLTV match 129241 against static
-HLTV values in `cmd/demo_parser/testdata/hltv-129241/expected.json`. HLTV is an
-external correctness oracle for this test. Analysing one CS2 Premier demo at a
-time remains the product's primary workflow; this harness does not aggregate
-the three maps into a best-of-three result.
+`TestHLTVRegression` compares eight independently parsed maps with static HLTV
+oracles. The original Rooster–Mindfreak fixture remains three maps and 30
+player-map rows. A Spirit–MOUZ BO5 and standalone Spirit–JiJieHao Mirage add
+five maps and 50 rows.
 
-The test never contacts HLTV, downloads a demo, or reads an ignored `build/`
-artifact. The fixture records the source match/map URLs, reviewed HLTV
-nicknames, SteamID64 mappings, and expected values so changes are visible in a
-normal code review.
+The test never contacts HLTV or downloads demos. The committed JSON records
+source URLs, reviewed SteamID64 mappings, expected values, demo filenames, and
+SHA-256 digests. Demo bytes remain external, read-only inputs.
 
 ## Demo setup
 
-Set `HLTV_DEMO_DIR` to a directory with this exact layout:
+The original commands and directory layout are unchanged:
 
 ```text
 <HLTV_DEMO_DIR>/
@@ -22,38 +20,38 @@ Set `HLTV_DEMO_DIR` to a directory with this exact layout:
 └── rooster-vs-mindfreak-m3-mirage.dem
 ```
 
-The files are external and must not be copied into the repository. Before
-parsing, the test streams the entire selected file through SHA-256 and requires
-the following digest:
+Additional demos may live in one directory or several. Set
+`HLTV_EXTRA_DEMO_DIRS` to an OS path-list (`:` on Unix, `;` on Windows); the
+harness searches each entry for every filename:
 
-| Map | SHA-256 |
-| --- | --- |
-| Inferno | `60129e983bb529bd77b642d59bd2e172367b6ab0dbe73849bb656f7eb76d43c4` |
-| Anubis | `7b2a1c89ea0b99be5d4874452716f25cfcbd49353c49b3402cc107f0c5a4bcae` |
-| Mirage | `53a3ab2814af90cb9898f2e8f3d7d14ae254d94f020de418ec307e57abd7008a` |
+```text
+spirit-vs-mouz-m1-dust2.dem
+spirit-vs-mouz-m2-mirage.dem
+spirit-vs-mouz-m3-ancient.dem
+spirit-vs-mouz-m4-nuke.dem
+spirit-vs-jijiehao-mirage.dem
+```
 
-A checksum mismatch always fails and identifies the affected file, actual
-digest, and required digest.
+| Fixture | Map | Map ID | SHA-256 |
+| --- | --- | ---: | --- |
+| Rooster–Mindfreak | Inferno | 234944 | `60129e983bb529bd77b642d59bd2e172367b6ab0dbe73849bb656f7eb76d43c4` |
+| Rooster–Mindfreak | Anubis | 234945 | `7b2a1c89ea0b99be5d4874452716f25cfcbd49353c49b3402cc107f0c5a4bcae` |
+| Rooster–Mindfreak | Mirage | 234947 | `53a3ab2814af90cb9898f2e8f3d7d14ae254d94f020de418ec307e57abd7008a` |
+| Spirit–MOUZ | Dust2 | 234227 | `06075d8cd46422ea9cfd989a4eb849556cd87bcce6b5c83c6343d8e031c9ae19` |
+| Spirit–MOUZ | Mirage | 234233 | `a1d8cc6e2f9e709d17519157fd577f98db98ea80edd2177c12c9b8c666b11c89` |
+| Spirit–MOUZ | Ancient | 234238 | `4ddc87a2b87ff604ccfeb5ee498f543b45afa1f22e8366163db73e828eeb0785` |
+| Spirit–MOUZ | Nuke | 234256 | `11596e71c48615b49248b9b3e915ca0b1beaaf29230af90ceb8cbde9267b4337` |
+| Spirit–JiJieHao | Mirage | 234956 | `d68a4453645332f2a1da37acb07b1e4621362145e678e056f5252b213df2dd38` |
 
 ## Commands and missing-demo behavior
 
-Normal test runs need no external data. With `HLTV_DEMO_DIR` unset, the harness
-loads and validates its static fixture, then clearly skips:
+Normal test runs validate the JSON and skip unconfigured external maps:
 
 ```sh
 go test -count=1 ./...
 ```
 
-Run every available map with:
-
-```sh
-HLTV_DEMO_DIR=/path/to/match-129241-demos \
-  go test -count=1 -v ./cmd/demo_parser -run '^TestHLTVRegression$'
-```
-
-If the directory is set but a map file is absent, that map subtest skips. Make
-the environment variable and every selected demo mandatory with
-`REQUIRE_HLTV_DEMOS=1`; this is the full three-map regression command:
+The original fixture still runs with:
 
 ```sh
 HLTV_DEMO_DIR=/path/to/match-129241-demos \
@@ -61,42 +59,153 @@ REQUIRE_HLTV_DEMOS=1 \
   go test -count=1 -v ./cmd/demo_parser -run '^TestHLTVRegression$'
 ```
 
-With required mode enabled, an unset `HLTV_DEMO_DIR` or absent selected demo is
-a test failure. Run one map independently by selecting its table-driven
-subtest, for example Inferno:
+Run the complete eight-map harness with:
 
 ```sh
 HLTV_DEMO_DIR=/path/to/match-129241-demos \
 REQUIRE_HLTV_DEMOS=1 \
-  go test -count=1 -v ./cmd/demo_parser -run '^TestHLTVRegression$/^inferno$'
+HLTV_EXTRA_DEMO_DIRS=/path/to/match-128974-demos:/path/to/map-234956-demo \
+REQUIRE_HLTV_EXTRA_DEMOS=1 \
+  go test -count=1 -v ./cmd/demo_parser -run '^TestHLTVRegression$'
 ```
 
-The other subtest names are `anubis` and `mirage`.
+`REQUIRE_HLTV_DEMOS=1` applies only to the original fixture;
+`REQUIRE_HLTV_EXTRA_DEMOS=1` applies only to the five additional maps. An
+unset directory variable or missing file becomes a failure only for its
+required group. A checksum mismatch always fails.
+
+Original subtests remain `inferno`, `anubis`, and `mirage`. Additional names
+are unique, for example:
+
+```text
+extra/match-128974/dust2-234227
+extra/match-128974/mirage-234233
+extra/match-128974/ancient-234238
+extra/match-128974/nuke-234256
+extra/match-2396559/mirage-234956
+```
 
 ## Comparison contract
 
-Each map must contain exactly the ten fixture SteamID64 values. Display names
-are diagnostic labels only; nicknames never establish identity. Map name,
-round count, the two exact final score values, kills, and deaths require strict
-parity. Score values are sorted before comparison because the parser exposes
-final CT/T scoreboard fields rather than stable team identity; the values
-themselves are not given a tolerance.
+Each map requires exactly the ten oracle SteamIDs. Map name, round count,
+final score values, kills, and deaths are strict. Score values are sorted
+because the parser exposes final CT/T fields rather than stable team identity.
 
-ADR is compared exactly after formatting both sides to the one-decimal value
-shown by HLTV and the CLI. HLTV KAST percentages are converted to integer
-qualifying-round counts with `round(percent * map rounds / 100)` before
-comparison.
+ADR is compared after both values are formatted to one decimal. KAST is
+compared as an integer qualifying-round count:
 
-All remaining expected differences are #38 KAST rows in
-`hltvExpectedDifferences`. Every row pins the map, SteamID64, metric, HLTV
-value, current tool value, and issue. A third value fails as a regression. If
-the parser reaches HLTV parity, the test also fails with a request to remove
-the stale exception and promote that row to strict parity. ADR has no expected
-difference rows, so all 30 player-map ADR values use strict parity. This
-harness does not change or relax the behavior owned by #38.
+```text
+round(displayed percentage × map rounds / 100)
+```
 
-Rating 3.0 is approximate because HLTV's formula is proprietary. The harness
-therefore reports, but never asserts, exact rating parity: mean absolute error,
-root mean squared error, bias, Spearman rank correlation, and counts within
-±0.05, ±0.10, and ±0.20. The report uses the same two-decimal rating display
-values users see in the CLI.
+Expected-difference keys contain fixture identity, map ID, SteamID, and metric.
+They are exact exceptions, not tolerances: a third value fails, and reaching
+parity fails until the stale row is removed. ADR follow-ups are independent of
+issue #38.
+
+## Authoritative scored rounds
+
+Round-derived facts are finalized and queued until `TotalRoundsPlayed`
+advances. The queue survives a later `RoundStart`, so delayed replication of
+that property cannot silently lose a genuine round. When several candidates
+wait for one scored-round slot, a candidate that received `RoundEnd` is used
+before an unended same-score setup candidate; unresolved extras are discarded
+at parse end. This gate covers participation, KAST, survival, rating-KAST,
+rating kill/damage points, trades, openings, clutches, multi-kills, aces,
+swing, and MVPs. Raw event totals—kills, deaths, assists, damage, and
+utility—are deliberately unchanged.
+
+The Spirit–MOUZ Dust2 demo demonstrates the bug: it starts a setup round at
+score 0:0, then starts again at 0:0 without a scored result. Before the gate,
+21 scored rounds produced 22 participant rounds and one extra KAST round for
+every player. After the gate, every player has 21 participant rounds and all
+four BO5 maps reach 40/40 classic-KAST parity. Rating changes caused by this
+filter are shared-round-fact corrections, not formula changes.
+
+## Current oracle result and hard gate
+
+With the pinned demos:
+
+| Group | Kills | Deaths | ADR | Classic KAST |
+| --- | ---: | ---: | ---: | ---: |
+| Original fixture | 30/30 | 30/30 | 30/30 | 29/30 |
+| Additional fixtures | 50/50 | 50/50 | 43/50 | 49/50 |
+
+The ADR exceptions are all exactly 0.1: six occur in the BO5 (Dust2 sh1ro and
+PR, Mirage sh1ro, Ancient xelex, Nuke xertioN and PR), and one occurs in the
+standalone Mirage (0SAMAS). They are retained as out-of-scope evidence rather
+than widened tolerances. This is seven rows; the earlier investigation note
+counted only the six BO5 rows.
+
+Two classic-KAST rows remain:
+
+| Fixture | Player | Round | Evidence | Aggregate difference |
+| --- | --- | ---: | --- | --- |
+| Original Inferno | kairo | 9 | Died to Skullhunter at tick 76714. Skullhunter killed 1angel at 76991 and died at 77068. kairo-to-revenge is 354 ticks (5.531 s). No K/A/S/T under the supported rule. | Tool 17/22, HLTV 18/22 |
+| Standalone Mirage | magixx | 22 | Died to bibu at tick 176030. tN1R killed m1N1 at 176051 and bibu at 176358. magixx-to-revenge is 328 ticks (5.125 s). No K/A/S/T under the supported rule. | Tool 17/23, HLTV 18/23 |
+
+`TestEvaluateHLTVTradeModels` replays all eight maps through 18 combinations:
+one death versus multiple deaths per revenge kill, earliest versus nearest
+eligible death, exact time versus timestamp-resolution and normalized-tick
+boundaries, and post-round exclusion versus inclusion. The best general model
+is the production rule—one oldest death, a normalized five-second tick
+boundary—which reaches 29/30 original and 49/50 additional rows. Nearest and
+multiple-death attribution regress already-correct rows. Post-round eligibility
+does not change these eight aggregates, though it remains independently tested.
+
+A six-second boundary fixes the two rows above but creates other aggregate
+regressions. Absolute-clock rounding is rejected because its effective window
+depends on the demo clock's phase. A scalar cutoff selected between observed
+ticks is also rejected as fitted: the original Mirage contains an already
+correct 358-tick control. No evaluated general rule reaches every oracle, so
+the plan's hard gate applies: the two exact #38 exceptions remain and issue
+#38 must not be closed. A focused follow-up needs either an independent
+per-round HLTV oracle or additional evidence for multi-kill trade sequencing.
+
+Run the model matrix with the same demo paths plus:
+
+```sh
+HLTV_EVALUATE_TRADE_MODELS=1 \
+  go test -count=1 -v ./cmd/demo_parser -run '^TestEvaluateHLTVTradeModels$'
+```
+
+For event-level evidence on one player, set a demo and optional SteamID:
+
+```sh
+HLTV_TRACE_DEMO=/path/to/map.dem \
+HLTV_TRACE_STEAM_ID=76561199063238565 \
+  go test -count=1 -v ./cmd/demo_parser -run '^TestTraceHLTVRoundEvidence$'
+```
+
+The trace records participation, side, kills, normal/flash assists, death
+cause/frame/time/tick, every direct trade candidate and trading kill, survival
+at `RoundEnd` and `RoundEndOfficial`, disconnects, scored status, rating-assist
+status, and the final classic-KAST reasons. It writes no files.
+
+## Original issue #38 event evidence
+
+HLTV publishes map-level KAST, not per-round flags. The table records the demo
+events whose rule changes explain the original 13 aggregate differences. Each
+player participated, was dead at both end events, and had no disconnect or
+reconnect in the listed round. `K`, `A`, `S`, and `T` are classic-KAST facts
+after flash assists are excluded.
+
+| Map | Player | Round | Event-level evidence | Result |
+| --- | --- | ---: | --- | --- |
+| Inferno | chelleos | 20 | Flash assist at tick 156870; then died with no K/A/S/T. | Removed one flash-only qualification; parity. |
+| Inferno | rekonz | 14, 18 | Later of two deaths to one killer before one revenge kill (110026/110128→110222 and 139499/139550→139555); T was the only reason. | Oldest-death attribution removes two; parity. |
+| Inferno | JD | 15 | Second of three deaths at 119653/119692/119779 before revenge at 119809; T only. | Oldest-death attribution removes one; parity. |
+| Inferno | ADK | 2 | Later death at 23737 after 23523 before revenge at 23794; T only. | Oldest-death attribution removes one; parity. |
+| Inferno | void | 4, 8 | Round 4 was flash-only. In round 8, last of deaths at 70085/70155/70229 before revenge at 70330; T only. | Removes two; parity. |
+| Inferno | kairo | 9 | Death at 76714; killer died at 77068, 354 ticks later. | Unresolved; HLTV has one more. |
+| Inferno | phoebe | 4 | Second of deaths at 42017/42037/42062 before revenge at 42319; T only. | Oldest-death attribution removes one; parity. |
+| Inferno | lawlkay | 4 | Third death in the same sequence; T only. | Oldest-death attribution removes one; parity. |
+| Anubis | ADK | 11 | Death at 83051 and revenge at 83372 are 321 ticks apart. Their tick intervals can be exactly five seconds apart. | Normalized tick boundary adds T; parity. |
+| Anubis | zune | 17 | Flash assist at 127990; then died with no K/A/S/T. | Removed one flash-only qualification; parity. |
+| Anubis | void | 5 | Flash assist at 33824; then died with no K/A/S/T. | Removed one flash-only qualification; parity. |
+| Mirage | zune | 10 | Later death at 100974 after 100855 before revenge at 100979; T only. | Oldest-death attribution removes one; parity. |
+| Mirage | kairo | 13, 23 | Round 13: later death at 121603 after 121355 before revenge at 121657; T only. Round 23: flash-only assist. | Removes two; parity. |
+
+Rating 3.0 remains approximate because HLTV's formula is proprietary. The
+harness reports MAE, RMSE, bias, Spearman correlation, and counts within
+±0.05/0.10/0.20; it does not assert exact rating parity.

--- a/_docs/PLAYER_DATA.MD
+++ b/_docs/PLAYER_DATA.MD
@@ -31,12 +31,12 @@ A kill is a trade when it lands on the *specific* enemy who killed a teammate, w
 
 - It must be that killer. Killing any other enemy inside the window is not a trade.
 - Both deaths have to fall in the same round.
-- One kill gives its player one `trade_kill`, even when the enemy it lands on had killed two teammates. Each qualifying teammate gets one `deaths_traded`, so that one kill can trade two deaths.
+- One kill gives its player one `trade_kill` and trades at most one death. If the enemy killed several teammates inside the window, the oldest eligible death gets the credit.
 - Post-round events deliberately remain eligible: a death after the round is decided can be traded, and a revenge kill after the round can trade an earlier death, as long as both events stay in this round and inside the window. This differs from opening duels, which cannot start after the round is decided.
 
 `deaths_traded` lives at the player top level beside `deaths` because it describes what happened to the player who died, not a kill they made. It is a per-round count, not a per-death count: the tracker records a boolean per player, so a round adds at most one even when a respawn mode lets that player die and be traded more than once. Its CT/T split always uses the side that player held in that round, never the team they finished the match on. No separate rate is stored. `deaths_traded.total / deaths` is only a per-death rate in modes without mid-round respawns; in respawn modes the numerator stays per-round while `deaths` counts every death.
 
-The 5-second window is a deliberate choice, not a value read out of the demo: HLTV states 5 seconds for Rating 3.0 ("two kills within 5 seconds") and Refrag documents the same for its Trades column. Other trackers differ — Leetify builds 4-second kill chains instead — so trade counts are not comparable between tools even when the label matches. If you are forking and your league counts trades differently, the window is the `tradeWindow` constant at the top of `cmd/demo_parser/round_tracker.go`.
+The 5-second window is a deliberate choice, not a value read out of the demo: HLTV describes a traded death as one avenged within five seconds, and Refrag documents the same duration for its Trades column. Events identify server-tick intervals rather than exact instants. The comparison therefore uses the closest possible instants in those intervals: `(revenge tick - death tick - 1) × tick duration <= 5 seconds`. At 64 ticks per second, a delta of 321 ticks is the inclusive boundary; 322 is outside. Relative ticks make this invariant to the absolute demo-clock phase and avoid demoinfocs' float32 timestamp rounding. If demoinfocs cannot provide a positive tick duration, parsing fails instead of silently reporting zero trades. Fractional configured windows are preserved rather than rounded to whole seconds. Other trackers differ — Leetify builds 4-second kill chains instead — so trade counts are not comparable between tools even when the label matches. If you are forking and your league counts trades differently, the window is the `tradeWindow` constant at the top of `cmd/demo_parser/round_tracker.go`.
 
 The count is in JSON, in CSV as `Deaths Traded` plus its CT/T columns, and in the `Trade stats` table that `--details` prints. The main table stays unchanged.
 
@@ -105,11 +105,28 @@ All utility scalars are appended to CSV after the existing columns. `--details` 
 
 | Field | JSON key | Description |
 | --- | --- | --- |
-| MVPs | `mvps` | Round MVP awards. |
+| MVPs | `mvps` | Round MVP awards. Event and scoreboard values are committed only for authoritative scored rounds. |
 | ACEs | `aces` | Rounds with 5 or more enemy kills. |
 | MultiKills | `multi_kills` | Multi-kill rounds bucketed by kill count: `{k2, k3, k4, k5}`. See [multi-kill rounds](#multi-kill-rounds). |
 | ClutchesWon | `clutches_won` | Rounds won after being the last player alive on the team against at least one enemy (1v1 counts). Winning by defuse or time counts — no kills required. |
-| KAST | `kast` | Percentage of the match's rounds with a Kill, Assist, Survival or Traded death (a teammate killed your killer within 5 seconds). `RoundEnd` does not award survival immediately: exit frags and C4 deaths before `RoundEndOfficial` still cancel it. This round/KAST treatment is separate from raw death totals, where a C4 event emitted after `RoundEnd` during `GamePhaseGameHalfEnded` is excluded. Match-end World cleanup does not cancel survival. |
+| KAST | `kast` | Percentage of the match's rounds with a Kill, non-flash demo Assist, Survival or Traded death. Flash assists are excluded from classic KAST. `RoundEnd` does not award survival immediately: exit frags and C4 deaths before `RoundEndOfficial` still cancel it. This round/KAST treatment is separate from raw death totals, where a C4 event emitted after `RoundEnd` during `GamePhaseGameHalfEnded` is excluded. Match-end World cleanup does not cancel survival. |
+
+#### Authoritative scored rounds
+
+Round-derived facts are queued until the scoreboard's `TotalRoundsPlayed`
+advances. The queue survives a later round start, so a delayed property update
+cannot silently lose a genuine round. If several candidates wait for one
+scored-round slot, a round that received `RoundEnd` is used before an unended
+same-score setup candidate; unresolved extras are discarded at parse end.
+Participation, KAST, survival, rating-KAST, rating kill/damage points, trades,
+openings, clutches, multi-kills, aces, round swing, and MVPs all use this gate.
+A missing `RoundEndOfficial` is handled at the next round start or parse end,
+and duplicate finalization is harmless.
+
+Raw event totals are intentionally separate: kills, deaths, assists, damage,
+and utility still reflect the events present in the demo. Filtering a setup
+round can therefore change round denominators and round-derived rating facts
+without deleting those raw events.
 
 #### Multi-kill rounds
 
@@ -191,7 +208,7 @@ Survival and KAST credit use a per-round weight from the player's own buy, captu
 
 #### Rating KAST
 
-The rating's KAST axis differs from the classic `player_map_stats.kast` in one rule: assists. The classic KAST takes the demo's assist events as they are. The rating additionally credits any player who dealt at least 40 damage to an enemy who died that round — Rating 3.0's threshold, raised from the 25 of Rating 2.0 — whoever or whatever finished them, while keeping the demo's assist events so flash assists still count. Kill, survival and traded-death credit are unchanged. The classic KAST field itself is untouched by this feature.
+The rating's KAST axis differs from the classic `player_map_stats.kast` in its assist rule. Classic KAST counts non-flash demo assists. Rating KAST keeps every demo assist, including flash assists, and additionally credits any player who dealt at least 40 damage to an enemy who died that round — Rating 3.0's threshold, raised from the 25 of Rating 2.0 — whoever or whatever finished them. Kill, survival and traded-death facts are shared. The classic KAST field itself remains separate from this approximate rating logic.
 
 #### Round swing
 

--- a/cmd/demo_parser/demo_parser.go
+++ b/cmd/demo_parser/demo_parser.go
@@ -2,6 +2,7 @@ package demoparser
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"slices"
 	"strings"
@@ -16,23 +17,47 @@ import (
 // analyser accumulates player stats while the demo is parsed. Round-scoped
 // bookkeeping (clutches, aces, trades, KAST) is delegated to roundTracker.
 type analyser struct {
-	parser      demoinfocs.Parser
-	players     map[uint64]*DemoPlayer
-	tracker     *roundTracker
-	kastRounds  map[uint64]SideCount // rounds with KAST, total and per side
-	sideDamage  map[uint64]SideCount // damage given, total and per side
-	openingWins map[uint64]int       // rounds won after taking the opening kill
-	lastHealth  map[uint64]int
-	worldSource map[uint64]worldDamageSource
-	flashEnds   map[uint64]time.Duration // latest known end of each player's blind interval
-	ecoKills    map[uint64]float64       // eco-adjusted kill points
-	ecoDamage   map[uint64]float64       // eco-adjusted damage given
-	roundSwing  map[uint64]float64       // summed round-win-probability swing
-	ecoSurvival map[uint64]float64       // eco-weighted rounds survived
-	ecoKast     map[uint64]float64       // eco-weighted rounds with rating KAST credit
-	roundTiers  map[uint64]equipTier     // loadout tier per player in the current round
-	mapData     MapData
-	gameMode    string
+	parser         demoinfocs.Parser
+	players        map[uint64]*DemoPlayer
+	tracker        *roundTracker
+	kastRounds     map[uint64]SideCount // rounds with KAST, total and per side
+	sideDamage     map[uint64]SideCount // damage given, total and per side
+	openingWins    map[uint64]int       // rounds won after taking the opening kill
+	lastHealth     map[uint64]int
+	worldSource    map[uint64]worldDamageSource
+	flashEnds      map[uint64]time.Duration // latest known end of each player's blind interval
+	ecoKills       map[uint64]float64       // eco-adjusted kill points
+	ecoDamage      map[uint64]float64       // eco-adjusted damage given
+	roundSwing     map[uint64]float64       // summed round-win-probability swing
+	ecoSurvival    map[uint64]float64       // eco-weighted rounds survived
+	ecoKast        map[uint64]float64       // eco-weighted rounds with rating KAST credit
+	roundTiers     map[uint64]equipTier     // loadout tier per player in the current round
+	roundMVPs      map[uint64]int           // cumulative scoreboard MVPs captured for the current round
+	roundEcoKills  []playerRatingFact       // rating kill points in event order for the current round
+	roundEcoDamage []playerRatingFact       // rating damage points in event order for the current round
+	pendingRounds  []*pendingRoundFacts     // finalized facts waiting for scoreboard advances
+	latestRound    *pendingRoundFacts       // most recently finalized round, for late MVP events
+	appliedRounds  int                      // authoritative round count already represented in player facts
+	roundsStarted  bool                     // whether appliedRounds has been initialized
+	eventMVPs      map[uint64]int           // MVP announcements from authoritative scored rounds
+	parseErr       error                    // delayed handler error returned after parsing
+	mapData        MapData
+	gameMode       string
+}
+
+type pendingRoundFacts struct {
+	outcome    roundOutcome
+	tiers      map[uint64]equipTier
+	mvps       map[uint64]int
+	ecoKills   []playerRatingFact
+	ecoDamage  []playerRatingFact
+	scored     bool
+	mvpCounted bool
+}
+
+type playerRatingFact struct {
+	player uint64
+	value  float64
 }
 
 type worldDamageSource struct {
@@ -57,6 +82,8 @@ func newAnalyser(parser demoinfocs.Parser) *analyser {
 		ecoSurvival: make(map[uint64]float64),
 		ecoKast:     make(map[uint64]float64),
 		roundTiers:  make(map[uint64]equipTier),
+		roundMVPs:   make(map[uint64]int),
+		eventMVPs:   make(map[uint64]int),
 	}
 }
 
@@ -74,6 +101,9 @@ func ProcessDemo(demoPath string) (*ProcessedDemo, error) {
 
 	if err := a.parser.ParseToEnd(); err != nil {
 		return nil, fmt.Errorf("parsing demo: %w", err)
+	}
+	if a.parseErr != nil {
+		return nil, fmt.Errorf("parsing demo: %w", a.parseErr)
 	}
 
 	a.finalise()
@@ -195,11 +225,20 @@ func (a *analyser) onRoundStart(e events.RoundStart) {
 	if a.inWarmupOrPregame() {
 		return
 	}
-	// Close the previous round in case its official end was never seen.
-	// That outcome consumes the previous round's tier snapshot, so the
-	// reset has to fall between it and the roster read for the new round.
-	a.applyRoundOutcome(a.tracker.finalize())
+	if !a.roundsStarted {
+		a.appliedRounds = a.parser.GameState().TotalRoundsPlayed()
+		a.roundsStarted = true
+	}
+	// Close the previous round in case its official end was never seen. It
+	// remains queued until the authoritative round count creates room for it;
+	// this tolerates a late property update without crediting a same-score
+	// setup RoundStart.
+	a.finalizeRoundFacts()
+	a.latestRound = nil
 	clear(a.roundTiers)
+	clear(a.roundMVPs)
+	a.roundEcoKills = a.roundEcoKills[:0]
+	a.roundEcoDamage = a.roundEcoDamage[:0]
 	clear(a.worldSource)
 	a.tracker.startRound(a.playingRoster())
 }
@@ -286,7 +325,10 @@ func (a *analyser) onKill(e events.Kill) {
 			// victim's inventory is still their pre-death one during Kill,
 			// which TestProcessDemoGolden pins for unused utility. Keyed by
 			// SteamID like ecoDamage, matching how derive reads both back.
-			a.ecoKills[killer.SteamID] += killPoints(playerTier(e.Killer.Inventory), playerTier(e.Victim.Inventory))
+			a.roundEcoKills = append(a.roundEcoKills, playerRatingFact{
+				player: killer.SteamID,
+				value:  killPoints(playerTier(e.Killer.Inventory), playerTier(e.Victim.Inventory)),
+			})
 		}
 	}
 
@@ -302,12 +344,12 @@ func (a *analyser) onKill(e events.Kill) {
 		}
 	}
 
-	isTrade := a.tracker.kill(killerID, trackerID(e.Victim), killerTeam, e.Victim.Team, assisterID, byWorld, a.parser.CurrentTime())
-	if isTrade && !teamkill {
-		if killer := a.ensurePlayer(e.Killer); killer != nil {
-			killer.KillStats.TradeKills++
-		}
+	tickTime := a.parser.TickTime()
+	if tickTime <= 0 && a.parseErr == nil {
+		a.parseErr = fmt.Errorf("demo tick duration is %s; cannot calculate trades", tickTime)
 	}
+	a.tracker.kill(killerID, trackerID(e.Victim), killerTeam, e.Victim.Team,
+		assisterID, e.AssistedFlash, byWorld, a.parser.GameState().IngameTick(), tickTime)
 }
 
 func (a *analyser) onPlayerHurt(e events.PlayerHurt) {
@@ -382,8 +424,11 @@ func (a *analyser) onPlayerHurt(e events.PlayerHurt) {
 	// absorbed hits) and cannot change either total, so skip pricing
 	// their duel.
 	if realDamage > 0 {
-		a.ecoDamage[attackerStats.SteamID] += float64(realDamage) *
-			ecoDuelFactor(playerTier(damageAttacker.Inventory), playerTier(e.Player.Inventory))
+		a.roundEcoDamage = append(a.roundEcoDamage, playerRatingFact{
+			player: attackerStats.SteamID,
+			value: float64(realDamage) *
+				ecoDuelFactor(playerTier(damageAttacker.Inventory), playerTier(e.Player.Inventory)),
+		})
 		a.tracker.damage(trackerID(damageAttacker), victimID, realDamage)
 	}
 }
@@ -427,7 +472,17 @@ func (a *analyser) onRoundMVP(e events.RoundMVPAnnouncement) {
 		return
 	}
 	if player := a.ensurePlayer(e.Player); player != nil {
-		player.PlayerMapStats.MVPs++
+		if a.tracker.live {
+			a.tracker.markMVP(player.SteamID)
+			return
+		}
+		// Some demos announce the MVP after RoundEndOfficial finalized the
+		// tracker. Attach it to that round until the next RoundStart instead of
+		// silently dropping it.
+		if a.latestRound != nil && a.latestRound.outcome.mvp == 0 {
+			a.latestRound.outcome.mvp = player.SteamID
+			a.applyEventMVP(a.latestRound)
+		}
 	}
 }
 
@@ -441,12 +496,12 @@ func (a *analyser) onRoundEnd(e events.RoundEnd) {
 	if a.inWarmupOrPregame() {
 		return
 	}
-	a.syncScoreboardMVPs()
+	a.captureScoreboardMVPs()
 	a.tracker.markEnd(e.Winner)
 }
 
 func (a *analyser) onRoundEndOfficial(e events.RoundEndOfficial) {
-	a.applyRoundOutcome(a.tracker.finalize())
+	a.finalizeRoundFacts()
 }
 
 // add credits n to the side the player was on. Anything but CT and T only
@@ -491,7 +546,7 @@ func (m *MultiKillRounds) add(kills int) {
 	}
 }
 
-func (a *analyser) applyRoundOutcome(outcome roundOutcome) {
+func (a *analyser) applyRoundOutcomeWithTiers(outcome roundOutcome, tiers map[uint64]equipTier) {
 	if !outcome.played {
 		return
 	}
@@ -503,6 +558,11 @@ func (a *analyser) applyRoundOutcome(outcome roundOutcome) {
 	for id, kills := range outcome.multiKills {
 		if p := a.players[id]; p != nil {
 			p.PlayerMapStats.MultiKills.add(kills)
+		}
+	}
+	for id, kills := range outcome.tradeKills {
+		if p := a.players[id]; p != nil {
+			p.KillStats.TradeKills += kills
 		}
 	}
 	if p := a.players[outcome.clutcher]; p != nil {
@@ -540,21 +600,96 @@ func (a *analyser) applyRoundOutcome(outcome roundOutcome) {
 	// worth on the player's buy that round is the rating model's business.
 	// A player with no tier snapshot weighs the neutral 1.
 	for id := range outcome.survived {
-		a.ecoSurvival[id] += ecoRoundWeight(a.roundTiers[id])
+		a.ecoSurvival[id] += ecoRoundWeight(tiers[id])
 	}
 	for id := range outcome.ratingKast {
-		a.ecoKast[id] += ecoRoundWeight(a.roundTiers[id])
+		a.ecoKast[id] += ecoRoundWeight(tiers[id])
 	}
 }
 
-// syncScoreboardMVPs mirrors the scoreboard MVP counter into the player
-// stats. CS2 demos no longer carry the round_mvp game event, so the
-// RoundMVPAnnouncement handler never fires and the entity property is the
-// only reliable source. Synced every round end so leavers keep theirs.
-func (a *analyser) syncScoreboardMVPs() {
+// finalizeRoundFacts closes the current round and queues its derived facts.
+// The queue is reconciled against the authoritative round count so a late
+// property update cannot lose a genuine round and an unended setup round
+// cannot consume a scored-round slot. Raw event totals deliberately bypass it.
+func (a *analyser) finalizeRoundFacts() {
+	outcome := a.tracker.finalize()
+	if outcome.played {
+		pending := &pendingRoundFacts{
+			outcome:   outcome,
+			tiers:     maps.Clone(a.roundTiers),
+			mvps:      maps.Clone(a.roundMVPs),
+			ecoKills:  slices.Clone(a.roundEcoKills),
+			ecoDamage: slices.Clone(a.roundEcoDamage),
+		}
+		a.pendingRounds = append(a.pendingRounds, pending)
+		a.latestRound = pending
+	}
+	a.applyScoredRoundFacts()
+}
+
+func (a *analyser) applyScoredRoundFacts() {
+	if !a.roundsStarted {
+		return
+	}
+	available := a.parser.GameState().TotalRoundsPlayed() - a.appliedRounds
+	for available > 0 && len(a.pendingRounds) > 0 {
+		index := a.nextScoredRound()
+		pending := a.pendingRounds[index]
+		a.pendingRounds = slices.Delete(a.pendingRounds, index, index+1)
+		pending.scored = true
+		a.applyRoundOutcomeWithTiers(pending.outcome, pending.tiers)
+		for _, fact := range pending.ecoKills {
+			a.ecoKills[fact.player] += fact.value
+		}
+		for _, fact := range pending.ecoDamage {
+			a.ecoDamage[fact.player] += fact.value
+		}
+		a.applyScoreboardMVPs(pending.mvps)
+		a.applyEventMVP(pending)
+		a.appliedRounds++
+		available--
+	}
+}
+
+// nextScoredRound prefers rounds that received RoundEnd. If only unended
+// candidates remain, the newest one wins: this is the parse-corruption
+// fallback that skips an earlier same-score setup RoundStart.
+func (a *analyser) nextScoredRound() int {
+	for i, pending := range a.pendingRounds {
+		if pending.outcome.decided {
+			return i
+		}
+	}
+	return len(a.pendingRounds) - 1
+}
+
+func (a *analyser) applyEventMVP(pending *pendingRoundFacts) {
+	if !pending.scored || pending.mvpCounted || pending.outcome.mvp == 0 {
+		return
+	}
+	pending.mvpCounted = true
+	id := pending.outcome.mvp
+	a.eventMVPs[id]++
+	if player := a.players[id]; player != nil {
+		player.PlayerMapStats.MVPs = max(player.PlayerMapStats.MVPs, a.eventMVPs[id])
+	}
+}
+
+// captureScoreboardMVPs snapshots the cumulative scoreboard counter while
+// leavers are still present. It is applied only if this round later proves to
+// be scored; CS2 demos often omit RoundMVPAnnouncement entirely.
+func (a *analyser) captureScoreboardMVPs() {
 	for _, pl := range a.parser.GameState().Participants().Playing() {
 		if dp := a.ensurePlayer(pl); dp != nil {
-			dp.PlayerMapStats.MVPs = max(dp.PlayerMapStats.MVPs, pl.MVPs())
+			a.roundMVPs[dp.SteamID] = max(a.roundMVPs[dp.SteamID], pl.MVPs())
+		}
+	}
+}
+
+func (a *analyser) applyScoreboardMVPs(mvps map[uint64]int) {
+	for id, count := range mvps {
+		if player := a.players[id]; player != nil {
+			player.PlayerMapStats.MVPs = max(player.PlayerMapStats.MVPs, count)
 		}
 	}
 }
@@ -562,8 +697,17 @@ func (a *analyser) syncScoreboardMVPs() {
 // finalise fills in everything that needs the full match: final score and
 // the per-player derived stats.
 func (a *analyser) finalise() {
-	a.applyRoundOutcome(a.tracker.finalize())
-	a.syncScoreboardMVPs()
+	a.captureScoreboardMVPs()
+	a.finalizeRoundFacts()
+	// The final scoreboard is authoritative and catches MVP entity updates
+	// that arrived after RoundEndOfficial. Per-round snapshots above still
+	// preserve MVPs for players who disconnected before parse end. Keep this
+	// safety net behind the same scored-round gate as every other MVP fact.
+	if a.latestRound != nil && a.latestRound.scored {
+		a.applyScoreboardMVPs(a.roundMVPs)
+	}
+	a.pendingRounds = nil
+	a.latestRound = nil
 
 	gs := a.parser.GameState()
 	a.mapData.TotalRounds = gs.TotalRoundsPlayed()

--- a/cmd/demo_parser/demo_parser_test.go
+++ b/cmd/demo_parser/demo_parser_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 // The handlers under test only ask the parser for round state, who is
-// playing, and the current time, so these stubs answer those questions and
-// leave the embedded interfaces nil.
+// playing, the current time, and its tick resolution, so these stubs answer
+// those questions and leave the embedded interfaces nil.
 type matchParser struct {
 	demoinfocs.Parser
 	playing      []*common.Player
@@ -21,26 +21,56 @@ type matchParser struct {
 	gamePhase    common.GamePhase
 	currentTime  time.Duration
 	currentFrame int
+	tickTime     time.Duration
+	ingameTick   int
+	roundsPlayed int
+	ctScore      int
+	tScore       int
 }
 
 func (p *matchParser) GameState() demoinfocs.GameState {
-	return matchGameState{playing: p.playing, warmup: p.warmup, gamePhase: p.gamePhase}
+	return matchGameState{
+		playing: p.playing, warmup: p.warmup, gamePhase: p.gamePhase, ingameTick: p.ingameTick,
+		roundsPlayed: p.roundsPlayed, ctScore: p.ctScore, tScore: p.tScore,
+	}
 }
 
 func (p *matchParser) CurrentTime() time.Duration { return p.currentTime }
 
 func (p *matchParser) CurrentFrame() int { return p.currentFrame }
 
+func (p *matchParser) TickTime() time.Duration { return p.tickTime }
+
 type matchGameState struct {
 	demoinfocs.GameState
-	playing   []*common.Player
-	warmup    bool
-	gamePhase common.GamePhase
+	playing      []*common.Player
+	warmup       bool
+	gamePhase    common.GamePhase
+	ingameTick   int
+	roundsPlayed int
+	ctScore      int
+	tScore       int
 }
 
 func (g matchGameState) IsWarmupPeriod() bool { return g.warmup }
 
 func (g matchGameState) GamePhase() common.GamePhase { return g.gamePhase }
+
+func (g matchGameState) IngameTick() int { return g.ingameTick }
+
+func (g matchGameState) TotalRoundsPlayed() int { return g.roundsPlayed }
+
+func (g matchGameState) TeamCounterTerrorists() *common.TeamState {
+	return &common.TeamState{Entity: matchEntity{properties: map[string]st.PropertyValue{
+		"m_iScore": {Any: int32(g.ctScore)},
+	}}}
+}
+
+func (g matchGameState) TeamTerrorists() *common.TeamState {
+	return &common.TeamState{Entity: matchEntity{properties: map[string]st.PropertyValue{
+		"m_iScore": {Any: int32(g.tScore)},
+	}}}
+}
 
 func (g matchGameState) Participants() demoinfocs.Participants {
 	return matchParticipants{playing: g.playing}
@@ -54,7 +84,17 @@ type matchParticipants struct {
 func (p matchParticipants) Playing() []*common.Player { return p.playing }
 
 func liveAnalyser(playing ...*common.Player) *analyser {
-	return newAnalyser(&matchParser{playing: playing})
+	return newAnalyser(&matchParser{playing: playing, tickTime: time.Second / 64})
+}
+
+func markRoundScored(a *analyser) {
+	a.parser.(*matchParser).roundsPlayed++
+}
+
+func endScoredRound(a *analyser, winner common.Team) {
+	markRoundScored(a)
+	a.onRoundEnd(events.RoundEnd{Winner: winner})
+	a.onRoundEndOfficial(events.RoundEndOfficial{})
 }
 
 const (
@@ -156,7 +196,7 @@ func TestPlayingRosterExcludesCoachingController(t *testing.T) {
 				t.Error("coaching controller was exported as a player")
 			}
 
-			a.syncScoreboardMVPs()
+			a.captureScoreboardMVPs()
 			if _, ok := a.players[coachID]; ok {
 				t.Error("scoreboard MVP sync exported the coaching controller")
 			}
@@ -217,8 +257,7 @@ func TestCoachingControllerEventsDoNotAffectCompetitiveRound(t *testing.T) {
 		t.Error("coach plant changed the competitive round state")
 	}
 
-	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
-	a.onRoundEndOfficial(events.RoundEndOfficial{})
+	endScoredRound(a, common.TeamTerrorists)
 	for _, id := range []uint64{shooterID, victimID} {
 		if got := a.players[id].SideStats.Rounds.Total; got != 1 {
 			t.Errorf("player %d rounds = %d, want 1", id, got)
@@ -263,6 +302,7 @@ func TestAdjacentWorldDamageCreditsPreviousEnemy(t *testing.T) {
 
 	hurtAtFrame(a, 100, hurtEvent(shooter, victim, common.EqUSP, 15, 66))
 	hurtAtFrame(a, 101, hurtEvent(nil, victim, common.EqWorld, 5, 61))
+	endScoredRound(a, common.TeamTerrorists)
 
 	got := a.players[shooterID]
 	if got.AssistStats.DamageGiven != 20 {
@@ -423,11 +463,96 @@ func liveRound() (*analyser, *common.Player, *common.Player) {
 func TestSurvivorsGetKastWhenTheRoundEndsOfficially(t *testing.T) {
 	a, _, _ := liveRound()
 
-	a.onRoundEnd(events.RoundEnd{Winner: common.TeamCounterTerrorists})
-	a.onRoundEndOfficial(events.RoundEndOfficial{})
+	endScoredRound(a, common.TeamCounterTerrorists)
 
 	if got := a.kastRounds[victimID].Total; got != 1 {
 		t.Errorf("victim kast rounds = %d, want 1: nobody died all round", got)
+	}
+}
+
+func TestKillHandlerSeparatesClassicAndFlashAssists(t *testing.T) {
+	tests := []struct {
+		name          string
+		assistedFlash bool
+		wantClassic   int
+		wantFlashed   int
+	}{
+		{name: "normal assist", wantClassic: 1},
+		{name: "flash assist", assistedFlash: true, wantFlashed: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			killer := player(11, "killer", common.TeamCounterTerrorists)
+			victim := player(5, "victim", common.TeamTerrorists)
+			assister := player(12, "assister", common.TeamCounterTerrorists)
+			finisher := player(1, "finisher", common.TeamTerrorists)
+			a := liveAnalyser(killer, victim, assister, finisher)
+			a.onRoundStart(events.RoundStart{})
+
+			a.onKill(events.Kill{
+				Killer: killer, Victim: victim, Assister: assister,
+				AssistedFlash: tt.assistedFlash, Weapon: &common.Equipment{Type: common.EqM4A1},
+			})
+			a.onKill(events.Kill{
+				Killer: finisher, Victim: assister, Weapon: &common.Equipment{Type: common.EqAK47},
+			})
+			endScoredRound(a, common.TeamTerrorists)
+
+			if got := a.kastRounds[12].Total; got != tt.wantClassic {
+				t.Errorf("assister classic-KAST rounds = %d, want %d", got, tt.wantClassic)
+			}
+			if got := a.ecoKast[12]; got == 0 {
+				t.Error("demo assist must reach the separate rating-KAST facts")
+			}
+			if got := a.players[12].AssistStats; got.Total != 1 || got.FlashedEnemies != tt.wantFlashed {
+				t.Errorf("assist stats = %+v, want total 1 and flashed %d", got, tt.wantFlashed)
+			}
+		})
+	}
+}
+
+func TestKillHandlerPassesServerTicksToTrades(t *testing.T) {
+	const tick = time.Second / 64
+	killer := player(11, "killer", common.TeamCounterTerrorists)
+	victim := player(1, "victim", common.TeamTerrorists)
+	trader := player(2, "trader", common.TeamTerrorists)
+	a := liveAnalyser(killer, victim, trader)
+	p := a.parser.(*matchParser)
+	p.tickTime = tick
+	a.onRoundStart(events.RoundStart{})
+
+	p.ingameTick = 640
+	a.onKill(events.Kill{Killer: killer, Victim: victim, Weapon: &common.Equipment{Type: common.EqM4A1}})
+	p.ingameTick = 961
+	a.onKill(events.Kill{Killer: trader, Victim: killer, Weapon: &common.Equipment{Type: common.EqAK47}})
+	endScoredRound(a, common.TeamTerrorists)
+
+	if got := a.kastRounds[victim.SteamID64].Total; got != 1 {
+		t.Errorf("traded victim classic-KAST rounds = %d, want 1", got)
+	}
+	if got := a.players[trader.SteamID64].KillStats.TradeKills; got != 1 {
+		t.Errorf("trade kills = %d, want 1", got)
+	}
+}
+
+func TestKillHandlerRejectsUnavailableTickTime(t *testing.T) {
+	for _, tickTime := range []time.Duration{0, -1} {
+		t.Run(tickTime.String(), func(t *testing.T) {
+			killer := player(11, "killer", common.TeamCounterTerrorists)
+			victim := player(1, "victim", common.TeamTerrorists)
+			a := liveAnalyser(killer, victim)
+			a.parser.(*matchParser).tickTime = tickTime
+			a.onRoundStart(events.RoundStart{})
+
+			a.onKill(events.Kill{
+				Killer: killer, Victim: victim, Weapon: &common.Equipment{Type: common.EqM4A1},
+			})
+
+			if a.parseErr == nil {
+				t.Fatal("unavailable tick duration did not produce a parser error")
+			}
+		})
 	}
 }
 
@@ -476,6 +601,7 @@ func TestRoundEndingBombDeathCountsRawDeathDuringActiveGamePhase(t *testing.T) {
 func TestPostRoundBombDeathStillCancelsSurvivalKast(t *testing.T) {
 	a, _, victim := liveRound()
 	a.parser.(*matchParser).gamePhase = common.GamePhaseGameHalfEnded
+	markRoundScored(a)
 	a.onRoundEnd(events.RoundEnd{
 		Winner: common.TeamTerrorists,
 		Reason: events.RoundEndReasonTargetBombed,
@@ -493,6 +619,7 @@ func TestPostRoundDeathBeforeOfficialEndCancelsKast(t *testing.T) {
 
 	// The exit frag lands after the round is decided but before it is
 	// officially over, so the victim did not survive it.
+	markRoundScored(a)
 	a.onRoundEnd(events.RoundEnd{Winner: common.TeamCounterTerrorists})
 	a.onKill(events.Kill{Killer: shooter, Victim: victim, Weapon: &common.Equipment{Type: common.EqAK47}})
 	a.onRoundEndOfficial(events.RoundEndOfficial{})
@@ -514,6 +641,7 @@ func TestPregameKnifeRoundIsExcludedBeforeFirstScoredRound(t *testing.T) {
 	parser := &matchParser{
 		playing:   []*common.Player{shooter, victim},
 		gamePhase: common.GamePhasePregame,
+		tickTime:  time.Second / 64,
 	}
 	a := newAnalyser(parser)
 	knife := &common.Equipment{Type: common.EqKnife}
@@ -543,8 +671,7 @@ func TestPregameKnifeRoundIsExcludedBeforeFirstScoredRound(t *testing.T) {
 	a.onKill(events.Kill{
 		Killer: shooter, Victim: victim, Weapon: &common.Equipment{Type: common.EqAK47},
 	})
-	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
-	a.onRoundEndOfficial(events.RoundEndOfficial{})
+	endScoredRound(a, common.TeamTerrorists)
 
 	gotShooter := a.players[shooterID]
 	if gotShooter.KillStats.Total != 1 || gotShooter.AssistStats.DamageGiven != 30 {
@@ -574,6 +701,7 @@ func TestDemoStartingWithCompetitiveRoundKeepsFirstRound(t *testing.T) {
 	parser := &matchParser{
 		playing:   []*common.Player{shooter, victim},
 		gamePhase: common.GamePhaseStartGamePhase,
+		tickTime:  time.Second / 64,
 	}
 	a := newAnalyser(parser)
 
@@ -592,11 +720,276 @@ func TestDemoStartingWithCompetitiveRoundKeepsFirstRound(t *testing.T) {
 	}
 }
 
+func TestUnscoredSetupRoundDiscardsRoundFactsButKeepsRawEvents(t *testing.T) {
+	victim := player(1, "victim", common.TeamTerrorists)
+	trader := player(2, "trader", common.TeamTerrorists)
+	killer := player(11, "killer", common.TeamCounterTerrorists)
+	otherCTs := []*common.Player{
+		player(12, "ct-12", common.TeamCounterTerrorists),
+		player(13, "ct-13", common.TeamCounterTerrorists),
+		player(14, "ct-14", common.TeamCounterTerrorists),
+		player(15, "ct-15", common.TeamCounterTerrorists),
+	}
+	a := liveAnalyser(append([]*common.Player{victim, trader, killer}, otherCTs...)...)
+	a.parser.(*matchParser).gamePhase = common.GamePhaseStartGamePhase
+	a.onRoundStart(events.RoundStart{})
+
+	hurtBy(a, killer, victim, 30)
+	a.parser.(*matchParser).ingameTick = 640
+	a.onKill(events.Kill{Killer: killer, Victim: victim, Weapon: &common.Equipment{Type: common.EqM4A1}})
+	a.parser.(*matchParser).ingameTick = 768
+	a.onKill(events.Kill{Killer: trader, Victim: killer, Weapon: &common.Equipment{Type: common.EqAK47}})
+	for _, ct := range otherCTs {
+		a.onKill(events.Kill{Killer: trader, Victim: ct, Weapon: &common.Equipment{Type: common.EqAK47}})
+	}
+	a.onRoundMVP(events.RoundMVPAnnouncement{Player: trader})
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
+	a.onRoundEndOfficial(events.RoundEndOfficial{})
+
+	// A restart at the same authoritative round count proves the prior
+	// outcome was setup rather than a played round.
+	a.onRoundStart(events.RoundStart{})
+
+	if got := a.players[killer.SteamID64].KillStats.Total; got != 1 {
+		t.Errorf("raw kills = %d, want 1", got)
+	}
+	if got := a.players[victim.SteamID64].Deaths; got != 1 {
+		t.Errorf("raw deaths = %d, want 1", got)
+	}
+	if got := a.players[trader.SteamID64].KillStats.Total; got != 5 {
+		t.Errorf("raw trader kills = %d, want 5", got)
+	}
+	if got := a.players[killer.SteamID64].AssistStats.DamageGiven; got != 30 {
+		t.Errorf("raw damage = %d, want 30", got)
+	}
+	for _, id := range []uint64{victim.SteamID64, trader.SteamID64, killer.SteamID64} {
+		if got := a.players[id].SideStats.Rounds.Total; got != 0 {
+			t.Errorf("player %d rounds = %d, want 0", id, got)
+		}
+		if got := a.kastRounds[id].Total; got != 0 {
+			t.Errorf("player %d KAST rounds = %d, want 0", id, got)
+		}
+		if got := a.ecoSurvival[id]; got != 0 {
+			t.Errorf("player %d rating survival = %v, want 0", id, got)
+		}
+		if got := a.ecoKast[id]; got != 0 {
+			t.Errorf("player %d rating KAST = %v, want 0", id, got)
+		}
+	}
+	if got := a.players[trader.SteamID64].KillStats.TradeKills; got != 0 {
+		t.Errorf("trade kills = %d, want 0", got)
+	}
+	if got := a.players[victim.SteamID64].DeathsTraded.Total; got != 0 {
+		t.Errorf("traded deaths = %d, want 0", got)
+	}
+	if got := a.players[killer.SteamID64].OpeningDuelStats.OpeningKills.Total; got != 0 {
+		t.Errorf("opening kills = %d, want 0", got)
+	}
+	if got := a.players[trader.SteamID64].PlayerMapStats.ClutchesWon; got != 0 {
+		t.Errorf("clutches = %d, want 0", got)
+	}
+	if got := a.players[trader.SteamID64].PlayerMapStats.MVPs; got != 0 {
+		t.Errorf("MVPs = %d, want 0", got)
+	}
+	if got := a.players[trader.SteamID64].PlayerMapStats.ACEs; got != 0 {
+		t.Errorf("ACEs = %d, want 0", got)
+	}
+	if got := a.players[trader.SteamID64].PlayerMapStats.MultiKills; got != (MultiKillRounds{}) {
+		t.Errorf("multi-kills = %+v, want none", got)
+	}
+	if len(a.roundSwing) != 0 {
+		t.Errorf("round swing was committed for setup round: %v", a.roundSwing)
+	}
+	if len(a.ecoKills) != 0 || len(a.ecoDamage) != 0 {
+		t.Errorf("rating kill/damage facts were committed for setup round: kills=%v damage=%v", a.ecoKills, a.ecoDamage)
+	}
+}
+
+func TestMVPFactsWaitForAuthoritativeScore(t *testing.T) {
+	eventMVP := player(1, "event-mvp", common.TeamTerrorists)
+	scoreboardMVP := player(2, "scoreboard-mvp", common.TeamCounterTerrorists)
+	scoreboardMVP.Entity = matchEntity{properties: map[string]st.PropertyValue{
+		"m_iMVPs": {Any: int32(1)},
+	}}
+	a := liveAnalyser(eventMVP, scoreboardMVP)
+	a.onRoundStart(events.RoundStart{})
+	a.onRoundMVP(events.RoundMVPAnnouncement{Player: eventMVP})
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
+	a.onRoundEndOfficial(events.RoundEndOfficial{})
+
+	// Starting again at the same score leaves both event and scoreboard facts
+	// uncommitted; the next scored-round slot belongs to the decided round.
+	a.onRoundStart(events.RoundStart{})
+	for _, id := range []uint64{eventMVP.SteamID64, scoreboardMVP.SteamID64} {
+		if got := a.players[id].PlayerMapStats.MVPs; got != 0 {
+			t.Errorf("setup MVPs for player %d = %d, want 0", id, got)
+		}
+	}
+
+	a.onRoundMVP(events.RoundMVPAnnouncement{Player: eventMVP})
+	endScoredRound(a, common.TeamTerrorists)
+	if got := a.players[eventMVP.SteamID64].PlayerMapStats.MVPs; got != 1 {
+		t.Errorf("event MVPs = %d, want 1", got)
+	}
+	if got := a.players[scoreboardMVP.SteamID64].PlayerMapStats.MVPs; got != 1 {
+		t.Errorf("scoreboard MVPs = %d, want 1", got)
+	}
+}
+
+func TestMVPAnnouncementAfterOfficialEndUsesFinalizedRound(t *testing.T) {
+	mvp := player(1, "mvp", common.TeamTerrorists)
+	opponent := player(11, "opponent", common.TeamCounterTerrorists)
+	a := liveAnalyser(mvp, opponent)
+	a.onRoundStart(events.RoundStart{})
+	endScoredRound(a, common.TeamTerrorists)
+
+	a.onRoundMVP(events.RoundMVPAnnouncement{Player: mvp})
+
+	if got := a.players[mvp.SteamID64].PlayerMapStats.MVPs; got != 1 {
+		t.Errorf("late event MVPs = %d, want 1", got)
+	}
+}
+
+func TestFinaliseAppliesLateScoreboardMVPUpdate(t *testing.T) {
+	mvp := player(1, "mvp", common.TeamTerrorists)
+	opponent := player(11, "opponent", common.TeamCounterTerrorists)
+	properties := map[string]st.PropertyValue{"m_iMVPs": {Any: int32(0)}}
+	mvp.Entity = matchEntity{properties: properties}
+	a := liveAnalyser(mvp, opponent)
+	a.onRoundStart(events.RoundStart{})
+	endScoredRound(a, common.TeamTerrorists)
+
+	properties["m_iMVPs"] = st.PropertyValue{Any: int32(1)}
+	a.finalise()
+
+	if got := a.players[mvp.SteamID64].PlayerMapStats.MVPs; got != 1 {
+		t.Errorf("late scoreboard MVPs = %d, want 1", got)
+	}
+}
+
+func TestFinaliseDoesNotApplyUnscoredScoreboardMVP(t *testing.T) {
+	mvp := player(1, "mvp", common.TeamTerrorists)
+	opponent := player(11, "opponent", common.TeamCounterTerrorists)
+	mvp.Entity = matchEntity{properties: map[string]st.PropertyValue{
+		"m_iMVPs": {Any: int32(1)},
+	}}
+	a := liveAnalyser(mvp, opponent)
+	a.onRoundStart(events.RoundStart{})
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
+	a.onRoundEndOfficial(events.RoundEndOfficial{})
+
+	a.finalise()
+
+	if got := a.players[mvp.SteamID64].PlayerMapStats.MVPs; got != 0 {
+		t.Errorf("unscored scoreboard MVPs = %d, want 0", got)
+	}
+}
+
+func TestHalftimeRoundCommitsAfterScoreAdvance(t *testing.T) {
+	shooter := player(shooterID, "shooter", common.TeamTerrorists)
+	victim := player(victimID, "victim", common.TeamCounterTerrorists)
+	parser := &matchParser{
+		playing:      []*common.Player{shooter, victim},
+		gamePhase:    common.GamePhaseStartGamePhase,
+		roundsPlayed: 11,
+		tickTime:     time.Second / 64,
+	}
+	a := newAnalyser(parser)
+	a.onRoundStart(events.RoundStart{})
+	a.onKill(events.Kill{Killer: shooter, Victim: victim, Weapon: &common.Equipment{Type: common.EqAK47}})
+
+	parser.gamePhase = common.GamePhaseGameHalfEnded
+	endScoredRound(a, common.TeamTerrorists)
+
+	if got := a.players[shooterID].SideStats.Rounds; got != (SideCount{Total: 1, T: 1}) {
+		t.Errorf("halftime rounds = %+v, want one T round", got)
+	}
+	if got := a.players[shooterID].OpeningDuelStats.OpeningKills.Total; got != 1 {
+		t.Errorf("halftime opening kills = %d, want 1", got)
+	}
+}
+
+func TestDelayedRoundCountDoesNotDiscardScoredRound(t *testing.T) {
+	shooter := player(shooterID, "shooter", common.TeamTerrorists)
+	victim := player(victimID, "victim", common.TeamCounterTerrorists)
+	a := liveAnalyser(shooter, victim)
+	p := a.parser.(*matchParser)
+	a.onRoundStart(events.RoundStart{})
+	a.onKill(events.Kill{
+		Killer: shooter, Victim: victim, Weapon: &common.Equipment{Type: common.EqAK47},
+	})
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
+	a.onRoundEndOfficial(events.RoundEndOfficial{})
+
+	// The next round begins before m_totalRoundsPlayed reflects round one.
+	a.onRoundStart(events.RoundStart{})
+	if got := a.players[shooterID].SideStats.Rounds.Total; got != 0 {
+		t.Fatalf("round committed before the delayed authoritative count: %d", got)
+	}
+
+	// When the property advances only once at round two's end, the oldest
+	// decided outcome (round one) consumes that slot.
+	p.roundsPlayed = 1
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamCounterTerrorists})
+	a.onRoundEndOfficial(events.RoundEndOfficial{})
+	if got := a.players[shooterID].SideStats.Rounds.Total; got != 1 {
+		t.Fatalf("rounds after delayed advance = %d, want 1", got)
+	}
+	if got := a.players[shooterID].OpeningDuelStats.OpeningKills.Total; got != 1 {
+		t.Fatalf("the first round's opening kill was lost: %d", got)
+	}
+
+	// A later observation catches the second round up without duplicating the
+	// first one's facts.
+	p.roundsPlayed = 2
+	a.onRoundStart(events.RoundStart{})
+	if got := a.players[shooterID].SideStats.Rounds.Total; got != 2 {
+		t.Errorf("rounds after catch-up = %d, want 2", got)
+	}
+	if got := a.players[shooterID].OpeningDuelStats.OpeningKills.Total; got != 1 {
+		t.Errorf("opening kill was duplicated during catch-up: %d", got)
+	}
+}
+
+func TestFinaliseFlushesLastScoredRoundWithoutOfficialEnd(t *testing.T) {
+	a, shooter, victim := liveRound()
+	a.onKill(events.Kill{Killer: shooter, Victim: victim, Weapon: &common.Equipment{Type: common.EqAK47}})
+	markRoundScored(a)
+	a.parser.(*matchParser).tScore = 1
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
+
+	a.finalise()
+
+	if got := a.mapData.TotalRounds; got != 1 {
+		t.Errorf("map rounds = %d, want 1", got)
+	}
+	if got := a.players[shooterID].SideStats.Rounds.Total; got != 1 {
+		t.Errorf("player rounds = %d, want 1", got)
+	}
+	if got := a.players[shooterID].OpeningDuelStats.OpeningKills.Total; got != 1 {
+		t.Errorf("opening kills = %d, want 1", got)
+	}
+}
+
+func TestDuplicateOfficialEndDoesNotCommitRoundTwice(t *testing.T) {
+	a, _, _ := liveRound()
+	endScoredRound(a, common.TeamCounterTerrorists)
+	a.onRoundEndOfficial(events.RoundEndOfficial{})
+
+	if got := a.players[shooterID].SideStats.Rounds.Total; got != 1 {
+		t.Errorf("player rounds = %d, want 1", got)
+	}
+	if got := a.kastRounds[shooterID].Total; got != 1 {
+		t.Errorf("KAST rounds = %d, want 1", got)
+	}
+}
+
 func TestNextRoundFinalizesDecidedRoundWithoutOfficialEndOnce(t *testing.T) {
 	a, shooter, victim := liveRound()
 	a.onKill(events.Kill{
 		Killer: shooter, Victim: victim, Weapon: &common.Equipment{Type: common.EqAK47},
 	})
+	markRoundScored(a)
 	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
 	a.onRoundStart(events.RoundStart{})
 
@@ -607,8 +1000,7 @@ func TestNextRoundFinalizesDecidedRoundWithoutOfficialEndOnce(t *testing.T) {
 		t.Fatalf("opening kills after fallback finalization = %d, want 1", got)
 	}
 
-	a.onRoundEnd(events.RoundEnd{Winner: common.TeamCounterTerrorists})
-	a.onRoundEndOfficial(events.RoundEndOfficial{})
+	endScoredRound(a, common.TeamCounterTerrorists)
 	if got := a.players[shooterID].SideStats.Rounds.Total; got != 2 {
 		t.Errorf("rounds after the next official end = %d, want 2", got)
 	}
@@ -624,8 +1016,7 @@ func TestOpeningDuelIsCredited(t *testing.T) {
 	a, shooter, victim := liveRound()
 
 	a.onKill(events.Kill{Killer: shooter, Victim: victim, Weapon: &common.Equipment{Type: common.EqAK47}})
-	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
-	a.onRoundEndOfficial(events.RoundEndOfficial{})
+	endScoredRound(a, common.TeamTerrorists)
 
 	kills := a.players[shooterID].OpeningDuelStats.OpeningKills
 	if kills.Total != 1 || kills.T != 1 || kills.CT != 0 {
@@ -647,8 +1038,7 @@ func playRound(a *analyser, winner common.Team, kills ...events.Kill) {
 	for _, kill := range kills {
 		a.onKill(kill)
 	}
-	a.onRoundEnd(events.RoundEnd{Winner: winner})
-	a.onRoundEndOfficial(events.RoundEndOfficial{})
+	endScoredRound(a, winner)
 }
 
 // hurtBy lands one hit for the given damage, starting the victim from full
@@ -720,16 +1110,14 @@ func TestSideAdrAndKastDivideByRoundsOnThatSide(t *testing.T) {
 		if round == 2 {
 			a.onKill(events.Kill{Killer: victim, Victim: shooter, Weapon: &common.Equipment{Type: common.EqAK47}})
 		}
-		a.onRoundEnd(events.RoundEnd{Winner: common.TeamCounterTerrorists})
-		a.onRoundEndOfficial(events.RoundEndOfficial{})
+		endScoredRound(a, common.TeamCounterTerrorists)
 	}
 
 	// Halftime, then a single round on CT with 60 damage and a survival.
 	shooter.Team, victim.Team = common.TeamCounterTerrorists, common.TeamTerrorists
 	a.onRoundStart(events.RoundStart{})
 	hurtBy(a, shooter, victim, 60)
-	a.onRoundEnd(events.RoundEnd{Winner: common.TeamCounterTerrorists})
-	a.onRoundEndOfficial(events.RoundEndOfficial{})
+	endScoredRound(a, common.TeamCounterTerrorists)
 
 	a.derive(4)
 
@@ -768,8 +1156,7 @@ func TestFreezeTimeJoinerPlaysTheRound(t *testing.T) {
 	joiner.Team = common.TeamTerrorists
 	a.onRoundFreezetimeEnd(events.RoundFreezetimeEnd{})
 	hurtBy(a, joiner, holder, 40)
-	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
-	a.onRoundEndOfficial(events.RoundEndOfficial{})
+	endScoredRound(a, common.TeamTerrorists)
 
 	a.derive(1)
 
@@ -799,8 +1186,7 @@ func TestBotOnBotKillDoesNotStealTheOpeningDuel(t *testing.T) {
 	a.onRoundStart(events.RoundStart{})
 	a.onKill(events.Kill{Killer: botT, Victim: botCT, Weapon: &common.Equipment{Type: common.EqAK47}})
 	a.onKill(events.Kill{Killer: shooter, Victim: victim, Weapon: &common.Equipment{Type: common.EqAK47}})
-	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
-	a.onRoundEndOfficial(events.RoundEndOfficial{})
+	endScoredRound(a, common.TeamTerrorists)
 
 	if got := a.players[shooterID].OpeningDuelStats.OpeningKills.Total; got != 0 {
 		t.Errorf("shooter opening kills = %d, want 0: the bot-on-bot kill opened the round first", got)
@@ -819,8 +1205,7 @@ func TestClutchGoesToTheTeamThatWonTheRound(t *testing.T) {
 	a.onRoundStart(events.RoundStart{})
 	a.onKill(events.Kill{Killer: lone, Victim: first, Weapon: &common.Equipment{Type: common.EqAK47}})
 	a.onKill(events.Kill{Killer: lone, Victim: second, Weapon: &common.Equipment{Type: common.EqAK47}})
-	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
-	a.onRoundEndOfficial(events.RoundEndOfficial{})
+	endScoredRound(a, common.TeamTerrorists)
 
 	if got := a.players[shooterID].PlayerMapStats.ClutchesWon; got != 1 {
 		t.Errorf("clutches won = %d, want 1", got)

--- a/cmd/demo_parser/hltv_regression_test.go
+++ b/cmd/demo_parser/hltv_regression_test.go
@@ -17,14 +17,17 @@ import (
 )
 
 const (
-	hltvDemoDirEnv        = "HLTV_DEMO_DIR"
-	requireHLTVDemosEnv   = "REQUIRE_HLTV_DEMOS"
-	hltvOracleFixturePath = "testdata/hltv-129241/expected.json"
-	adrMetric             = "ADR"
-	kastMetric            = "KAST qualifying rounds"
+	hltvDemoDirEnv          = "HLTV_DEMO_DIR"
+	requireHLTVDemosEnv     = "REQUIRE_HLTV_DEMOS"
+	hltvExtraDemoDirsEnv    = "HLTV_EXTRA_DEMO_DIRS"
+	requireHLTVExtraDemoEnv = "REQUIRE_HLTV_EXTRA_DEMOS"
+	hltvOracleFixturePath   = "testdata/hltv-129241/expected.json"
+	adrMetric               = "ADR"
+	kastMetric              = "KAST qualifying rounds"
 )
 
 type hltvOracle struct {
+	FixtureID     string            `json:"fixture_id"`
 	MatchID       int               `json:"match_id"`
 	MatchStatsURL string            `json:"match_stats_url"`
 	Maps          []hltvMapExpected `json:"maps"`
@@ -53,41 +56,88 @@ type hltvPlayerExpected struct {
 }
 
 type hltvDifferenceKey struct {
-	MapName string
-	SteamID uint64
-	Metric  string
+	FixtureID string
+	MapID     int
+	SteamID   uint64
+	Metric    string
+}
+
+type hltvFixtureMapKey struct {
+	FixtureID string
+	MapID     int
 }
 
 type hltvExpectedDifference struct {
-	MapName   string
+	FixtureID string
+	MapID     int
 	SteamID   uint64
 	Metric    string
 	HLTVValue string
 	ToolValue string
-	Issue     int
+	FollowUp  string
 }
 
 func (d hltvExpectedDifference) key() hltvDifferenceKey {
-	return hltvDifferenceKey{MapName: d.MapName, SteamID: d.SteamID, Metric: d.Metric}
+	return hltvDifferenceKey{
+		FixtureID: d.FixtureID,
+		MapID:     d.MapID,
+		SteamID:   d.SteamID,
+		Metric:    d.Metric,
+	}
 }
 
 // These are known parser differences, not tolerances. Each row pins both
 // sides of the current discrepancy: a new value fails, and reaching parity
 // also fails until the stale exception is removed.
 var hltvExpectedDifferences = []hltvExpectedDifference{
-	{MapName: "inferno", SteamID: 76561198158971650, Metric: kastMetric, HLTVValue: "17/22 (77.3%)", ToolValue: "18/22 (81.8%)", Issue: 38},
-	{MapName: "inferno", SteamID: 76561198050779850, Metric: kastMetric, HLTVValue: "14/22 (63.6%)", ToolValue: "16/22 (72.7%)", Issue: 38},
-	{MapName: "inferno", SteamID: 76561198127259887, Metric: kastMetric, HLTVValue: "14/22 (63.6%)", ToolValue: "15/22 (68.2%)", Issue: 38},
-	{MapName: "inferno", SteamID: 76561198081702155, Metric: kastMetric, HLTVValue: "15/22 (68.2%)", ToolValue: "16/22 (72.7%)", Issue: 38},
-	{MapName: "inferno", SteamID: 76561198044112269, Metric: kastMetric, HLTVValue: "16/22 (72.7%)", ToolValue: "18/22 (81.8%)", Issue: 38},
-	{MapName: "inferno", SteamID: 76561199048086137, Metric: kastMetric, HLTVValue: "18/22 (81.8%)", ToolValue: "17/22 (77.3%)", Issue: 38},
-	{MapName: "inferno", SteamID: 76561198226777692, Metric: kastMetric, HLTVValue: "15/22 (68.2%)", ToolValue: "16/22 (72.7%)", Issue: 38},
-	{MapName: "inferno", SteamID: 76561198208618504, Metric: kastMetric, HLTVValue: "16/22 (72.7%)", ToolValue: "17/22 (77.3%)", Issue: 38},
-	{MapName: "anubis", SteamID: 76561198081702155, Metric: kastMetric, HLTVValue: "13/19 (68.4%)", ToolValue: "12/19 (63.2%)", Issue: 38},
-	{MapName: "anubis", SteamID: 76561198108660703, Metric: kastMetric, HLTVValue: "14/19 (73.7%)", ToolValue: "15/19 (78.9%)", Issue: 38},
-	{MapName: "anubis", SteamID: 76561198044112269, Metric: kastMetric, HLTVValue: "15/19 (78.9%)", ToolValue: "16/19 (84.2%)", Issue: 38},
-	{MapName: "mirage", SteamID: 76561198108660703, Metric: kastMetric, HLTVValue: "17/23 (73.9%)", ToolValue: "18/23 (78.3%)", Issue: 38},
-	{MapName: "mirage", SteamID: 76561199048086137, Metric: kastMetric, HLTVValue: "17/23 (73.9%)", ToolValue: "19/23 (82.6%)", Issue: 38},
+	{
+		FixtureID: "match-129241", MapID: 234944, SteamID: 76561199048086137,
+		Metric: kastMetric, HLTVValue: "18/22 (81.8%)", ToolValue: "17/22 (77.3%)", FollowUp: "issue #38",
+	},
+	{
+		FixtureID: "match-128974", MapID: 234227, SteamID: 76561198081484775,
+		Metric: adrMetric, HLTVValue: "49.6", ToolValue: "49.5", FollowUp: "ADR rounding follow-up",
+	},
+	{
+		FixtureID: "match-128974", MapID: 234227, SteamID: 76561198310561479,
+		Metric: adrMetric, HLTVValue: "108.7", ToolValue: "108.8", FollowUp: "ADR rounding follow-up",
+	},
+	{
+		FixtureID: "match-128974", MapID: 234233, SteamID: 76561198081484775,
+		Metric: adrMetric, HLTVValue: "59.6", ToolValue: "59.7", FollowUp: "ADR rounding follow-up",
+	},
+	{
+		FixtureID: "match-128974", MapID: 234238, SteamID: 76561198998266210,
+		Metric: adrMetric, HLTVValue: "64.8", ToolValue: "64.9", FollowUp: "ADR rounding follow-up",
+	},
+	{
+		FixtureID: "match-128974", MapID: 234256, SteamID: 76561198193174134,
+		Metric: adrMetric, HLTVValue: "81.4", ToolValue: "81.5", FollowUp: "ADR rounding follow-up",
+	},
+	{
+		FixtureID: "match-128974", MapID: 234256, SteamID: 76561198310561479,
+		Metric: adrMetric, HLTVValue: "76.5", ToolValue: "76.6", FollowUp: "ADR rounding follow-up",
+	},
+	{
+		FixtureID: "match-2396559", MapID: 234956, SteamID: 76561199024583803,
+		Metric: adrMetric, HLTVValue: "63.9", ToolValue: "64.0", FollowUp: "ADR rounding follow-up",
+	},
+	{
+		FixtureID: "match-2396559", MapID: 234956, SteamID: 76561199063238565,
+		Metric: kastMetric, HLTVValue: "18/23 (78.3%)", ToolValue: "17/23 (73.9%)", FollowUp: "issue #38",
+	},
+}
+
+type hltvOracleSpec struct {
+	Path         string
+	ExpectedMaps int
+	Extra        bool
+}
+
+var hltvOracleSpecs = []hltvOracleSpec{
+	{Path: hltvOracleFixturePath, ExpectedMaps: 3},
+	{Path: "testdata/hltv-128974/expected.json", ExpectedMaps: 4, Extra: true},
+	{Path: "testdata/hltv-2396559/expected.json", ExpectedMaps: 1, Extra: true},
 }
 
 type ratingObservation struct {
@@ -113,69 +163,147 @@ type hltvParity struct {
 }
 
 func TestHLTVRegression(t *testing.T) {
-	oracle := loadHLTVOracle(t)
-	demoDir := os.Getenv(hltvDemoDirEnv)
-	requireDemos := os.Getenv(requireHLTVDemosEnv) != ""
-	if demoDir == "" {
-		if requireDemos {
-			t.Fatalf("%s is set but %s is empty; point it at the directory containing the three match 129241 demos",
-				requireHLTVDemosEnv, hltvDemoDirEnv)
+	oracles := make([]hltvOracle, len(hltvOracleSpecs))
+	for i, spec := range hltvOracleSpecs {
+		oracles[i] = loadHLTVOracle(t, spec.Path)
+	}
+	validateHLTVOracleSet(t, hltvOracleSpecs, oracles)
+	validateHLTVExpectedDifferences(t, oracles)
+
+	originalDirs := configuredDemoDirs(os.Getenv(hltvDemoDirEnv))
+	extraDirs := configuredDemoDirs(os.Getenv(hltvExtraDemoDirsEnv))
+	requireOriginal := os.Getenv(requireHLTVDemosEnv) != ""
+	requireExtra := os.Getenv(requireHLTVExtraDemoEnv) != ""
+	if requireOriginal && len(originalDirs) == 0 {
+		t.Fatalf("%s is set but %s is empty; point it at the directory containing the three match 129241 demos",
+			requireHLTVDemosEnv, hltvDemoDirEnv)
+	}
+	if requireExtra && len(extraDirs) == 0 {
+		t.Fatalf("%s is set but %s is empty; provide an OS path-list containing the five additional demos",
+			requireHLTVExtraDemoEnv, hltvExtraDemoDirsEnv)
+	}
+
+	var originalRatings, extraRatings []ratingObservation
+	var originalParity, extraParity hltvParity
+	for i, spec := range hltvOracleSpecs {
+		oracle := oracles[i]
+		dirs := originalDirs
+		required := requireOriginal
+		requireEnv := requireHLTVDemosEnv
+		if spec.Extra {
+			dirs = extraDirs
+			required = requireExtra
+			requireEnv = requireHLTVExtraDemoEnv
 		}
-		t.Skipf("HLTV regression demos are not configured; set %s to run the external-oracle harness", hltvDemoDirEnv)
+
+		for _, expectedMap := range oracle.Maps {
+			testName := expectedMap.Name
+			if spec.Extra {
+				testName = fmt.Sprintf("extra/%s/%s-%d", oracle.FixtureID, expectedMap.Name, expectedMap.MapID)
+			}
+			t.Run(testName, func(t *testing.T) {
+				if len(dirs) == 0 {
+					t.Skipf("HLTV demos are not configured; set %s to run this external-oracle fixture", demoDirsEnv(spec.Extra))
+				}
+				demoPath, err := findDemo(dirs, expectedMap.DemoFile)
+				if err != nil {
+					if errors.Is(err, os.ErrNotExist) && !required {
+						t.Skipf("HLTV demo %s is absent; set %s to make missing demos fail", expectedMap.DemoFile, requireEnv)
+					}
+					t.Fatalf("locating HLTV demo: %v", err)
+				}
+				if err := verifyDemoChecksum(demoPath, expectedMap.DemoSHA256); err != nil {
+					t.Fatalf("verifying HLTV demo: %v", err)
+				}
+
+				result, err := ProcessDemo(demoPath)
+				if err != nil {
+					t.Fatalf("ProcessDemo(%s): %v", expectedMap.DemoFile, err)
+				}
+
+				assertHLTVMap(t, oracle.FixtureID, result, expectedMap)
+				assertHLTVRoster(t, oracle.FixtureID, result.Players, expectedMap)
+				for _, expectedPlayer := range expectedMap.Players {
+					player := result.Players[expectedPlayer.SteamID]
+					assertHLTVPlayer(t, oracle.FixtureID, expectedMap, expectedPlayer, player)
+					parity := &originalParity
+					ratings := &originalRatings
+					if spec.Extra {
+						parity = &extraParity
+						ratings = &extraRatings
+					}
+					observeHLTVParity(parity, player, expectedMap, expectedPlayer)
+					*ratings = append(*ratings, ratingObservation{
+						Tool: displayedRating(player.Rating.Value),
+						HLTV: expectedPlayer.Rating,
+					})
+				}
+			})
+		}
 	}
 
-	var ratings []ratingObservation
-	var parity hltvParity
-	for _, expectedMap := range oracle.Maps {
-		t.Run(expectedMap.Name, func(t *testing.T) {
-			demoPath := filepath.Join(demoDir, expectedMap.DemoFile)
-			if err := verifyDemoChecksum(demoPath, expectedMap.DemoSHA256); err != nil {
-				if errors.Is(err, os.ErrNotExist) && !requireDemos {
-					t.Skipf("HLTV demo %s is absent; set %s to make missing demos fail", demoPath, requireHLTVDemosEnv)
-				}
-				t.Fatalf("verifying HLTV demo: %v", err)
-			}
+	logHLTVParity(t, "original fixture", originalParity, originalRatings)
+	logHLTVParity(t, "additional fixtures", extraParity, extraRatings)
+}
 
-			result, err := ProcessDemo(demoPath)
-			if err != nil {
-				t.Fatalf("ProcessDemo(%s): %v", expectedMap.DemoFile, err)
-			}
-
-			assertHLTVMap(t, result, expectedMap)
-			assertHLTVRoster(t, result.Players, expectedMap)
-			for _, expectedPlayer := range expectedMap.Players {
-				player := result.Players[expectedPlayer.SteamID]
-				assertHLTVPlayer(t, expectedMap, expectedPlayer, player)
-				if player.KillStats.Total == expectedPlayer.Kills {
-					parity.Kills++
-				}
-				if player.Deaths == expectedPlayer.Deaths {
-					parity.Deaths++
-				}
-				if fmt.Sprintf("%.1f", player.AssistStats.ADR) == fmt.Sprintf("%.1f", expectedPlayer.ADR) {
-					parity.ADR++
-				}
-				if kastRounds(player.PlayerMapStats.KAST, expectedMap.Rounds) ==
-					kastRounds(expectedPlayer.KASTPercent, expectedMap.Rounds) {
-					parity.KAST++
-				}
-				ratings = append(ratings, ratingObservation{
-					Tool: displayedRating(player.Rating.Value),
-					HLTV: expectedPlayer.Rating,
-				})
-			}
-		})
+func configuredDemoDirs(value string) []string {
+	var dirs []string
+	for _, dir := range filepath.SplitList(value) {
+		if dir = strings.TrimSpace(dir); dir != "" {
+			dirs = append(dirs, dir)
+		}
 	}
+	return dirs
+}
 
-	if len(ratings) > 0 {
-		rows := len(ratings)
-		t.Logf("HLTV parity (%d player-maps): kills=%d/%d deaths=%d/%d ADR=%d/%d KAST=%d/%d",
-			rows, parity.Kills, rows, parity.Deaths, rows, parity.ADR, rows, parity.KAST, rows)
-		quality := summarizeRatingQuality(ratings)
-		t.Logf("Rating 3.0 quality (%d player-maps): MAE=%.3f RMSE=%.3f bias=%+.3f Spearman=%.3f; within ±0.05=%d, ±0.10=%d, ±0.20=%d",
-			rows, quality.MAE, quality.RMSE, quality.Bias, quality.Spearman,
-			quality.Within005, quality.Within010, quality.Within020)
+func demoDirsEnv(extra bool) string {
+	if extra {
+		return hltvExtraDemoDirsEnv
 	}
+	return hltvDemoDirEnv
+}
+
+func findDemo(dirs []string, name string) (string, error) {
+	for _, dir := range dirs {
+		path := filepath.Join(dir, name)
+		_, err := os.Stat(path)
+		if err == nil {
+			return path, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("checking %s: %w", path, err)
+		}
+	}
+	return "", fmt.Errorf("%s not found in %v: %w", name, dirs, os.ErrNotExist)
+}
+
+func observeHLTVParity(parity *hltvParity, player *DemoPlayer, expectedMap hltvMapExpected, expected hltvPlayerExpected) {
+	if player.KillStats.Total == expected.Kills {
+		parity.Kills++
+	}
+	if player.Deaths == expected.Deaths {
+		parity.Deaths++
+	}
+	if fmt.Sprintf("%.1f", player.AssistStats.ADR) == fmt.Sprintf("%.1f", expected.ADR) {
+		parity.ADR++
+	}
+	if kastRounds(player.PlayerMapStats.KAST, expectedMap.Rounds) == kastRounds(expected.KASTPercent, expectedMap.Rounds) {
+		parity.KAST++
+	}
+}
+
+func logHLTVParity(t *testing.T, label string, parity hltvParity, ratings []ratingObservation) {
+	t.Helper()
+	if len(ratings) == 0 {
+		return
+	}
+	rows := len(ratings)
+	t.Logf("HLTV parity, %s (%d player-maps): kills=%d/%d deaths=%d/%d ADR=%d/%d KAST=%d/%d",
+		label, rows, parity.Kills, rows, parity.Deaths, rows, parity.ADR, rows, parity.KAST, rows)
+	quality := summarizeRatingQuality(ratings)
+	t.Logf("Rating 3.0 quality, %s (%d player-maps): MAE=%.3f RMSE=%.3f bias=%+.3f Spearman=%.3f; within ±0.05=%d, ±0.10=%d, ±0.20=%d",
+		label, rows, quality.MAE, quality.RMSE, quality.Bias, quality.Spearman,
+		quality.Within005, quality.Within010, quality.Within020)
 }
 
 func TestSummarizeRatingQuality(t *testing.T) {
@@ -223,6 +351,20 @@ func TestKASTRounds(t *testing.T) {
 	}
 }
 
+func TestHLTVDifferenceKeyIncludesFixtureIdentity(t *testing.T) {
+	base := hltvExpectedDifference{
+		FixtureID: "fixture-a", MapID: 1, SteamID: 2, Metric: adrMetric,
+	}
+	keys := map[hltvDifferenceKey]bool{
+		base.key(): true,
+		(hltvExpectedDifference{FixtureID: "fixture-b", MapID: 1, SteamID: 2, Metric: adrMetric}).key(): true,
+		(hltvExpectedDifference{FixtureID: "fixture-a", MapID: 3, SteamID: 2, Metric: adrMetric}).key(): true,
+	}
+	if len(keys) != 3 {
+		t.Fatalf("fixture/map identities collapsed into %d expected-difference keys, want 3", len(keys))
+	}
+}
+
 func TestSpearmanRankCorrelation(t *testing.T) {
 	tests := []struct {
 		name string
@@ -243,82 +385,127 @@ func TestSpearmanRankCorrelation(t *testing.T) {
 	}
 }
 
-func loadHLTVOracle(t *testing.T) hltvOracle {
+func loadHLTVOracle(t *testing.T, path string) hltvOracle {
 	t.Helper()
-	data, err := os.ReadFile(hltvOracleFixturePath)
+	data, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("reading HLTV oracle fixture: %v", err)
+		t.Fatalf("reading HLTV oracle fixture %s: %v", path, err)
 	}
 	var oracle hltvOracle
 	decoder := json.NewDecoder(strings.NewReader(string(data)))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&oracle); err != nil {
-		t.Fatalf("decoding HLTV oracle fixture: %v", err)
+		t.Fatalf("decoding HLTV oracle fixture %s: %v", path, err)
 	}
-	validateHLTVOracle(t, oracle)
+	validateHLTVOracle(t, path, oracle)
 	return oracle
 }
 
-func validateHLTVOracle(t *testing.T, oracle hltvOracle) {
+func validateHLTVOracle(t *testing.T, path string, oracle hltvOracle) {
 	t.Helper()
-	if oracle.MatchID != 129241 {
-		t.Fatalf("HLTV oracle match_id = %d, want 129241", oracle.MatchID)
+	if oracle.FixtureID == "" {
+		t.Fatalf("HLTV oracle %s has an empty fixture_id", path)
 	}
-	if len(oracle.Maps) != 3 {
-		t.Fatalf("HLTV oracle has %d maps, want 3", len(oracle.Maps))
+	if oracle.MatchID == 0 || oracle.MatchStatsURL == "" {
+		t.Fatalf("HLTV oracle %s is missing match metadata", path)
+	}
+	if len(oracle.Maps) == 0 {
+		t.Fatalf("HLTV oracle %s has no maps", path)
 	}
 
-	mapsByName := make(map[string]hltvMapExpected, len(oracle.Maps))
+	mapsByID := make(map[int]hltvMapExpected, len(oracle.Maps))
 	for _, expectedMap := range oracle.Maps {
-		if _, exists := mapsByName[expectedMap.Name]; exists {
-			t.Fatalf("HLTV oracle repeats map %q", expectedMap.Name)
+		if expectedMap.MapID == 0 || expectedMap.MapStatsURL == "" || expectedMap.DemoSHA256 == "" {
+			t.Fatalf("HLTV oracle %s map %q is missing source metadata", path, expectedMap.Name)
 		}
-		mapsByName[expectedMap.Name] = expectedMap
+		if _, exists := mapsByID[expectedMap.MapID]; exists {
+			t.Fatalf("HLTV oracle %s repeats map ID %d", path, expectedMap.MapID)
+		}
+		mapsByID[expectedMap.MapID] = expectedMap
 		if len(expectedMap.Players) != 10 {
-			t.Fatalf("HLTV oracle map %s has %d players, want 10", expectedMap.Name, len(expectedMap.Players))
+			t.Fatalf("HLTV oracle %s map %s has %d players, want 10", path, expectedMap.Name, len(expectedMap.Players))
 		}
 		seenPlayers := make(map[uint64]bool, len(expectedMap.Players))
 		for _, player := range expectedMap.Players {
 			if player.SteamID == 0 {
-				t.Fatalf("HLTV oracle map %s contains a zero SteamID", expectedMap.Name)
+				t.Fatalf("HLTV oracle %s map %s contains a zero SteamID", path, expectedMap.Name)
 			}
 			if seenPlayers[player.SteamID] {
-				t.Fatalf("HLTV oracle map %s repeats SteamID %d", expectedMap.Name, player.SteamID)
+				t.Fatalf("HLTV oracle %s map %s repeats SteamID %d", path, expectedMap.Name, player.SteamID)
 			}
 			seenPlayers[player.SteamID] = true
 		}
 	}
+}
 
+func validateHLTVOracleSet(t *testing.T, specs []hltvOracleSpec, oracles []hltvOracle) {
+	t.Helper()
+	if len(specs) != len(oracles) {
+		t.Fatalf("HLTV oracle specs = %d, loaded oracles = %d", len(specs), len(oracles))
+	}
+	seenFixtures := make(map[string]bool, len(oracles))
+	totalMaps, totalRows := 0, 0
+	for i, oracle := range oracles {
+		if seenFixtures[oracle.FixtureID] {
+			t.Fatalf("HLTV oracles repeat fixture_id %q", oracle.FixtureID)
+		}
+		seenFixtures[oracle.FixtureID] = true
+		if got, want := len(oracle.Maps), specs[i].ExpectedMaps; got != want {
+			t.Fatalf("HLTV oracle %s has %d maps, want %d", specs[i].Path, got, want)
+		}
+		totalMaps += len(oracle.Maps)
+		for _, expectedMap := range oracle.Maps {
+			totalRows += len(expectedMap.Players)
+		}
+	}
+	if totalMaps != 8 || totalRows != 80 {
+		t.Fatalf("HLTV oracle coverage = %d maps/%d player-maps, want 8/80", totalMaps, totalRows)
+	}
+}
+
+func validateHLTVExpectedDifferences(t *testing.T, oracles []hltvOracle) {
+	t.Helper()
+	mapsByKey := make(map[hltvFixtureMapKey]hltvMapExpected)
+	for _, oracle := range oracles {
+		for _, expectedMap := range oracle.Maps {
+			key := hltvFixtureMapKey{FixtureID: oracle.FixtureID, MapID: expectedMap.MapID}
+			if _, exists := mapsByKey[key]; exists {
+				t.Fatalf("HLTV oracles repeat fixture/map key %s/%d", oracle.FixtureID, expectedMap.MapID)
+			}
+			mapsByKey[key] = expectedMap
+		}
+	}
 	seenDifferences := make(map[hltvDifferenceKey]bool, len(hltvExpectedDifferences))
 	for _, difference := range hltvExpectedDifferences {
 		if seenDifferences[difference.key()] {
 			t.Fatalf("expected-difference table repeats %+v", difference.key())
 		}
 		seenDifferences[difference.key()] = true
-		expectedMap, exists := mapsByName[difference.MapName]
+		expectedMap, exists := mapsByKey[hltvFixtureMapKey{FixtureID: difference.FixtureID, MapID: difference.MapID}]
 		if !exists {
-			t.Fatalf("expected difference references unknown map %q", difference.MapName)
+			t.Fatalf("expected difference references unknown fixture/map %q/%d", difference.FixtureID, difference.MapID)
 		}
 		expectedPlayer, exists := findExpectedPlayer(expectedMap, difference.SteamID)
 		if !exists {
-			t.Fatalf("expected difference references unknown SteamID %d on %s", difference.SteamID, difference.MapName)
+			t.Fatalf("expected difference references unknown SteamID %d on %s/%d",
+				difference.SteamID, difference.FixtureID, difference.MapID)
 		}
 		wantValue := expectedMetricValue(t, expectedMap, expectedPlayer, difference.Metric)
 		if difference.HLTVValue != wantValue {
-			t.Fatalf("expected difference %s/%d/%s has HLTV value %q, fixture says %q",
-				difference.MapName, difference.SteamID, difference.Metric, difference.HLTVValue, wantValue)
+			t.Fatalf("expected difference %s/%d/%d/%s has HLTV value %q, fixture says %q",
+				difference.FixtureID, difference.MapID, difference.SteamID, difference.Metric, difference.HLTVValue, wantValue)
 		}
 		if difference.ToolValue == difference.HLTVValue {
-			t.Fatalf("expected difference %s/%d/%s has identical HLTV and tool values %q",
-				difference.MapName, difference.SteamID, difference.Metric, difference.HLTVValue)
+			t.Fatalf("expected difference %s/%d/%d/%s has identical HLTV and tool values %q",
+				difference.FixtureID, difference.MapID, difference.SteamID, difference.Metric, difference.HLTVValue)
 		}
-		if difference.Metric != kastMetric {
-			t.Fatalf("expected difference %s/%d uses unsupported metric %q; only issue #38 KAST differences are allowed",
-				difference.MapName, difference.SteamID, difference.Metric)
+		if difference.Metric != adrMetric && difference.Metric != kastMetric {
+			t.Fatalf("expected difference %s/%d/%d uses unsupported metric %q",
+				difference.FixtureID, difference.MapID, difference.SteamID, difference.Metric)
 		}
-		if difference.Issue != 38 {
-			t.Fatalf("expected difference %s/%d/%s points to issue #%d", difference.MapName,
-				difference.SteamID, difference.Metric, difference.Issue)
+		if difference.FollowUp == "" {
+			t.Fatalf("expected difference %s/%d/%d/%s has no follow-up reference",
+				difference.FixtureID, difference.MapID, difference.SteamID, difference.Metric)
 		}
 	}
 }
@@ -336,27 +523,28 @@ func verifyDemoChecksum(path, want string) error {
 	}
 	got := hex.EncodeToString(hash.Sum(nil))
 	if got != want {
-		return fmt.Errorf("%s has SHA-256 %s, want %s; use the exact match 129241 demo", path, got, want)
+		return fmt.Errorf("%s has SHA-256 %s, want %s; use the exact audited demo named by the oracle", path, got, want)
 	}
 	return nil
 }
 
-func assertHLTVMap(t *testing.T, result *ProcessedDemo, expected hltvMapExpected) {
+func assertHLTVMap(t *testing.T, fixtureID string, result *ProcessedDemo, expected hltvMapExpected) {
 	t.Helper()
+	label := fmt.Sprintf("%s/%d/%s", fixtureID, expected.MapID, expected.Name)
 	if result.Map.MapName != expected.ParserMapName {
-		t.Errorf("map name = %q, want %q", result.Map.MapName, expected.ParserMapName)
+		t.Errorf("%s map name = %q, want %q", label, result.Map.MapName, expected.ParserMapName)
 	}
 	if result.Map.TotalRounds != expected.Rounds {
-		t.Errorf("%s rounds = %d, want %d", expected.Name, result.Map.TotalRounds, expected.Rounds)
+		t.Errorf("%s rounds = %d, want %d", label, result.Map.TotalRounds, expected.Rounds)
 	}
 	gotScore := sortedScore(result.Map.RoundsWonCT, result.Map.RoundsWonT)
 	wantScore := sortedScore(expected.ScoreValues[0], expected.ScoreValues[1])
 	if gotScore != wantScore {
-		t.Errorf("%s score values = %v, want %v", expected.Name, gotScore, wantScore)
+		t.Errorf("%s score values = %v, want %v", label, gotScore, wantScore)
 	}
 }
 
-func assertHLTVRoster(t *testing.T, players map[uint64]*DemoPlayer, expected hltvMapExpected) {
+func assertHLTVRoster(t *testing.T, fixtureID string, players map[uint64]*DemoPlayer, expected hltvMapExpected) {
 	t.Helper()
 	expectedPlayers := make(map[uint64]string, len(expected.Players))
 	for _, player := range expected.Players {
@@ -377,30 +565,32 @@ func assertHLTVRoster(t *testing.T, players map[uint64]*DemoPlayer, expected hlt
 	sort.Strings(missing)
 	sort.Strings(unexpected)
 	if len(players) != 10 || len(missing) > 0 || len(unexpected) > 0 {
-		t.Fatalf("%s roster mismatch: got %d players; missing=%v unexpected=%v", expected.Name,
+		t.Fatalf("%s/%d/%s roster mismatch: got %d players; missing=%v unexpected=%v",
+			fixtureID, expected.MapID, expected.Name,
 			len(players), missing, unexpected)
 	}
 }
 
-func assertHLTVPlayer(t *testing.T, expectedMap hltvMapExpected, expected hltvPlayerExpected, player *DemoPlayer) {
+func assertHLTVPlayer(t *testing.T, fixtureID string, expectedMap hltvMapExpected, expected hltvPlayerExpected, player *DemoPlayer) {
 	t.Helper()
 	if player.SteamID != expected.SteamID {
-		t.Errorf("%s/%s SteamID = %d, want %d", expectedMap.Name, expected.HLTVName, player.SteamID, expected.SteamID)
+		t.Errorf("%s/%d/%s SteamID = %d, want %d",
+			fixtureID, expectedMap.MapID, expected.HLTVName, player.SteamID, expected.SteamID)
 	}
 	if player.KillStats.Total != expected.Kills {
-		t.Errorf("%s/%s (%d) kills = %d, HLTV %d", expectedMap.Name, expected.HLTVName,
+		t.Errorf("%s/%d/%s (%d) kills = %d, HLTV %d", fixtureID, expectedMap.MapID, expected.HLTVName,
 			expected.SteamID, player.KillStats.Total, expected.Kills)
 	}
 	if player.Deaths != expected.Deaths {
-		t.Errorf("%s/%s (%d) deaths = %d, HLTV %d", expectedMap.Name, expected.HLTVName,
+		t.Errorf("%s/%d/%s (%d) deaths = %d, HLTV %d", fixtureID, expectedMap.MapID, expected.HLTVName,
 			expected.SteamID, player.Deaths, expected.Deaths)
 	}
 
-	assertHLTVMetric(t, hltvDifferenceKey{expectedMap.Name, expected.SteamID, adrMetric},
+	assertHLTVMetric(t, hltvDifferenceKey{fixtureID, expectedMap.MapID, expected.SteamID, adrMetric},
 		fmt.Sprintf("%.1f", expected.ADR), fmt.Sprintf("%.1f", player.AssistStats.ADR), expected.HLTVName)
 	wantKASTRounds := kastRounds(expected.KASTPercent, expectedMap.Rounds)
 	gotKASTRounds := kastRounds(player.PlayerMapStats.KAST, expectedMap.Rounds)
-	assertHLTVMetric(t, hltvDifferenceKey{expectedMap.Name, expected.SteamID, kastMetric},
+	assertHLTVMetric(t, hltvDifferenceKey{fixtureID, expectedMap.MapID, expected.SteamID, kastMetric},
 		formatKAST(wantKASTRounds, expectedMap.Rounds, expected.KASTPercent),
 		formatKAST(gotKASTRounds, expectedMap.Rounds, player.PlayerMapStats.KAST), expected.HLTVName)
 }
@@ -410,23 +600,24 @@ func assertHLTVMetric(t *testing.T, key hltvDifferenceKey, want, got, hltvName s
 	difference, known := findExpectedDifference(key)
 	if !known {
 		if got != want {
-			t.Errorf("%s/%s (%d) %s = %s, HLTV %s", key.MapName, hltvName, key.SteamID, key.Metric, got, want)
+			t.Errorf("%s/%d/%s (%d) %s = %s, HLTV %s",
+				key.FixtureID, key.MapID, hltvName, key.SteamID, key.Metric, got, want)
 		}
 		return
 	}
 	if difference.HLTVValue != want {
-		t.Fatalf("%s/%s (%d) %s exception says HLTV %s, fixture says %s",
-			key.MapName, hltvName, key.SteamID, key.Metric, difference.HLTVValue, want)
+		t.Fatalf("%s/%d/%s (%d) %s exception says HLTV %s, fixture says %s",
+			key.FixtureID, key.MapID, hltvName, key.SteamID, key.Metric, difference.HLTVValue, want)
 	}
 	if got == want {
-		t.Errorf("%s/%s (%d) %s now matches HLTV at %s; remove the stale issue #%d exception and promote this row to strict parity",
-			key.MapName, hltvName, key.SteamID, key.Metric, got, difference.Issue)
+		t.Errorf("%s/%d/%s (%d) %s now matches HLTV at %s; remove the stale exception (%s) and promote this row to strict parity",
+			key.FixtureID, key.MapID, hltvName, key.SteamID, key.Metric, got, difference.FollowUp)
 		return
 	}
 	if got != difference.ToolValue {
-		t.Errorf("%s/%s (%d) %s = %s, want current tool value %s (HLTV %s, issue #%d)",
-			key.MapName, hltvName, key.SteamID, key.Metric, got, difference.ToolValue,
-			difference.HLTVValue, difference.Issue)
+		t.Errorf("%s/%d/%s (%d) %s = %s, want current tool value %s (HLTV %s; %s)",
+			key.FixtureID, key.MapID, hltvName, key.SteamID, key.Metric, got, difference.ToolValue,
+			difference.HLTVValue, difference.FollowUp)
 	}
 }
 

--- a/cmd/demo_parser/hltv_trace_test.go
+++ b/cmd/demo_parser/hltv_trace_test.go
@@ -1,0 +1,333 @@
+package demoparser
+
+import (
+	"fmt"
+	"maps"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	demoinfocs "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
+	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
+	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
+)
+
+const (
+	hltvTraceDemoEnv    = "HLTV_TRACE_DEMO"
+	hltvTraceSteamIDEnv = "HLTV_TRACE_STEAM_ID"
+)
+
+type hltvRoundTrace struct {
+	startedAtRound   int
+	tickTime         time.Duration
+	participants     map[uint64]common.Team
+	kills            []hltvKillTrace
+	disconnects      []hltvDisconnectTrace
+	enemyKills       map[uint64]int
+	assists          map[uint64]assistFacts
+	traded           map[uint64]bool
+	damageAssists    map[uint64]bool
+	survivedRoundEnd map[uint64]bool
+	survivedOfficial map[uint64]bool
+	finalAlive       map[uint64]bool
+	winner           common.Team
+}
+
+type hltvKillTrace struct {
+	frame         int
+	tick          int
+	at            time.Duration
+	killer        uint64
+	killerName    string
+	killerTeam    common.Team
+	victim        uint64
+	victimName    string
+	victimTeam    common.Team
+	assisterName  string
+	assistedFlash bool
+	cause         string
+	postRound     bool
+}
+
+type hltvDisconnectTrace struct {
+	frame  int
+	tick   int
+	player uint64
+	name   string
+}
+
+// TestTraceHLTVRoundEvidence is an opt-in, read-only diagnostic. It records
+// the event-level facts used by classic KAST without adding trace-only state
+// to production. Set HLTV_TRACE_STEAM_ID to focus the output on one player;
+// omit it to print every participant's final round reasons.
+func TestTraceHLTVRoundEvidence(t *testing.T) {
+	demoPath := os.Getenv(hltvTraceDemoEnv)
+	if demoPath == "" {
+		t.Skipf("set %s to trace one external demo", hltvTraceDemoEnv)
+	}
+	target := parseTraceSteamID(t, os.Getenv(hltvTraceSteamIDEnv))
+
+	file, err := os.Open(demoPath)
+	if err != nil {
+		t.Fatalf("opening trace demo: %v", err)
+	}
+	defer file.Close()
+
+	parser := demoinfocs.NewParser(file)
+	defer parser.Close()
+	analysis := newAnalyser(parser)
+	analysis.registerHandlers()
+
+	var current *hltvRoundTrace
+	var names = make(map[uint64]string)
+	finishCurrent := func(totalRounds int) {
+		if current == nil {
+			return
+		}
+		scored := totalRounds > current.startedAtRound
+		logHLTVRoundTrace(t, current, scored, target, names)
+		current = nil
+	}
+	snapshot := func() {
+		if current == nil {
+			return
+		}
+		current.participants = maps.Clone(analysis.tracker.startAlive)
+		current.enemyKills = maps.Clone(analysis.tracker.enemyKills)
+		current.assists = maps.Clone(analysis.tracker.assists)
+		current.traded = maps.Clone(analysis.tracker.traded)
+		current.damageAssists = maps.Clone(analysis.tracker.damageAssists)
+		current.finalAlive = aliveSet(analysis.tracker.alive)
+	}
+	parser.RegisterEventHandler(func(events.RoundStart) {
+		state := parser.GameState()
+		finishCurrent(state.TotalRoundsPlayed())
+		current = &hltvRoundTrace{
+			startedAtRound: state.TotalRoundsPlayed(),
+			tickTime:       parser.TickTime(),
+		}
+		rememberTraceRoster(names, state.Participants().Playing())
+		snapshot()
+		t.Logf("RoundStart frame=%d tick=%d rounds=%d phase=%s warmup=%t",
+			parser.CurrentFrame(), state.IngameTick(), state.TotalRoundsPlayed(), state.GamePhase(), state.IsWarmupPeriod())
+	})
+	parser.RegisterEventHandler(func(events.RoundFreezetimeEnd) {
+		rememberTraceRoster(names, parser.GameState().Participants().Playing())
+		snapshot()
+	})
+	parser.RegisterEventHandler(func(e events.Kill) {
+		if current == nil || e.Victim == nil {
+			return
+		}
+		kill := hltvKillTrace{
+			frame:         parser.CurrentFrame(),
+			tick:          parser.GameState().IngameTick(),
+			at:            parser.CurrentTime(),
+			killer:        trackerID(e.Killer),
+			killerName:    tracePlayerName(e.Killer),
+			killerTeam:    tracePlayerTeam(e.Killer),
+			victim:        trackerID(e.Victim),
+			victimName:    tracePlayerName(e.Victim),
+			victimTeam:    e.Victim.Team,
+			assisterName:  tracePlayerName(e.Assister),
+			assistedFlash: e.AssistedFlash,
+			cause:         traceKillCause(e),
+			postRound:     analysis.tracker.isPostRound(),
+		}
+		current.kills = append(current.kills, kill)
+		rememberTracePlayer(names, e.Killer)
+		rememberTracePlayer(names, e.Victim)
+		rememberTracePlayer(names, e.Assister)
+		snapshot()
+	})
+	parser.RegisterEventHandler(func(e events.PlayerDisconnected) {
+		if current == nil || e.Player == nil {
+			return
+		}
+		current.disconnects = append(current.disconnects, hltvDisconnectTrace{
+			frame: parser.CurrentFrame(), tick: parser.GameState().IngameTick(),
+			player: trackerID(e.Player), name: tracePlayerName(e.Player),
+		})
+		snapshot()
+	})
+	parser.RegisterEventHandler(func(e events.RoundEnd) {
+		if current == nil {
+			return
+		}
+		current.winner = e.Winner
+		snapshot()
+		current.survivedRoundEnd = maps.Clone(current.finalAlive)
+		state := parser.GameState()
+		t.Logf("RoundEnd frame=%d tick=%d rounds=%d phase=%s winner=%v",
+			parser.CurrentFrame(), state.IngameTick(), state.TotalRoundsPlayed(), state.GamePhase(), e.Winner)
+	})
+	parser.RegisterEventHandler(func(events.RoundEndOfficial) {
+		if current == nil {
+			return
+		}
+		snapshot()
+		current.survivedOfficial = maps.Clone(current.finalAlive)
+		state := parser.GameState()
+		t.Logf("RoundEndOfficial frame=%d tick=%d rounds=%d phase=%s",
+			parser.CurrentFrame(), state.IngameTick(), state.TotalRoundsPlayed(), state.GamePhase())
+	})
+
+	if err := parser.ParseToEnd(); err != nil {
+		t.Fatalf("parsing trace demo: %v", err)
+	}
+	snapshot()
+	state := parser.GameState()
+	t.Logf("ParseEnd frame=%d tick=%d rounds=%d phase=%s",
+		parser.CurrentFrame(), state.IngameTick(), state.TotalRoundsPlayed(), state.GamePhase())
+	finishCurrent(state.TotalRoundsPlayed())
+	analysis.finalise()
+
+	ids := slices.Sorted(maps.Keys(analysis.players))
+	for _, id := range ids {
+		if target != 0 && id != target {
+			continue
+		}
+		player := analysis.players[id]
+		t.Logf("player=%s steam=%d participant_rounds=%d KAST=%.1f",
+			player.Name, id, player.SideStats.Rounds.Total, player.PlayerMapStats.KAST)
+	}
+}
+
+func parseTraceSteamID(t *testing.T, value string) uint64 {
+	t.Helper()
+	if value == "" {
+		return 0
+	}
+	id, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		t.Fatalf("%s must be a uint64: %v", hltvTraceSteamIDEnv, err)
+	}
+	return id
+}
+
+func logHLTVRoundTrace(t *testing.T, round *hltvRoundTrace, scored bool, target uint64, names map[uint64]string) {
+	t.Helper()
+	if !scored {
+		t.Logf("round setup start_score=%d scored=false events=%d", round.startedAtRound, len(round.kills))
+		return
+	}
+	roundNumber := round.startedAtRound + 1
+	ids := slices.Sorted(maps.Keys(round.participants))
+	for _, id := range ids {
+		if target != 0 && target != id {
+			continue
+		}
+		killed := round.enemyKills[id] > 0
+		classicAssisted := round.assists[id]&classicAssist != 0
+		flashAssisted := round.assists[id]&ratingAssist != 0 && !classicAssisted
+		survivedEnd := round.survivedRoundEnd[id]
+		survivedOfficial := round.survivedOfficial[id]
+		survivedFinal := round.finalAlive[id]
+		traded := round.traded[id]
+		kast := killed || classicAssisted || survivedFinal || traded
+		t.Logf("round=%d scored=true player=%s steam=%d side=%v K=%t A=%t flash_only=%t S_end=%t S_official=%t S_final=%t T=%t rating_damage_assist=%t KAST=%t winner=%v official=%t",
+			roundNumber, names[id], id, round.participants[id], killed, classicAssisted, flashAssisted,
+			survivedEnd, survivedOfficial, survivedFinal, traded, round.damageAssists[id], kast,
+			round.winner, round.survivedOfficial != nil)
+		logTraceDeaths(t, roundNumber, id, round, names)
+	}
+	for _, disconnect := range round.disconnects {
+		if target == 0 || target == disconnect.player {
+			t.Logf("round=%d disconnect player=%s steam=%d frame=%d tick=%d",
+				roundNumber, disconnect.name, disconnect.player, disconnect.frame, disconnect.tick)
+		}
+	}
+}
+
+func logTraceDeaths(t *testing.T, roundNumber int, player uint64, round *hltvRoundTrace, names map[uint64]string) {
+	t.Helper()
+	for i, death := range round.kills {
+		if death.victim != player {
+			continue
+		}
+		t.Logf("round=%d death player=%s killer=%s cause=%s frame=%d tick=%d time=%s post_round=%t assister=%s flash=%t",
+			roundNumber, names[player], death.killerName, death.cause, death.frame, death.tick,
+			death.at, death.postRound, death.assisterName, death.assistedFlash)
+		for offset, revenge := range round.kills[i+1:] {
+			if death.killer == 0 || revenge.killerTeam != death.victimTeam || revenge.victim != death.killer {
+				continue
+			}
+			revengeIndex := i + 1 + offset
+			tickDelta := revenge.tick - death.tick
+			timeDelta := revenge.at - death.at
+			productionEligible := insideTradeWindow(death.tick, revenge.tick, round.tickTime, tradeWindow)
+			productionCredited := productionTradeVictim(round, revengeIndex) == death.victim
+			t.Logf("round=%d trade_candidate death=%s trading_kill=%s->%s death_tick=%d kill_tick=%d tick_delta=%d frame_delta=%d time_delta=%s kill_post_round=%t exact_5s=%t production_window=%t production_credited=%t sequence=%s",
+				roundNumber, names[player], revenge.killerName, revenge.victimName, death.tick, revenge.tick,
+				tickDelta, revenge.frame-death.frame, timeDelta, revenge.postRound, timeDelta <= 5*time.Second,
+				productionEligible, productionCredited, formatTraceSequence(round.kills))
+		}
+	}
+}
+
+func productionTradeVictim(round *hltvRoundTrace, revengeIndex int) uint64 {
+	revenge := round.kills[revengeIndex]
+	for _, death := range round.kills[:revengeIndex] {
+		if death.killer == revenge.victim && death.victimTeam == revenge.killerTeam &&
+			insideTradeWindow(death.tick, revenge.tick, round.tickTime, tradeWindow) {
+			return death.victim
+		}
+	}
+	return 0
+}
+
+func tracePlayerName(player *common.Player) string {
+	if player == nil {
+		return "World"
+	}
+	return player.Name
+}
+
+func tracePlayerTeam(player *common.Player) common.Team {
+	if player == nil {
+		return common.TeamUnassigned
+	}
+	return player.Team
+}
+
+func rememberTracePlayer(names map[uint64]string, player *common.Player) {
+	if id := trackerID(player); id != 0 {
+		names[id] = tracePlayerName(player)
+	}
+}
+
+func rememberTraceRoster(names map[uint64]string, players []*common.Player) {
+	for _, player := range players {
+		rememberTracePlayer(names, player)
+	}
+}
+
+func traceKillCause(event events.Kill) string {
+	if event.Weapon == nil {
+		return "unknown"
+	}
+	return event.Weapon.String()
+}
+
+func aliveSet(source map[uint64]common.Team) map[uint64]bool {
+	result := make(map[uint64]bool, len(source))
+	for id := range source {
+		result[id] = true
+	}
+	return result
+}
+
+func formatTraceKill(kill hltvKillTrace) string {
+	return fmt.Sprintf("%s->%s@%d", kill.killerName, kill.victimName, kill.tick)
+}
+
+func formatTraceSequence(kills []hltvKillTrace) string {
+	values := make([]string, len(kills))
+	for i, kill := range kills {
+		values[i] = formatTraceKill(kill)
+	}
+	return strings.Join(values, ",")
+}

--- a/cmd/demo_parser/hltv_trade_models_test.go
+++ b/cmd/demo_parser/hltv_trade_models_test.go
@@ -1,0 +1,284 @@
+package demoparser
+
+import (
+	"fmt"
+	"maps"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	demoinfocs "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
+	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
+	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
+)
+
+const evaluateHLTVTradeModelsEnv = "HLTV_EVALUATE_TRADE_MODELS"
+
+type hltvTradeSelection uint8
+
+const (
+	hltvTradeEarliest hltvTradeSelection = iota
+	hltvTradeNearest
+	hltvTradeMultiple
+)
+
+type hltvTradeBoundary uint8
+
+const (
+	hltvTradeExactTime hltvTradeBoundary = iota
+	hltvTradeTimeResolution
+	hltvTradeNormalizedTicks
+)
+
+type hltvTradeModel struct {
+	selection hltvTradeSelection
+	boundary  hltvTradeBoundary
+	postRound bool
+}
+
+func (model hltvTradeModel) String() string {
+	selections := []string{"earliest", "nearest", "multiple"}
+	boundaries := []string{"exact-time", "time-plus-resolution", "normalized-ticks"}
+	return fmt.Sprintf("%s/%s/post=%t", selections[model.selection], boundaries[model.boundary], model.postRound)
+}
+
+type hltvModelFixture struct {
+	oracle hltvOracle
+	maps   map[int][]hltvTradeRoundTrace
+}
+
+// hltvTradeRoundTrace contains only the facts consumed by the model matrix;
+// the richer evidence trace deliberately remains a separate diagnostic type.
+type hltvTradeRoundTrace struct {
+	tickTime     time.Duration
+	participants map[uint64]common.Team
+	kills        []hltvKillTrace
+	enemyKills   map[uint64]int
+	assists      map[uint64]assistFacts
+	finalAlive   map[uint64]bool
+}
+
+// TestEvaluateHLTVTradeModels is an opt-in diagnostic matrix. It evaluates
+// semantic models from the same recorded events; it never mutates production
+// state or treats aggregate parity as permission to fit a custom cutoff.
+func TestEvaluateHLTVTradeModels(t *testing.T) {
+	if os.Getenv(evaluateHLTVTradeModelsEnv) == "" {
+		t.Skipf("set %s=1 with the HLTV demo directories to evaluate trade models", evaluateHLTVTradeModelsEnv)
+	}
+
+	originalDirs := configuredDemoDirs(os.Getenv(hltvDemoDirEnv))
+	extraDirs := configuredDemoDirs(os.Getenv(hltvExtraDemoDirsEnv))
+	if len(originalDirs) == 0 || len(extraDirs) == 0 {
+		t.Fatalf("%s and %s must both be configured", hltvDemoDirEnv, hltvExtraDemoDirsEnv)
+	}
+
+	fixtures := make([]hltvModelFixture, len(hltvOracleSpecs))
+	oracles := make([]hltvOracle, len(hltvOracleSpecs))
+	for i, spec := range hltvOracleSpecs {
+		oracle := loadHLTVOracle(t, spec.Path)
+		oracles[i] = oracle
+		fixtures[i] = hltvModelFixture{oracle: oracle, maps: make(map[int][]hltvTradeRoundTrace)}
+		dirs := originalDirs
+		if spec.Extra {
+			dirs = extraDirs
+		}
+		for _, expectedMap := range oracle.Maps {
+			path, err := findDemo(dirs, expectedMap.DemoFile)
+			if err != nil {
+				t.Fatalf("locating %s: %v", expectedMap.DemoFile, err)
+			}
+			if err := verifyDemoChecksum(path, expectedMap.DemoSHA256); err != nil {
+				t.Fatalf("verifying %s: %v", expectedMap.DemoFile, err)
+			}
+			traces := collectHLTVRoundTraces(t, path)
+			if len(traces) != expectedMap.Rounds {
+				t.Fatalf("%s collected %d scored rounds, want %d", expectedMap.DemoFile, len(traces), expectedMap.Rounds)
+			}
+			fixtures[i].maps[expectedMap.MapID] = traces
+		}
+	}
+	validateHLTVOracleSet(t, hltvOracleSpecs, oracles)
+
+	for _, model := range allHLTVTradeModels() {
+		originalMatches, originalRows := 0, 0
+		extraMatches, extraRows := 0, 0
+		var mismatches []string
+		for i, fixture := range fixtures {
+			for _, expectedMap := range fixture.oracle.Maps {
+				traces := fixture.maps[expectedMap.MapID]
+				gotByPlayer := modelKASTRounds(traces, model)
+				for _, expectedPlayer := range expectedMap.Players {
+					got := gotByPlayer[expectedPlayer.SteamID]
+					want := kastRounds(expectedPlayer.KASTPercent, expectedMap.Rounds)
+					if hltvOracleSpecs[i].Extra {
+						extraRows++
+						if got == want {
+							extraMatches++
+						}
+					} else {
+						originalRows++
+						if got == want {
+							originalMatches++
+						}
+					}
+					if got != want {
+						mismatches = append(mismatches, fmt.Sprintf("%s/%d/%s=%d:%d",
+							fixture.oracle.FixtureID, expectedMap.MapID, expectedPlayer.HLTVName, got, want))
+					}
+				}
+			}
+		}
+		sort.Strings(mismatches)
+		t.Logf("model=%s original=%d/%d extra=%d/%d mismatches=%v",
+			model, originalMatches, originalRows, extraMatches, extraRows, mismatches)
+	}
+}
+
+func allHLTVTradeModels() []hltvTradeModel {
+	var models []hltvTradeModel
+	for _, selection := range []hltvTradeSelection{hltvTradeEarliest, hltvTradeNearest, hltvTradeMultiple} {
+		for _, boundary := range []hltvTradeBoundary{hltvTradeExactTime, hltvTradeTimeResolution, hltvTradeNormalizedTicks} {
+			for _, postRound := range []bool{false, true} {
+				models = append(models, hltvTradeModel{selection: selection, boundary: boundary, postRound: postRound})
+			}
+		}
+	}
+	return models
+}
+
+func collectHLTVRoundTraces(t *testing.T, demoPath string) []hltvTradeRoundTrace {
+	t.Helper()
+	file, err := os.Open(demoPath)
+	if err != nil {
+		t.Fatalf("opening trace demo: %v", err)
+	}
+	defer file.Close()
+
+	parser := demoinfocs.NewParser(file)
+	defer parser.Close()
+	analysis := newAnalyser(parser)
+	analysis.registerHandlers()
+
+	var traces []hltvTradeRoundTrace
+	var current *hltvTradeRoundTrace
+	var startedAtRound int
+	finishCurrent := func(totalRounds int) {
+		if current == nil {
+			return
+		}
+		if totalRounds > startedAtRound {
+			traces = append(traces, *current)
+		}
+		current = nil
+	}
+	snapshot := func() {
+		if current == nil {
+			return
+		}
+		current.participants = maps.Clone(analysis.tracker.startAlive)
+		current.enemyKills = maps.Clone(analysis.tracker.enemyKills)
+		current.assists = maps.Clone(analysis.tracker.assists)
+		current.finalAlive = aliveSet(analysis.tracker.alive)
+	}
+
+	parser.RegisterEventHandler(func(events.RoundStart) {
+		state := parser.GameState()
+		finishCurrent(state.TotalRoundsPlayed())
+		startedAtRound = state.TotalRoundsPlayed()
+		current = &hltvTradeRoundTrace{
+			tickTime: parser.TickTime(),
+		}
+		snapshot()
+	})
+	parser.RegisterEventHandler(func(events.RoundFreezetimeEnd) { snapshot() })
+	parser.RegisterEventHandler(func(event events.Kill) {
+		if current == nil || event.Victim == nil {
+			return
+		}
+		current.kills = append(current.kills, hltvKillTrace{
+			frame:      parser.CurrentFrame(),
+			tick:       parser.GameState().IngameTick(),
+			at:         parser.CurrentTime(),
+			killer:     trackerID(event.Killer),
+			killerTeam: tracePlayerTeam(event.Killer),
+			victim:     trackerID(event.Victim),
+			victimTeam: event.Victim.Team,
+			postRound:  analysis.tracker.isPostRound(),
+		})
+		snapshot()
+	})
+	parser.RegisterEventHandler(func(events.PlayerDisconnected) { snapshot() })
+	parser.RegisterEventHandler(func(events.RoundEnd) { snapshot() })
+	parser.RegisterEventHandler(func(events.RoundEndOfficial) { snapshot() })
+
+	if err := parser.ParseToEnd(); err != nil {
+		t.Fatalf("parsing trace demo: %v", err)
+	}
+	snapshot()
+	finishCurrent(parser.GameState().TotalRoundsPlayed())
+	return traces
+}
+
+func modelKASTRounds(rounds []hltvTradeRoundTrace, model hltvTradeModel) map[uint64]int {
+	qualifying := make(map[uint64]int)
+	for i := range rounds {
+		round := &rounds[i]
+		traded := modelTradedDeaths(round, model)
+		for player := range round.participants {
+			if round.enemyKills[player] > 0 || round.assists[player]&classicAssist != 0 ||
+				round.finalAlive[player] || traded[player] {
+				qualifying[player]++
+			}
+		}
+	}
+	return qualifying
+}
+
+func modelTradedDeaths(round *hltvTradeRoundTrace, model hltvTradeModel) map[uint64]bool {
+	traded := make(map[uint64]bool)
+	for revengeIndex, revenge := range round.kills {
+		if revenge.killer == 0 || revenge.killerTeam == revenge.victimTeam ||
+			(!model.postRound && revenge.postRound) {
+			continue
+		}
+		var selected uint64
+		found := false
+		for _, death := range round.kills[:revengeIndex] {
+			if death.killer != revenge.victim || death.victimTeam != revenge.killerTeam ||
+				(!model.postRound && death.postRound) || !model.insideWindow(death, revenge, round.tickTime) {
+				continue
+			}
+			switch model.selection {
+			case hltvTradeEarliest:
+				selected = death.victim
+				found = true
+			case hltvTradeNearest:
+				selected = death.victim
+				found = true
+			case hltvTradeMultiple:
+				traded[death.victim] = true
+			}
+			if model.selection == hltvTradeEarliest {
+				break
+			}
+		}
+		if found {
+			traded[selected] = true
+		}
+	}
+	return traded
+}
+
+func (model hltvTradeModel) insideWindow(death, revenge hltvKillTrace, tickTime time.Duration) bool {
+	switch model.boundary {
+	case hltvTradeExactTime:
+		return revenge.at-death.at <= tradeWindow
+	case hltvTradeTimeResolution:
+		return revenge.at-death.at <= tradeWindow+tickTime
+	case hltvTradeNormalizedTicks:
+		return insideTradeWindow(death.tick, revenge.tick, tickTime, tradeWindow)
+	default:
+		return false
+	}
+}

--- a/cmd/demo_parser/integration_test.go
+++ b/cmd/demo_parser/integration_test.go
@@ -33,7 +33,7 @@ type demoFixture struct {
 //     so it exercises the RoundMVPAnnouncement handler.
 //   - ancient is a later Premier match with no round_mvp events at all, so
 //     its MVP counts can only come from the scoreboard entity property.
-//     Dropping syncScoreboardMVPs zeroes this golden's MVPs.
+//     Dropping the staged scoreboard-MVP snapshot zeroes this golden's MVPs.
 //   - inferno contains XM1014 pellet events whose reported damage exceeds
 //     the victim's real health loss, reaches halftime, and has a player join
 //     between RoundStart and the end of freeze time. It exercises the damage

--- a/cmd/demo_parser/rating_tracker_test.go
+++ b/cmd/demo_parser/rating_tracker_test.go
@@ -10,8 +10,8 @@ func TestSwingIsZeroSumAndFavoursTheKiller(t *testing.T) {
 	rt := newRoundTracker()
 	rt.startRound(fiveVsFive())
 
-	rt.kill(1, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10))
-	rt.kill(12, 2, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(20))
+	recordKill(rt, 1, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10))
+	recordKill(rt, 12, 2, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(20))
 
 	outcome := endRound(rt, common.TeamTerrorists)
 	if outcome.swing[1] <= 0 {
@@ -39,7 +39,7 @@ func TestSwingDiminishesInWonRounds(t *testing.T) {
 	var swings []float64
 	previous := 0.0
 	for _, victim := range []uint64{11, 12, 13, 14, 15} {
-		rt.kill(1, victim, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10))
+		recordKill(rt, 1, victim, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10))
 		outcomeSoFar := rt.swing[1]
 		swings = append(swings, outcomeSoFar-previous)
 		previous = outcomeSoFar
@@ -57,7 +57,7 @@ func TestPostRoundKillMovesNoSwing(t *testing.T) {
 	rt.startRound(fiveVsFive())
 	rt.markEnd(common.TeamCounterTerrorists)
 
-	rt.kill(1, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(100))
+	recordKill(rt, 1, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(100))
 
 	if outcome := rt.finalize(); outcome.swing[1] != 0 || outcome.swing[11] != 0 {
 		t.Errorf("exit frag moved swing: killer %v, victim %v", outcome.swing[1], outcome.swing[11])
@@ -74,7 +74,7 @@ func TestBombPlantShrinksTSwing(t *testing.T) {
 		if planted {
 			rt.plantBomb()
 		}
-		rt.kill(1, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10))
+		recordKill(rt, 1, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10))
 		return endRound(rt, common.TeamTerrorists).swing[1]
 	}
 
@@ -95,10 +95,10 @@ func TestFortyDamageBecomesARatingAssist(t *testing.T) {
 	// one point short, and player 1 finishes the job.
 	rt.damage(2, 11, ratingAssistDamage)
 	rt.damage(3, 11, ratingAssistDamage-1)
-	rt.kill(1, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10))
+	recordKill(rt, 1, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10))
 	// Ts lose so that survival cannot grant the credit instead.
 	for _, victim := range []uint64{1, 2, 3, 4, 5} {
-		rt.kill(12, victim, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(20))
+		recordKill(rt, 12, victim, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(20))
 	}
 
 	outcome := endRound(rt, common.TeamCounterTerrorists)
@@ -120,7 +120,7 @@ func TestDamageOnASurvivorIsNoRatingAssist(t *testing.T) {
 	rt.damage(2, 11, 90)
 	// Ts lose with no kills; 11 survives, so 2 has no KAST path at all.
 	for _, victim := range []uint64{1, 2, 3, 4, 5} {
-		rt.kill(11, victim, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(20))
+		recordKill(rt, 11, victim, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(20))
 	}
 
 	if outcome := endRound(rt, common.TeamCounterTerrorists); outcome.ratingKast[2] {
@@ -138,9 +138,9 @@ func TestPostRoundCleanupDeathSettlesNoDamageAssist(t *testing.T) {
 	// Player 2 softens 11 past the threshold and then dies with no other
 	// KAST path; after the whistle, engine cleanup kills 11.
 	rt.damage(2, 11, ratingAssistDamage)
-	rt.kill(11, 2, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
+	recordKill(rt, 11, 2, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
 	rt.markEnd(common.TeamCounterTerrorists)
-	rt.kill(0, 11, common.TeamUnassigned, common.TeamCounterTerrorists, 0, true, at(70))
+	recordKill(rt, 0, 11, common.TeamUnassigned, common.TeamCounterTerrorists, 0, true, at(70))
 
 	outcome := rt.finalize()
 	if !outcome.survived[11] {
@@ -156,7 +156,7 @@ func TestKillerDamageIsNotAlsoAnAssist(t *testing.T) {
 	rt.startRound(fiveVsFive())
 
 	rt.damage(1, 11, 100)
-	rt.kill(1, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10))
+	recordKill(rt, 1, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10))
 
 	if rt.damageAssists[1] {
 		t.Error("the killer's own damage counted as an assist on their kill")
@@ -173,7 +173,7 @@ func TestEcoWeightsFollowTheRoundTier(t *testing.T) {
 	rt := newRoundTracker()
 	rt.startRound(fiveVsFive())
 
-	a.applyRoundOutcome(endRound(rt, common.TeamTerrorists))
+	a.applyRoundOutcomeWithTiers(endRound(rt, common.TeamTerrorists), a.roundTiers)
 
 	if a.ecoSurvival[1] <= a.ecoSurvival[2] {
 		t.Errorf("starter pistol survival weighs %v, full buy %v; want the eco worth more",

--- a/cmd/demo_parser/round_tracker.go
+++ b/cmd/demo_parser/round_tracker.go
@@ -28,8 +28,15 @@ type deathRecord struct {
 	killer     uint64
 	victim     uint64
 	victimTeam common.Team
-	at         time.Duration
+	tick       int
 }
+
+type assistFacts uint8
+
+const (
+	classicAssist assistFacts = 1 << iota
+	ratingAssist
+)
 
 // openingDuel is the first enemy kill of a round. A zero killer means the
 // round had none.
@@ -41,8 +48,11 @@ type openingDuel struct {
 // roundOutcome is what a finished round contributes to player stats.
 type roundOutcome struct {
 	played       bool
+	decided      bool
+	mvp          uint64
 	aces         []uint64
 	multiKills   map[uint64]int // enemy kills of the players that got at least a 2k
+	tradeKills   map[uint64]int // revenge kills that traded one eligible teammate death
 	clutcher     uint64         // winner-side player that won a 1vX, 0 if none
 	opening      openingDuel
 	openingWon   bool // the opening killer's team won the round
@@ -61,12 +71,14 @@ type roundTracker struct {
 	live          bool
 	decided       bool
 	winner        common.Team
+	mvp           uint64
 	bombPlanted   bool
 	startAlive    map[uint64]common.Team
 	alive         map[uint64]common.Team
 	enemyKills    map[uint64]int
-	assists       map[uint64]bool
+	assists       map[uint64]assistFacts
 	traded        map[uint64]bool
+	tradeKills    map[uint64]int
 	deaths        []deathRecord
 	clutchers     map[common.Team]uint64
 	opening       openingDuel
@@ -83,6 +95,7 @@ func (rt *roundTracker) startRound(alive map[uint64]common.Team) {
 	rt.live = true
 	rt.decided = false
 	rt.winner = common.TeamUnassigned
+	rt.mvp = 0
 	rt.startAlive = make(map[uint64]common.Team, len(alive))
 	rt.alive = make(map[uint64]common.Team, len(alive))
 	for id, team := range alive {
@@ -90,8 +103,9 @@ func (rt *roundTracker) startRound(alive map[uint64]common.Team) {
 		rt.alive[id] = team
 	}
 	rt.enemyKills = make(map[uint64]int)
-	rt.assists = make(map[uint64]bool)
+	rt.assists = make(map[uint64]assistFacts)
 	rt.traded = make(map[uint64]bool)
+	rt.tradeKills = make(map[uint64]int)
 	rt.deaths = nil
 	rt.clutchers = make(map[common.Team]uint64)
 	rt.opening = openingDuel{}
@@ -100,6 +114,12 @@ func (rt *roundTracker) startRound(alive map[uint64]common.Team) {
 	rt.damageAssists = make(map[uint64]bool)
 	rt.swing = make(map[uint64]float64)
 	rt.updateClutchCandidates()
+}
+
+func (rt *roundTracker) markMVP(player uint64) {
+	if rt.live {
+		rt.mvp = player
+	}
 }
 
 // plantBomb records the bomb going down, which shifts the win probability
@@ -149,14 +169,13 @@ func (rt *roundTracker) joinRound(alive map[uint64]common.Team) {
 
 // kill records a death in the current round. killer and assister are 0 for
 // world deaths and suicides; byWorld marks deaths with no real cause (falls,
-// match-end cleanup kills), as opposed to the bomb or an enemy. It reports
-// whether the kill traded the death of one of the killer's teammates.
-func (rt *roundTracker) kill(killer, victim uint64, killerTeam, victimTeam common.Team, assister uint64, byWorld bool, at time.Duration) bool {
+// match-end cleanup kills), as opposed to the bomb or an enemy. Tick is the
+// server tick that carried the event, and tickTime is that tick's duration.
+func (rt *roundTracker) kill(killer, victim uint64, killerTeam, victimTeam common.Team, assister uint64, assistedFlash, byWorld bool, tick int, tickTime time.Duration) {
 	if !rt.live {
-		return false
+		return
 	}
 
-	isTrade := false
 	if killer != 0 && killerTeam != victimTeam {
 		// The first enemy kill is the round's opening duel. Teamkills,
 		// suicides and world deaths never open a round, and once the round
@@ -167,7 +186,10 @@ func (rt *roundTracker) kill(killer, victim uint64, killerTeam, victimTeam commo
 		}
 		rt.enemyKills[killer]++
 		if assister != 0 {
-			rt.assists[assister] = true
+			rt.assists[assister] |= ratingAssist
+			if !assistedFlash {
+				rt.assists[assister] |= classicAssist
+			}
 		}
 		// Post-round kills swing nothing: the probability table has no
 		// notion of a decided round, so without this guard an exit frag
@@ -177,16 +199,19 @@ func (rt *roundTracker) kill(killer, victim uint64, killerTeam, victimTeam commo
 		}
 		// Deliberately no rt.decided guard: deaths and revenge kills stay
 		// eligible until finalize, so a post-round death can still be
-		// avenged inside the window.
+		// avenged inside the window. One revenge kill credits the oldest
+		// eligible death and then stops.
 		for _, d := range rt.deaths {
-			if d.killer == victim && d.victimTeam == killerTeam && at-d.at <= tradeWindow {
+			if d.killer == victim && d.victimTeam == killerTeam &&
+				insideTradeWindow(d.tick, tick, tickTime, tradeWindow) {
 				rt.traded[d.victim] = true
-				isTrade = true
+				rt.tradeKills[killer]++
+				break
 			}
 		}
 	}
 
-	rt.deaths = append(rt.deaths, deathRecord{killer: killer, victim: victim, victimTeam: victimTeam, at: at})
+	rt.deaths = append(rt.deaths, deathRecord{killer: killer, victim: victim, victimTeam: victimTeam, tick: tick})
 	// Dying before the round officially ends cancels survival, including to
 	// the post-round bomb explosion. Raw death totals are handled separately
 	// by the analyser. Only match-end world cleanup kills are ignored once
@@ -204,7 +229,18 @@ func (rt *roundTracker) kill(killer, victim uint64, killerTeam, victimTeam commo
 		}
 		rt.remove(victim)
 	}
-	return isTrade
+}
+
+// insideTradeWindow compares the closest possible instants in two event
+// ticks. An event timestamp identifies an interval, not a point: tick n can
+// occur at its end and tick n+1 at its beginning. Relative ticks avoid the
+// phase-dependent rounding in demoinfocs' float32 absolute demo clock.
+func insideTradeWindow(deathTick, revengeTick int, tickTime, window time.Duration) bool {
+	if tickTime <= 0 || window < 0 || revengeTick < deathTick {
+		return false
+	}
+	minimumElapsedTicks := max(0, revengeTick-deathTick-1)
+	return time.Duration(minimumElapsedTicks)*tickTime <= window
 }
 
 // recordSwing credits the killer with the round-win-probability gain of the
@@ -333,7 +369,10 @@ func (rt *roundTracker) finalize() roundOutcome {
 
 	outcome := roundOutcome{
 		played:       true,
+		decided:      rt.decided,
+		mvp:          rt.mvp,
 		multiKills:   make(map[uint64]int),
+		tradeKills:   rt.tradeKills,
 		clutcher:     rt.clutchers[rt.winner],
 		opening:      rt.opening,
 		openingWon:   rt.opening.killer != 0 && rt.opening.killerTeam == rt.winner,
@@ -357,16 +396,15 @@ func (rt *roundTracker) finalize() roundOutcome {
 		if rt.traded[id] {
 			outcome.deathsTraded[id] = true
 		}
-		if survived || rt.enemyKills[id] > 0 || rt.assists[id] || rt.traded[id] {
+		if survived || rt.enemyKills[id] > 0 || rt.assists[id]&classicAssist != 0 || rt.traded[id] {
 			outcome.kast[id] = true
 		}
 		if survived {
 			outcome.survived[id] = true
 		}
-		// The rating's KAST differs from the classic one in its assist rule:
-		// the demo's assist events stay in (they carry flash assists), and
-		// the 40-damage rule adds contributors those events missed.
-		if outcome.kast[id] || rt.damageAssists[id] {
+		// Rating KAST keeps every demo assist, including flash assists, and
+		// adds contributors that meet its separate 40-damage rule.
+		if outcome.kast[id] || rt.assists[id]&ratingAssist != 0 || rt.damageAssists[id] {
 			outcome.ratingKast[id] = true
 		}
 	}

--- a/cmd/demo_parser/round_tracker_test.go
+++ b/cmd/demo_parser/round_tracker_test.go
@@ -24,6 +24,10 @@ func at(seconds int) time.Duration {
 	return time.Duration(seconds) * time.Second
 }
 
+func recordKill(rt *roundTracker, killer, victim uint64, killerTeam, victimTeam common.Team, assister uint64, byWorld bool, at time.Duration) {
+	rt.kill(killer, victim, killerTeam, victimTeam, assister, false, byWorld, int(at/time.Millisecond), time.Millisecond)
+}
+
 // endRound decides and immediately finalizes a round, for tests that have
 // no post-round events.
 func endRound(rt *roundTracker, winner common.Team) roundOutcome {
@@ -36,7 +40,7 @@ func TestAce(t *testing.T) {
 	rt.startRound(fiveVsFive())
 
 	for i, victim := range []uint64{11, 12, 13, 14, 15} {
-		rt.kill(1, victim, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10+i))
+		recordKill(rt, 1, victim, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10+i))
 	}
 
 	outcome := endRound(rt, common.TeamTerrorists)
@@ -56,7 +60,7 @@ func TestFourKillsIsNotAce(t *testing.T) {
 	rt.startRound(fiveVsFive())
 
 	for i, victim := range []uint64{11, 12, 13, 14} {
-		rt.kill(1, victim, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10+i))
+		recordKill(rt, 1, victim, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10+i))
 	}
 
 	if outcome := endRound(rt, common.TeamTerrorists); len(outcome.aces) != 0 {
@@ -70,9 +74,9 @@ func TestTeamkillsDoNotMakeAnAce(t *testing.T) {
 
 	// Four enemy kills plus a teamkill must not be an ace.
 	for i, victim := range []uint64{11, 12, 13, 14} {
-		rt.kill(1, victim, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10+i))
+		recordKill(rt, 1, victim, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10+i))
 	}
-	rt.kill(1, 2, common.TeamTerrorists, common.TeamTerrorists, 0, false, at(20))
+	recordKill(rt, 1, 2, common.TeamTerrorists, common.TeamTerrorists, 0, false, at(20))
 
 	if outcome := endRound(rt, common.TeamTerrorists); len(outcome.aces) != 0 {
 		t.Errorf("teamkill counted towards ace: %v", outcome.aces)
@@ -82,7 +86,7 @@ func TestTeamkillsDoNotMakeAnAce(t *testing.T) {
 // killEnemies has player 1 kill n CTs in one round.
 func killEnemies(rt *roundTracker, n int) {
 	for i := range n {
-		rt.kill(1, uint64(11+i), common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10+i))
+		recordKill(rt, 1, uint64(11+i), common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10+i))
 	}
 }
 
@@ -134,7 +138,7 @@ func TestMultiKillTopBucketMatchesAce(t *testing.T) {
 	// Six enemy kills need a CT who reconnected, but if it ever happens the
 	// round has to stay a single 5k so the bucket cannot drift from ACEs.
 	killEnemies(rt, 5)
-	rt.kill(1, 16, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(20))
+	recordKill(rt, 1, 16, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(20))
 
 	outcome := endRound(rt, common.TeamTerrorists)
 	var got MultiKillRounds
@@ -152,9 +156,9 @@ func TestTeamkillsDoNotMakeAMultiKill(t *testing.T) {
 	rt.startRound(fiveVsFive())
 
 	// One enemy kill plus two teamkills is not a 3k, and not even a 2k.
-	rt.kill(1, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10))
-	rt.kill(1, 2, common.TeamTerrorists, common.TeamTerrorists, 0, false, at(12))
-	rt.kill(1, 3, common.TeamTerrorists, common.TeamTerrorists, 0, false, at(14))
+	recordKill(rt, 1, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10))
+	recordKill(rt, 1, 2, common.TeamTerrorists, common.TeamTerrorists, 0, false, at(12))
+	recordKill(rt, 1, 3, common.TeamTerrorists, common.TeamTerrorists, 0, false, at(14))
 
 	if outcome := endRound(rt, common.TeamTerrorists); len(outcome.multiKills) != 0 {
 		t.Errorf("teamkills counted towards a multi-kill: %v", outcome.multiKills)
@@ -211,13 +215,13 @@ func TestFreezeTimeJoinerTradedDeathUsesJoinedSide(t *testing.T) {
 		1: common.TeamTerrorists, 11: common.TeamCounterTerrorists, 16: common.TeamCounterTerrorists,
 	})
 
-	rt.kill(1, 16, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10))
-	rt.kill(11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(13))
+	recordKill(rt, 1, 16, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10))
+	recordKill(rt, 11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(13))
 	outcome := endRound(rt, common.TeamCounterTerrorists)
 
 	a := liveAnalyser()
 	a.players[16] = &DemoPlayer{SteamID: 16}
-	a.applyRoundOutcome(outcome)
+	a.applyRoundOutcomeWithTiers(outcome, a.roundTiers)
 	if got, want := a.players[16].DeathsTraded, (SideCount{Total: 1, CT: 1}); got != want {
 		t.Errorf("freeze-time joiner's deaths traded = %+v, want %+v", got, want)
 	}
@@ -229,11 +233,11 @@ func TestClutchWon(t *testing.T) {
 
 	// CTs kill four Ts, leaving player 1 in a 1v5.
 	for i, victim := range []uint64{2, 3, 4, 5} {
-		rt.kill(11, victim, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10+i))
+		recordKill(rt, 11, victim, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10+i))
 	}
 	// Player 1 wins the clutch.
 	for i, victim := range []uint64{11, 12, 13, 14, 15} {
-		rt.kill(1, victim, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(20+i))
+		recordKill(rt, 1, victim, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(20+i))
 	}
 
 	if outcome := endRound(rt, common.TeamTerrorists); outcome.clutcher != 1 {
@@ -246,7 +250,7 @@ func TestClutchLostIsNotCounted(t *testing.T) {
 	rt.startRound(fiveVsFive())
 
 	for i, victim := range []uint64{2, 3, 4, 5} {
-		rt.kill(11, victim, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10+i))
+		recordKill(rt, 11, victim, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10+i))
 	}
 
 	// CTs win: their side never was in a clutch, so nobody gets one.
@@ -261,7 +265,7 @@ func TestClutchWonWithoutKills(t *testing.T) {
 
 	// Ts kill four CTs; player 11 is alone in a 1v5 and wins by defuse.
 	for i, victim := range []uint64{12, 13, 14, 15} {
-		rt.kill(1, victim, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10+i))
+		recordKill(rt, 1, victim, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10+i))
 	}
 
 	if outcome := endRound(rt, common.TeamCounterTerrorists); outcome.clutcher != 11 {
@@ -274,13 +278,13 @@ func TestOneVersusOneClutchGoesToWinner(t *testing.T) {
 	rt.startRound(fiveVsFive())
 
 	for i, victim := range []uint64{2, 3, 4, 5} {
-		rt.kill(11, victim, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10+i))
+		recordKill(rt, 11, victim, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10+i))
 	}
 	for i, victim := range []uint64{12, 13, 14, 15} {
-		rt.kill(1, victim, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(20+i))
+		recordKill(rt, 1, victim, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(20+i))
 	}
 	// 1v1 now: player 1 vs player 11. Player 1 wins.
-	rt.kill(1, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(30))
+	recordKill(rt, 1, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(30))
 
 	if outcome := endRound(rt, common.TeamTerrorists); outcome.clutcher != 1 {
 		t.Errorf("clutcher = %d, want player 1", outcome.clutcher)
@@ -291,13 +295,13 @@ func TestTradeKill(t *testing.T) {
 	rt := newRoundTracker()
 	rt.startRound(fiveVsFive())
 
-	rt.kill(11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
-	isTrade := rt.kill(2, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(13))
-	if !isTrade {
-		t.Error("revenge kill 3s after the teammate died should be a trade")
-	}
+	recordKill(rt, 11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
+	recordKill(rt, 2, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(13))
 
 	outcome := endRound(rt, common.TeamCounterTerrorists)
+	if outcome.tradeKills[2] != 1 {
+		t.Errorf("trade kills = %v, want one for player 2", outcome.tradeKills)
+	}
 	if len(outcome.deathsTraded) != 1 || !outcome.deathsTraded[1] {
 		t.Errorf("deaths traded = %v, want only player 1 counted once", outcome.deathsTraded)
 	}
@@ -310,12 +314,10 @@ func TestKillOutsideTradeWindowIsNoTrade(t *testing.T) {
 	rt := newRoundTracker()
 	rt.startRound(fiveVsFive())
 
-	rt.kill(11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
-	if rt.kill(2, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(16)) {
-		t.Error("revenge kill 6s later should not be a trade")
-	}
-	if outcome := endRound(rt, common.TeamCounterTerrorists); len(outcome.deathsTraded) != 0 {
-		t.Errorf("death outside the trade window was counted as traded: %v", outcome.deathsTraded)
+	recordKill(rt, 11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
+	recordKill(rt, 2, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(16))
+	if outcome := endRound(rt, common.TeamCounterTerrorists); len(outcome.deathsTraded) != 0 || len(outcome.tradeKills) != 0 {
+		t.Errorf("outside-window trade = deaths %v, kills %v; want none", outcome.deathsTraded, outcome.tradeKills)
 	}
 }
 
@@ -324,34 +326,99 @@ func TestPostRoundDeathCanBeTraded(t *testing.T) {
 	rt.startRound(fiveVsFive())
 
 	rt.markEnd(common.TeamCounterTerrorists)
-	rt.kill(11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
-	isTrade := rt.kill(2, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(13))
+	recordKill(rt, 11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
+	recordKill(rt, 2, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(13))
 
-	if !isTrade {
-		t.Error("post-round death avenged inside the window should be a trade")
-	}
-	if outcome := rt.finalize(); !outcome.deathsTraded[1] {
-		t.Errorf("post-round death was not marked as traded: %v", outcome.deathsTraded)
+	if outcome := rt.finalize(); !outcome.deathsTraded[1] || outcome.tradeKills[2] != 1 {
+		t.Errorf("post-round trade = deaths %v, kills %v; want player 1 traded by player 2", outcome.deathsTraded, outcome.tradeKills)
 	}
 }
 
-func TestOneTradeKillCanTradeTwoDeaths(t *testing.T) {
+func TestOneTradeKillCreditsTheOldestEligibleDeath(t *testing.T) {
 	rt := newRoundTracker()
 	rt.startRound(fiveVsFive())
 
-	rt.kill(11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
-	rt.kill(11, 2, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(12))
-	tradeKills := 0
-	if rt.kill(3, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(14)) {
-		tradeKills++
-	}
+	recordKill(rt, 11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
+	recordKill(rt, 11, 2, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(12))
+	recordKill(rt, 3, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(14))
 
 	outcome := endRound(rt, common.TeamTerrorists)
-	if tradeKills != 1 {
-		t.Errorf("trade kills = %d, want one revenge kill", tradeKills)
+	if outcome.tradeKills[3] != 1 {
+		t.Errorf("trade kills = %v, want one for player 3", outcome.tradeKills)
 	}
-	if len(outcome.deathsTraded) != 2 || !outcome.deathsTraded[1] || !outcome.deathsTraded[2] {
-		t.Errorf("deaths traded = %v, want players 1 and 2", outcome.deathsTraded)
+	if len(outcome.deathsTraded) != 1 || !outcome.deathsTraded[1] {
+		t.Errorf("deaths traded = %v, want only the oldest eligible death, player 1", outcome.deathsTraded)
+	}
+}
+
+func TestTradeWindowUsesTickIntervals(t *testing.T) {
+	const tick = time.Second / 64
+	tests := []struct {
+		name    string
+		delta   int
+		isTrade bool
+	}{
+		{name: "immediately below boundary", delta: 320, isTrade: true},
+		{name: "on boundary", delta: 321, isTrade: true},
+		{name: "immediately above boundary", delta: 322},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := insideTradeWindow(10_000, 10_000+tt.delta, tick, tradeWindow)
+			if got != tt.isTrade {
+				t.Errorf("trade %d ticks later with %s ticks = %t, want %t", tt.delta, tick, got, tt.isTrade)
+			}
+		})
+	}
+}
+
+func TestTradeWindowIsInvariantToDemoClockPhase(t *testing.T) {
+	const tick = time.Second / 64
+	for _, start := range []int{0, 76_714, 16_000_000} {
+		if !insideTradeWindow(start, start+321, tick, tradeWindow) {
+			t.Errorf("boundary trade changed at absolute tick %d", start)
+		}
+		if insideTradeWindow(start, start+322, tick, tradeWindow) {
+			t.Errorf("outside trade changed at absolute tick %d", start)
+		}
+	}
+}
+
+func TestTradeWindowIgnoresFloat32AbsoluteTimestampRounding(t *testing.T) {
+	const tickSeconds = float32(1.0 / 64.0)
+	deltas := make(map[time.Duration]bool)
+	for _, start := range []int{1, 1_000_000, 16_000_000, 100_000_000} {
+		deathTime := time.Duration(float32(start) * tickSeconds * float32(time.Second))
+		revengeTime := time.Duration(float32(start+321) * tickSeconds * float32(time.Second))
+		deltas[revengeTime-deathTime] = true
+		if !insideTradeWindow(start, start+321, time.Second/64, tradeWindow) {
+			t.Errorf("float32-derived times %s and %s changed a tick-normalized boundary trade", deathTime, revengeTime)
+		}
+	}
+	if len(deltas) < 2 {
+		t.Fatalf("test phases produced one float32 elapsed time %v; fixture does not exercise absolute-clock rounding", deltas)
+	}
+}
+
+func TestTradeWindowPreservesFractionalConfiguration(t *testing.T) {
+	const (
+		tick   = 16 * time.Millisecond
+		window = 5*time.Second + 7*time.Millisecond
+	)
+	if !insideTradeWindow(100, 413, tick, window) { // minimum elapsed: 4.992s
+		t.Error("last tick below a fractional window was excluded")
+	}
+	if insideTradeWindow(100, 414, tick, window) { // minimum elapsed: 5.008s
+		t.Error("first tick above a fractional window was included")
+	}
+}
+
+func TestTradeWindowRejectsUnavailableResolution(t *testing.T) {
+	for _, tickTime := range []time.Duration{0, -1} {
+		if insideTradeWindow(100, 101, tickTime, tradeWindow) {
+			t.Errorf("tick duration %s produced a trade", tickTime)
+		}
 	}
 }
 
@@ -364,17 +431,17 @@ func TestDeathsTradedFollowTheHalftimeSwap(t *testing.T) {
 	rt.startRound(map[uint64]common.Team{
 		1: common.TeamTerrorists, 2: common.TeamTerrorists, 11: common.TeamCounterTerrorists,
 	})
-	rt.kill(11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
-	rt.kill(2, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(13))
-	a.applyRoundOutcome(endRound(rt, common.TeamTerrorists))
+	recordKill(rt, 11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
+	recordKill(rt, 2, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(13))
+	a.applyRoundOutcomeWithTiers(endRound(rt, common.TeamTerrorists), a.roundTiers)
 
 	// After halftime the same players swap sides and repeat the trade.
 	rt.startRound(map[uint64]common.Team{
 		1: common.TeamCounterTerrorists, 2: common.TeamCounterTerrorists, 11: common.TeamTerrorists,
 	})
-	rt.kill(11, 1, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(20))
-	rt.kill(2, 11, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(23))
-	a.applyRoundOutcome(endRound(rt, common.TeamCounterTerrorists))
+	recordKill(rt, 11, 1, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(20))
+	recordKill(rt, 2, 11, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(23))
+	a.applyRoundOutcomeWithTiers(endRound(rt, common.TeamCounterTerrorists), a.roundTiers)
 
 	if got, want := a.players[1].DeathsTraded, (SideCount{Total: 2, CT: 1, T: 1}); got != want {
 		t.Errorf("deaths traded = %+v, want %+v after the side swap", got, want)
@@ -386,7 +453,7 @@ func TestKastSurvivorAndUninvolvedVictim(t *testing.T) {
 	rt.startRound(fiveVsFive())
 
 	// Player 5 dies untraded with no kills or assists; everyone else survives.
-	rt.kill(11, 5, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
+	recordKill(rt, 11, 5, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
 
 	outcome := endRound(rt, common.TeamCounterTerrorists)
 	if outcome.kast[5] {
@@ -404,12 +471,29 @@ func TestAssisterGetsKast(t *testing.T) {
 	rt := newRoundTracker()
 	rt.startRound(fiveVsFive())
 
-	rt.kill(11, 5, common.TeamCounterTerrorists, common.TeamTerrorists, 12, false, at(10))
+	recordKill(rt, 11, 5, common.TeamCounterTerrorists, common.TeamTerrorists, 12, false, at(10))
 	// Assister 12 then dies untraded: KAST must survive through the assist.
-	rt.kill(1, 12, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(20))
+	recordKill(rt, 1, 12, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(20))
 
 	if outcome := endRound(rt, common.TeamCounterTerrorists); !outcome.kast[12] {
 		t.Error("player 12 assisted and must have KAST")
+	}
+}
+
+func TestFlashAssistOnlyCountsForRatingKAST(t *testing.T) {
+	rt := newRoundTracker()
+	rt.startRound(fiveVsFive())
+
+	rt.kill(11, 5, common.TeamCounterTerrorists, common.TeamTerrorists, 12, true, false, 10, time.Second)
+	// The flash assister then dies without another qualifying classic-KAST fact.
+	recordKill(rt, 1, 12, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(20))
+
+	outcome := endRound(rt, common.TeamCounterTerrorists)
+	if outcome.kast[12] {
+		t.Error("flash assist alone must not qualify classic KAST")
+	}
+	if !outcome.ratingKast[12] {
+		t.Error("flash assist must remain a rating-KAST assist")
 	}
 }
 
@@ -418,7 +502,7 @@ func TestSuicideAndWorldDeaths(t *testing.T) {
 	rt.startRound(fiveVsFive())
 
 	// Killer id 0 marks world deaths and suicides.
-	rt.kill(0, 1, common.TeamUnassigned, common.TeamTerrorists, 0, true, at(10))
+	recordKill(rt, 0, 1, common.TeamUnassigned, common.TeamTerrorists, 0, true, at(10))
 
 	outcome := endRound(rt, common.TeamCounterTerrorists)
 	if len(outcome.aces) != 0 {
@@ -459,9 +543,7 @@ func TestPostRoundDisconnectKeepsSurvival(t *testing.T) {
 func TestEventsBeforeRoundStartAreIgnored(t *testing.T) {
 	rt := newRoundTracker()
 
-	if rt.kill(1, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10)) {
-		t.Error("kill before any round start should not be a trade")
-	}
+	recordKill(rt, 1, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10))
 	rt.remove(11)
 	if outcome := endRound(rt, common.TeamTerrorists); outcome.played {
 		t.Error("round end without round start should not count as played")
@@ -474,7 +556,7 @@ func TestPostRoundExitFragCancelsSurvival(t *testing.T) {
 	rt.markEnd(common.TeamCounterTerrorists)
 
 	// A real enemy kill after the round is decided still cancels survival.
-	rt.kill(11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(70))
+	recordKill(rt, 11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(70))
 
 	outcome := rt.finalize()
 	if outcome.kast[1] {
@@ -492,7 +574,7 @@ func TestPostRoundBombDeathCancelsSurvival(t *testing.T) {
 
 	// The event still cancels survival. Raw totals apply their separate
 	// round/game-phase rule in the analyser.
-	rt.kill(0, 1, common.TeamUnassigned, common.TeamTerrorists, 0, false, at(70))
+	recordKill(rt, 0, 1, common.TeamUnassigned, common.TeamTerrorists, 0, false, at(70))
 
 	if outcome := rt.finalize(); outcome.kast[1] {
 		t.Error("player 1 died to the bomb and must not get survival KAST")
@@ -506,7 +588,7 @@ func TestMatchEndWorldDeathKeepsSurvival(t *testing.T) {
 
 	// Match-end cleanup kills (weapon World, no killer) are artifacts, not
 	// real deaths.
-	rt.kill(0, 1, common.TeamUnassigned, common.TeamTerrorists, 0, true, at(70))
+	recordKill(rt, 0, 1, common.TeamUnassigned, common.TeamTerrorists, 0, true, at(70))
 
 	if outcome := rt.finalize(); !outcome.kast[1] {
 		t.Error("player 1 survived the round; the match-end world kill must not cancel it")
@@ -520,7 +602,7 @@ func TestNoClutchCandidacyAfterRoundDecided(t *testing.T) {
 
 	// Post-round exit frags leave player 1 as the only T alive.
 	for i, victim := range []uint64{2, 3, 4, 5} {
-		rt.kill(11, victim, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(70+i))
+		recordKill(rt, 11, victim, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(70+i))
 	}
 
 	if outcome := rt.finalize(); outcome.clutcher != 0 {
@@ -532,8 +614,8 @@ func TestOpeningDuelGoesToFirstEnemyKill(t *testing.T) {
 	rt := newRoundTracker()
 	rt.startRound(fiveVsFive())
 
-	rt.kill(11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
-	rt.kill(2, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(12))
+	recordKill(rt, 11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
+	recordKill(rt, 2, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(12))
 
 	outcome := endRound(rt, common.TeamCounterTerrorists)
 	want := openingDuel{killer: 11, victim: 1, killerTeam: common.TeamCounterTerrorists, victimTeam: common.TeamTerrorists}
@@ -549,7 +631,7 @@ func TestOpeningDuelInLostRoundIsNotWon(t *testing.T) {
 	rt := newRoundTracker()
 	rt.startRound(fiveVsFive())
 
-	rt.kill(11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
+	recordKill(rt, 11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
 
 	if outcome := endRound(rt, common.TeamTerrorists); outcome.openingWon {
 		t.Error("the opening killer's team lost the round, openingWon must be false")
@@ -561,9 +643,9 @@ func TestOpeningDuelSkipsTeamkillsAndWorldDeaths(t *testing.T) {
 	rt.startRound(fiveVsFive())
 
 	// A teamkill and a fall death come first; neither opens the round.
-	rt.kill(1, 2, common.TeamTerrorists, common.TeamTerrorists, 0, false, at(5))
-	rt.kill(0, 3, common.TeamUnassigned, common.TeamTerrorists, 0, true, at(8))
-	rt.kill(11, 4, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
+	recordKill(rt, 1, 2, common.TeamTerrorists, common.TeamTerrorists, 0, false, at(5))
+	recordKill(rt, 0, 3, common.TeamUnassigned, common.TeamTerrorists, 0, true, at(8))
+	recordKill(rt, 11, 4, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(10))
 
 	outcome := endRound(rt, common.TeamCounterTerrorists)
 	if outcome.opening.killer != 11 || outcome.opening.victim != 4 {
@@ -590,7 +672,7 @@ func TestPostRoundKillIsNotAnOpeningDuel(t *testing.T) {
 	rt.markEnd(common.TeamCounterTerrorists)
 
 	// An exit frag in an otherwise killless round is no entry.
-	rt.kill(11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(70))
+	recordKill(rt, 11, 1, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(70))
 
 	if outcome := rt.finalize(); outcome.opening.killer != 0 {
 		t.Errorf("opening = %+v, want none after the round was decided", outcome.opening)

--- a/cmd/demo_parser/testdata/README.md
+++ b/cmd/demo_parser/testdata/README.md
@@ -10,6 +10,10 @@ All demos are pinned by SHA-256 in `integration_test.go`; checksums for the two
 downloaded fixtures are repeated in the `Makefile`. Without the demo bytes,
 `go test ./...` skips the affected integration subtest.
 
+The `hltv-*` directories contain JSON oracles only. Their audited demos stay
+outside Git and are selected with `HLTV_DEMO_DIR` or the OS path-list
+`HLTV_EXTRA_DEMO_DIRS`; see [`_docs/HLTV_REGRESSION.md`](../../../_docs/HLTV_REGRESSION.md).
+
 ## mirage.dem
 
 A CS2 match on de_mirage from January 2024, still carrying `round_mvp` game

--- a/cmd/demo_parser/testdata/hltv-128974/expected.json
+++ b/cmd/demo_parser/testdata/hltv-128974/expected.json
@@ -1,0 +1,95 @@
+{
+  "fixture_id": "match-128974",
+  "match_id": 128974,
+  "match_stats_url": "https://www.hltv.org/stats/matches/128974/spirit-vs-mouz",
+  "maps": [
+    {
+      "name": "dust2",
+      "map_id": 234227,
+      "map_stats_url": "https://www.hltv.org/stats/matches/mapstatsid/234227/mouz-vs-spirit",
+      "demo_file": "spirit-vs-mouz-m1-dust2.dem",
+      "demo_sha256": "06075d8cd46422ea9cfd989a4eb849556cd87bcce6b5c83c6343d8e031c9ae19",
+      "parser_map_name": "de_dust2",
+      "rounds": 21,
+      "score_values": [8, 13],
+      "players": [
+        {"steam_id": "76561198386265483", "hltv_name": "donk", "kills": 14, "deaths": 16, "adr": 73.4, "kast_percent": 57.1, "rating": 1.09},
+        {"steam_id": "76561199063238565", "hltv_name": "magixx", "kills": 12, "deaths": 17, "adr": 77.3, "kast_percent": 42.9, "rating": 0.91},
+        {"steam_id": "76561198872013168", "hltv_name": "tN1R", "kills": 12, "deaths": 17, "adr": 50.8, "kast_percent": 57.1, "rating": 0.84},
+        {"steam_id": "76561198081484775", "hltv_name": "sh1ro", "kills": 9, "deaths": 17, "adr": 49.6, "kast_percent": 61.9, "rating": 0.76},
+        {"steam_id": "76561198995880877", "hltv_name": "zont1x", "kills": 9, "deaths": 19, "adr": 63.8, "kast_percent": 52.4, "rating": 0.66},
+        {"steam_id": "76561198063336407", "hltv_name": "Spinx", "kills": 23, "deaths": 8, "adr": 98.0, "kast_percent": 95.2, "rating": 1.91},
+        {"steam_id": "76561198310561479", "hltv_name": "PR", "kills": 18, "deaths": 12, "adr": 108.7, "kast_percent": 81.0, "rating": 1.42},
+        {"steam_id": "76561198355739212", "hltv_name": "torzsi", "kills": 20, "deaths": 11, "adr": 83.3, "kast_percent": 85.7, "rating": 1.14},
+        {"steam_id": "76561198193174134", "hltv_name": "xertioN", "kills": 13, "deaths": 13, "adr": 69.1, "kast_percent": 85.7, "rating": 1.01},
+        {"steam_id": "76561198998266210", "hltv_name": "xelex", "kills": 12, "deaths": 12, "adr": 61.6, "kast_percent": 66.7, "rating": 0.85}
+      ]
+    },
+    {
+      "name": "mirage",
+      "map_id": 234233,
+      "map_stats_url": "https://www.hltv.org/stats/matches/mapstatsid/234233/spirit-vs-mouz",
+      "demo_file": "spirit-vs-mouz-m2-mirage.dem",
+      "demo_sha256": "a1d8cc6e2f9e709d17519157fd577f98db98ea80edd2177c12c9b8c666b11c89",
+      "parser_map_name": "de_mirage",
+      "rounds": 17,
+      "score_values": [4, 13],
+      "players": [
+        {"steam_id": "76561198386265483", "hltv_name": "donk", "kills": 10, "deaths": 15, "adr": 70.5, "kast_percent": 52.9, "rating": 0.89},
+        {"steam_id": "76561198995880877", "hltv_name": "zont1x", "kills": 11, "deaths": 15, "adr": 69.8, "kast_percent": 58.8, "rating": 0.89},
+        {"steam_id": "76561198081484775", "hltv_name": "sh1ro", "kills": 7, "deaths": 14, "adr": 59.6, "kast_percent": 52.9, "rating": 0.58},
+        {"steam_id": "76561198872013168", "hltv_name": "tN1R", "kills": 6, "deaths": 16, "adr": 49.1, "kast_percent": 52.9, "rating": 0.55},
+        {"steam_id": "76561199063238565", "hltv_name": "magixx", "kills": 4, "deaths": 14, "adr": 39.4, "kast_percent": 52.9, "rating": 0.53},
+        {"steam_id": "76561198063336407", "hltv_name": "Spinx", "kills": 20, "deaths": 5, "adr": 95.6, "kast_percent": 88.2, "rating": 1.86},
+        {"steam_id": "76561198998266210", "hltv_name": "xelex", "kills": 17, "deaths": 8, "adr": 107.1, "kast_percent": 82.4, "rating": 1.78},
+        {"steam_id": "76561198310561479", "hltv_name": "PR", "kills": 14, "deaths": 6, "adr": 75.7, "kast_percent": 94.1, "rating": 1.32},
+        {"steam_id": "76561198355739212", "hltv_name": "torzsi", "kills": 14, "deaths": 8, "adr": 73.6, "kast_percent": 82.4, "rating": 1.14},
+        {"steam_id": "76561198193174134", "hltv_name": "xertioN", "kills": 9, "deaths": 11, "adr": 79.7, "kast_percent": 88.2, "rating": 0.94}
+      ]
+    },
+    {
+      "name": "ancient",
+      "map_id": 234238,
+      "map_stats_url": "https://www.hltv.org/stats/matches/mapstatsid/234238/mouz-vs-spirit",
+      "demo_file": "spirit-vs-mouz-m3-ancient.dem",
+      "demo_sha256": "4ddc87a2b87ff604ccfeb5ee498f543b45afa1f22e8366163db73e828eeb0785",
+      "parser_map_name": "de_ancient",
+      "rounds": 22,
+      "score_values": [9, 13],
+      "players": [
+        {"steam_id": "76561198386265483", "hltv_name": "donk", "kills": 21, "deaths": 16, "adr": 108.9, "kast_percent": 81.8, "rating": 1.37},
+        {"steam_id": "76561199063238565", "hltv_name": "magixx", "kills": 13, "deaths": 10, "adr": 65.0, "kast_percent": 68.2, "rating": 1.30},
+        {"steam_id": "76561198995880877", "hltv_name": "zont1x", "kills": 17, "deaths": 17, "adr": 82.8, "kast_percent": 72.7, "rating": 1.05},
+        {"steam_id": "76561198872013168", "hltv_name": "tN1R", "kills": 11, "deaths": 13, "adr": 52.1, "kast_percent": 72.7, "rating": 1.01},
+        {"steam_id": "76561198081484775", "hltv_name": "sh1ro", "kills": 13, "deaths": 13, "adr": 62.0, "kast_percent": 63.6, "rating": 0.92},
+        {"steam_id": "76561198063336407", "hltv_name": "Spinx", "kills": 15, "deaths": 14, "adr": 82.9, "kast_percent": 68.2, "rating": 1.16},
+        {"steam_id": "76561198355739212", "hltv_name": "torzsi", "kills": 15, "deaths": 11, "adr": 56.3, "kast_percent": 81.8, "rating": 1.04},
+        {"steam_id": "76561198998266210", "hltv_name": "xelex", "kills": 17, "deaths": 16, "adr": 64.8, "kast_percent": 72.7, "rating": 0.91},
+        {"steam_id": "76561198310561479", "hltv_name": "PR", "kills": 10, "deaths": 17, "adr": 74.7, "kast_percent": 72.7, "rating": 0.79},
+        {"steam_id": "76561198193174134", "hltv_name": "xertioN", "kills": 12, "deaths": 18, "adr": 61.8, "kast_percent": 59.1, "rating": 0.72}
+      ]
+    },
+    {
+      "name": "nuke",
+      "map_id": 234256,
+      "map_stats_url": "https://www.hltv.org/stats/matches/mapstatsid/234256/spirit-vs-mouz",
+      "demo_file": "spirit-vs-mouz-m4-nuke.dem",
+      "demo_sha256": "11596e71c48615b49248b9b3e915ca0b1beaaf29230af90ceb8cbde9267b4337",
+      "parser_map_name": "de_nuke",
+      "rounds": 23,
+      "score_values": [10, 13],
+      "players": [
+        {"steam_id": "76561198081484775", "hltv_name": "sh1ro", "kills": 20, "deaths": 15, "adr": 80.9, "kast_percent": 82.6, "rating": 1.34},
+        {"steam_id": "76561198386265483", "hltv_name": "donk", "kills": 13, "deaths": 18, "adr": 70.5, "kast_percent": 52.2, "rating": 1.00},
+        {"steam_id": "76561198872013168", "hltv_name": "tN1R", "kills": 15, "deaths": 16, "adr": 58.8, "kast_percent": 73.9, "rating": 0.92},
+        {"steam_id": "76561199063238565", "hltv_name": "magixx", "kills": 11, "deaths": 16, "adr": 62.0, "kast_percent": 65.2, "rating": 0.90},
+        {"steam_id": "76561198995880877", "hltv_name": "zont1x", "kills": 13, "deaths": 19, "adr": 83.0, "kast_percent": 60.9, "rating": 0.86},
+        {"steam_id": "76561198063336407", "hltv_name": "Spinx", "kills": 20, "deaths": 11, "adr": 82.9, "kast_percent": 78.3, "rating": 1.41},
+        {"steam_id": "76561198193174134", "hltv_name": "xertioN", "kills": 17, "deaths": 15, "adr": 81.4, "kast_percent": 87.0, "rating": 1.31},
+        {"steam_id": "76561198310561479", "hltv_name": "PR", "kills": 15, "deaths": 18, "adr": 76.5, "kast_percent": 82.6, "rating": 0.98},
+        {"steam_id": "76561198998266210", "hltv_name": "xelex", "kills": 16, "deaths": 17, "adr": 84.2, "kast_percent": 82.6, "rating": 0.98},
+        {"steam_id": "76561198355739212", "hltv_name": "torzsi", "kills": 14, "deaths": 12, "adr": 52.1, "kast_percent": 69.6, "rating": 0.94}
+      ]
+    }
+  ]
+}

--- a/cmd/demo_parser/testdata/hltv-129241/expected.json
+++ b/cmd/demo_parser/testdata/hltv-129241/expected.json
@@ -1,4 +1,5 @@
 {
+  "fixture_id": "match-129241",
   "match_id": 129241,
   "match_stats_url": "https://www.hltv.org/stats/matches/129241/rooster-vs-mindfreak",
   "maps": [

--- a/cmd/demo_parser/testdata/hltv-2396559/expected.json
+++ b/cmd/demo_parser/testdata/hltv-2396559/expected.json
@@ -1,0 +1,29 @@
+{
+  "fixture_id": "match-2396559",
+  "match_id": 2396559,
+  "match_stats_url": "https://www.hltv.org/matches/2396559/spirit-vs-jijiehao-esports-world-cup-2026",
+  "maps": [
+    {
+      "name": "mirage",
+      "map_id": 234956,
+      "map_stats_url": "https://www.hltv.org/stats/matches/mapstatsid/234956/spirit-vs-jijiehao",
+      "demo_file": "spirit-vs-jijiehao-mirage.dem",
+      "demo_sha256": "d68a4453645332f2a1da37acb07b1e4621362145e678e056f5252b213df2dd38",
+      "parser_map_name": "de_mirage",
+      "rounds": 23,
+      "score_values": [10, 13],
+      "players": [
+        {"steam_id": "76561198386265483", "hltv_name": "donk", "kills": 23, "deaths": 16, "adr": 93.2, "kast_percent": 69.6, "rating": 1.58},
+        {"steam_id": "76561199063238565", "hltv_name": "magixx", "kills": 13, "deaths": 15, "adr": 71.5, "kast_percent": 78.3, "rating": 1.18},
+        {"steam_id": "76561198872013168", "hltv_name": "tN1R", "kills": 13, "deaths": 16, "adr": 60.7, "kast_percent": 60.9, "rating": 0.78},
+        {"steam_id": "76561198995880877", "hltv_name": "zont1x", "kills": 10, "deaths": 17, "adr": 53.8, "kast_percent": 56.5, "rating": 0.75},
+        {"steam_id": "76561198081484775", "hltv_name": "sh1ro", "kills": 8, "deaths": 15, "adr": 52.3, "kast_percent": 52.2, "rating": 0.52},
+        {"steam_id": "76561198165327895", "hltv_name": "sinnopsyy", "kills": 17, "deaths": 14, "adr": 95.4, "kast_percent": 82.6, "rating": 1.29},
+        {"steam_id": "76561198422389693", "hltv_name": "m1N1", "kills": 17, "deaths": 12, "adr": 69.6, "kast_percent": 65.2, "rating": 1.21},
+        {"steam_id": "76561198263656468", "hltv_name": "CacaNito", "kills": 14, "deaths": 13, "adr": 64.7, "kast_percent": 73.9, "rating": 1.09},
+        {"steam_id": "76561198110839613", "hltv_name": "Bibu", "kills": 16, "deaths": 15, "adr": 84.6, "kast_percent": 65.2, "rating": 1.04},
+        {"steam_id": "76561199024583803", "hltv_name": "0SAMAS", "kills": 14, "deaths": 13, "adr": 63.9, "kast_percent": 69.6, "rating": 1.00}
+      ]
+    }
+  ]
+}

--- a/cmd/demo_parser/utility_test.go
+++ b/cmd/demo_parser/utility_test.go
@@ -327,6 +327,7 @@ func TestUnusedUtilityCountsRepeatedAndPostRoundCombatDeaths(t *testing.T) {
 	a.onKill(combatDeath)
 	a.onKill(combatDeath)
 	a.parser.(*matchParser).gamePhase = common.GamePhaseGameEnded
+	markRoundScored(a)
 	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
 	a.onKill(combatDeath)
 	a.onKill(events.Kill{Killer: victim, Victim: victim, Weapon: &common.Equipment{Type: common.EqWorld}})


### PR DESCRIPTION
## Summary

- Stage finalized round-derived facts until `TotalRoundsPlayed` advances, so unscored setup/restart rounds do not affect participant rounds, KAST, survival, clutches, MVPs, or Rating 3.0 inputs. Raw kills, deaths, and damage remain event-driven.
- Align classic KAST with the demonstrated event semantics: flash-only assists do not satisfy classic `A`, one revenge kill credits the oldest eligible teammate death, and the inclusive five-second trade boundary uses relative server ticks. Parsing now fails instead of silently reporting no trades when tick duration is unavailable.
- Preserve late event and scoreboard MVP updates behind the same scored-round gate.
- Expand the HLTV regression harness from three to eight maps with fixture-aware exceptions, source URLs, demo checksums, strict 8-map/80-row validation, per-round evidence tracing, and an 18-model trade diagnostic.

## Evidence and scope

The Spirit/MOUZ BO5 contains an unscored setup `RoundStart`: Dust2 has 21 authoritative scored rounds but previously produced 22 participant rounds. Filtering that lifecycle artifact moves the BO5 from 1/40 to 40/40 exact classic-KAST rows.

Eight-map results:

- Original fixture: kills 30/30, deaths 30/30, ADR 30/30, classic KAST 29/30.
- Additional fixtures: kills 50/50, deaths 50/50, ADR 43/50, classic KAST 49/50.
- Combined classic KAST: 78/80.

The two remaining KAST rows are kairo on original Mirage and magixx on standalone Mirage. No evaluated semantic trade model resolves both without regressions, so their exact exceptions remain pinned and issue #38 stays open. The seven additional ADR differences are all ±0.1, are pinned as out-of-scope evidence, and should be handled in a separate follow-up.

Only oracle JSON is committed; audited demo bytes remain external inputs.

Progresses #38.

## Verification

- `REQUIRE_TEST_DEMO=1 go test -count=1 ./...`
- `go vet ./...`
- `gofmt` and `git diff --check`
- Complete external eight-map `TestHLTVRegression` harness with both required-demo gates enabled
- Complete external `TestEvaluateHLTVTradeModels` matrix (18 models)
