### PR TITLE
Hltv trade chain diagnostics

### DIFF
--- a/_docs/HLTV_REGRESSION.md
+++ b/_docs/HLTV_REGRESSION.md
@@ -144,11 +144,12 @@ Two classic-KAST rows remain:
 | Original Inferno | kairo | 9 | Died to Skullhunter at tick 76714. Skullhunter killed 1angel at 76991 and died at 77068. kairo-to-revenge is 354 ticks (5.531 s). No K/A/S/T under the supported rule. | Tool 17/22, HLTV 18/22 |
 | Standalone Mirage | magixx | 22 | Died to bibu at tick 176030. tN1R killed m1N1 at 176051 and bibu at 176358. magixx-to-revenge is 328 ticks (5.125 s). No K/A/S/T under the supported rule. | Tool 17/23, HLTV 18/23 |
 
-`TestEvaluateHLTVTradeModels` replays all eight maps through 18 combinations:
-one death versus multiple deaths per revenge kill, earliest versus nearest
-eligible death, exact time versus timestamp-resolution and normalized-tick
-boundaries, and post-round exclusion versus inclusion. The best general model
-is the production rule—one oldest death, a normalized five-second tick
+`TestEvaluateHLTVTradeModels` replays all eight maps through 18 direct
+combinations—one death versus multiple deaths per revenge kill, earliest
+versus nearest eligible death, exact time versus timestamp-resolution and
+normalized-tick boundaries, and post-round exclusion versus inclusion—plus
+the six focused trade-chain models below. The best general model is the
+production rule—one oldest death, a normalized five-second tick
 boundary—which reaches 29/30 original and 49/50 additional rows. Nearest and
 multiple-death attribution regress already-correct rows. Post-round eligibility
 does not change these eight aggregates, though it remains independently tested.
@@ -157,10 +158,87 @@ A six-second boundary fixes the two rows above but creates other aggregate
 regressions. Absolute-clock rounding is rejected because its effective window
 depends on the demo clock's phase. A scalar cutoff selected between observed
 ticks is also rejected as fitted: the original Mirage contains an already
-correct 358-tick control. No evaluated general rule reaches every oracle, so
-the plan's hard gate applies: the two exact #38 exceptions remain and issue
-#38 must not be closed. A focused follow-up needs either an independent
-per-round HLTV oracle or additional evidence for multi-kill trade sequencing.
+correct 358-tick control. The trade-chain evaluation below completes the
+previously requested follow-up on multi-kill trade sequencing. No evaluated
+direct or chain rule passes the gate, so the two exact #38 exceptions remain
+and issue #38 may close as a documented HLTV implementation limitation.
+Reopening it requires an independent per-round oracle or independently
+observable positive controls.
+
+## Trade-chain diagnostics
+
+Both remaining rows share a shape: the direct death-to-revenge gap exceeds
+five seconds, but an intermediate kill splits it into sub-five-second links.
+The chain diagnostics test whether coherent chain semantics—not a wider
+window—explain them. For each enemy terminal revenge kill `R`, candidate
+deaths are earlier deaths `D` with `D.killer == R.victim` and
+`D.victimTeam == R.killerTeam`. The chain anchor starts at `D`; events
+between `D` and `R` are examined chronologically. A permitted bridge
+re-anchors the window only while the chain is active under the same
+normalized `insideTradeWindow` rule; unrelated events never re-anchor; once
+more than five seconds pass since the current anchor, later events cannot
+revive the candidate; the terminal revenge must land inside five seconds of
+the final anchor; multiple bridges may extend one chain; and each terminal
+revenge credits exactly one death, the earliest chain-eligible by event
+order. All six models keep earliest attribution, normalized ticks, and
+post-round inclusion:
+
+| Model | Permitted bridge |
+| --- | --- |
+| production-control | none |
+| killer-chain | an enemy kill by `D.killer` |
+| revenger-any-chain | any enemy kill by `R.killer` |
+| revenger-assister-chain | `R.killer` killing the nonzero assister of `D` |
+| combined-killer-revenger-any | killer-chain or revenger-any-chain |
+| combined-killer-revenger-assister | killer-chain or revenger-assister-chain |
+
+`production-control` is asserted equal to the canonical direct model
+(earliest/normalized-ticks/post=true) on every player-round of all eight
+maps; aggregate equality alone would let opposite round changes cancel.
+Synthetic tests in `TestChainTradeSemantics` pin each bridge rule, chain
+expiry, earliest-death credit, and the 358-tick no-bridge control.
+
+With the pinned demos the chain models score:
+
+| Model | Combined parity | kairo R9 | magixx R22 | Aggregate regressions |
+| --- | ---: | :-: | :-: | --- |
+| production-control | 78/80 | not traded | not traded | none |
+| killer-chain | 73/80 | traded | not traded | 6 rows |
+| revenger-any-chain | 73/80 | not traded | traded | 6 rows |
+| revenger-assister-chain | 78/80 | not traded | traded | 1 row (Inferno SkulL R18) |
+| combined-killer-revenger-any | 71/80 | traded | traded | 9 rows |
+| combined-killer-revenger-assister | 73/80 | traded | traded | 7 rows |
+
+Every regression row is an independent aggregate-negative control: a
+player-map where production already equals HLTV and the chain model moves the
+aggregate away. Some are additions (the bridged trade credits a death
+production did not) and some are removals (an earlier chain-eligible death
+steals the one credit from the death production traded, e.g. Anubis round 4
+rekonz→ADK). The sharpest aggregate counterexample is Inferno round 18: the
+assister-chain model adds KAST credit to SkulL in a structurally similar
+sequence—his death at tick 139240 avenged 424 ticks later, chelleos killing
+the assister in between—and moves his already-correct player-map aggregate
+one above HLTV. Because HLTV publishes no per-round flags, this disproves
+the model across the map but does not independently establish R18's hidden
+HLTV trade flag. The 358-tick Mirage round-4 control stays excluded under
+all six models. Chain results use HLTV oracle names; the raw sequences in
+the evidence table above use demo aliases: Skullhunter is SkulL, 1angel is
+phoebe, and HARRYPOTTER- is void.
+
+Across all eight maps the structural material is common: 153 killer-bridge
+triples and 99 revenger-any triples (counting unit: one scored-round
+`(D, B, R)` kill tuple per category). 15 of the 99 are also
+revenger-assister triples; as mutually exclusive categories that is 84
+other-enemy plus 15 assister triples. There are 16 distinct `(D, R)` pairs
+whose direct gap is outside the window while some chain stays inside. These
+are structural counts, not controls of either kind. No independently
+observable positive controls exist: HLTV publishes
+only map-level KAST aggregates, and the only two production/HLTV differences
+are the target rows themselves. Since every chain model that explains either
+target row regresses at least one already-correct row, no chain rule is
+promoted to production; the two exact exceptions remain, and issue #38 is
+closable only as a documented HLTV implementation limitation, not by a rule
+change validated against these oracles.
 
 Run the model matrix with the same demo paths plus:
 
@@ -178,9 +256,10 @@ HLTV_TRACE_STEAM_ID=76561199063238565 \
 ```
 
 The trace records participation, side, kills, normal/flash assists, death
-cause/frame/time/tick, every direct trade candidate and trading kill, survival
-at `RoundEnd` and `RoundEndOfficial`, disconnects, scored status, rating-assist
-status, and the final classic-KAST reasons. It writes no files.
+cause/frame/time/tick, the assister's name and SteamID64, every direct trade
+candidate and trading kill, survival at `RoundEnd` and `RoundEndOfficial`,
+disconnects, scored status, rating-assist status, and the final classic-KAST
+reasons. It writes no files.
 
 ## Original issue #38 event evidence
 

--- a/cmd/demo_parser/hltv_trace_test.go
+++ b/cmd/demo_parser/hltv_trace_test.go
@@ -46,6 +46,7 @@ type hltvKillTrace struct {
 	victim        uint64
 	victimName    string
 	victimTeam    common.Team
+	assister      uint64
 	assisterName  string
 	assistedFlash bool
 	cause         string
@@ -132,6 +133,7 @@ func TestTraceHLTVRoundEvidence(t *testing.T) {
 			victim:        trackerID(e.Victim),
 			victimName:    tracePlayerName(e.Victim),
 			victimTeam:    e.Victim.Team,
+			assister:      trackerID(e.Assister),
 			assisterName:  tracePlayerName(e.Assister),
 			assistedFlash: e.AssistedFlash,
 			cause:         traceKillCause(e),
@@ -248,9 +250,9 @@ func logTraceDeaths(t *testing.T, roundNumber int, player uint64, round *hltvRou
 		if death.victim != player {
 			continue
 		}
-		t.Logf("round=%d death player=%s killer=%s cause=%s frame=%d tick=%d time=%s post_round=%t assister=%s flash=%t",
+		t.Logf("round=%d death player=%s killer=%s cause=%s frame=%d tick=%d time=%s post_round=%t assister=%s assister_steam=%d flash=%t",
 			roundNumber, names[player], death.killerName, death.cause, death.frame, death.tick,
-			death.at, death.postRound, death.assisterName, death.assistedFlash)
+			death.at, death.postRound, death.assisterName, death.assister, death.assistedFlash)
 		for offset, revenge := range round.kills[i+1:] {
 			if death.killer == 0 || revenge.killerTeam != death.victimTeam || revenge.victim != death.killer {
 				continue

--- a/cmd/demo_parser/hltv_trade_models_test.go
+++ b/cmd/demo_parser/hltv_trade_models_test.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"slices"
 	"sort"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -43,6 +46,51 @@ func (model hltvTradeModel) String() string {
 	return fmt.Sprintf("%s/%s/post=%t", selections[model.selection], boundaries[model.boundary], model.postRound)
 }
 
+// canonicalDirectTradeModel is the direct model production implements:
+// earliest eligible death, normalized five-second ticks, post-round events
+// included.
+func canonicalDirectTradeModel() hltvTradeModel {
+	return hltvTradeModel{selection: hltvTradeEarliest, boundary: hltvTradeNormalizedTicks, postRound: true}
+}
+
+// hltvChainBridge names which intermediate kill may re-anchor a trade chain
+// between a candidate death and its terminal revenge kill. Every chain model
+// keeps production's other semantics: earliest eligible death, the normalized
+// five-second tick boundary, and post-round inclusion.
+type hltvChainBridge uint8
+
+const (
+	hltvChainNone hltvChainBridge = iota
+	hltvChainKiller
+	hltvChainRevengerAny
+	hltvChainRevengerAssister
+	hltvChainKillerOrRevengerAny
+	hltvChainKillerOrRevengerAssister
+)
+
+func (bridge hltvChainBridge) String() string {
+	names := []string{
+		"production-control",
+		"killer-chain",
+		"revenger-any-chain",
+		"revenger-assister-chain",
+		"combined-killer-revenger-any",
+		"combined-killer-revenger-assister",
+	}
+	return names[bridge]
+}
+
+func allHLTVChainBridges() []hltvChainBridge {
+	return []hltvChainBridge{
+		hltvChainNone,
+		hltvChainKiller,
+		hltvChainRevengerAny,
+		hltvChainRevengerAssister,
+		hltvChainKillerOrRevengerAny,
+		hltvChainKillerOrRevengerAssister,
+	}
+}
+
 type hltvModelFixture struct {
 	oracle hltvOracle
 	maps   map[int][]hltvTradeRoundTrace
@@ -57,6 +105,23 @@ type hltvTradeRoundTrace struct {
 	enemyKills   map[uint64]int
 	assists      map[uint64]assistFacts
 	finalAlive   map[uint64]bool
+}
+
+// hltvTradeCase pins the two remaining classic-KAST aggregate differences and
+// the 358-tick direct gap that production already scores correctly, which
+// every candidate model must keep excluded.
+type hltvTradeCase struct {
+	label     string
+	fixtureID string
+	mapID     int
+	steamID   uint64
+	round     int
+}
+
+var hltvTradeCases = []hltvTradeCase{
+	{label: "kairo-R9", fixtureID: "match-129241", mapID: 234944, steamID: 76561199048086137, round: 9},
+	{label: "magixx-R22", fixtureID: "match-2396559", mapID: 234956, steamID: 76561199063238565, round: 22},
+	{label: "mirage-R4-control", fixtureID: "match-129241", mapID: 234947, steamID: 76561198127259887, round: 4},
 }
 
 // TestEvaluateHLTVTradeModels is an opt-in diagnostic matrix. It evaluates
@@ -100,17 +165,49 @@ func TestEvaluateHLTVTradeModels(t *testing.T) {
 	}
 	validateHLTVOracleSet(t, hltvOracleSpecs, oracles)
 
-	for _, model := range allHLTVTradeModels() {
+	names := make(map[hltvFixtureMapKey]map[uint64]string)
+	wantKAST := make(map[hltvFixtureMapKey]map[uint64]int)
+	for _, fixture := range fixtures {
+		for _, expectedMap := range fixture.oracle.Maps {
+			key := hltvFixtureMapKey{FixtureID: fixture.oracle.FixtureID, MapID: expectedMap.MapID}
+			names[key] = make(map[uint64]string, len(expectedMap.Players))
+			wantKAST[key] = make(map[uint64]int, len(expectedMap.Players))
+			for _, player := range expectedMap.Players {
+				names[key][player.SteamID] = player.HLTVName
+				wantKAST[key][player.SteamID] = kastRounds(player.KASTPercent, expectedMap.Rounds)
+			}
+		}
+	}
+
+	canonical := canonicalDirectTradeModel()
+	production := make(map[hltvFixtureMapKey][]map[uint64]bool)
+	productionCounts := make(map[hltvFixtureMapKey]map[uint64]int)
+	for _, fixture := range fixtures {
+		for _, expectedMap := range fixture.oracle.Maps {
+			key := hltvFixtureMapKey{FixtureID: fixture.oracle.FixtureID, MapID: expectedMap.MapID}
+			byRound := evaluatedKASTByRound(fixture.maps[expectedMap.MapID],
+				func(round *hltvTradeRoundTrace) map[uint64]bool { return modelTradedDeaths(round, canonical) })
+			production[key] = byRound
+			productionCounts[key] = kastVectorCounts(byRound)
+		}
+	}
+
+	logHLTVTradeCaseRounds(t, fixtures, names)
+	assertProductionControlInvariant(t, fixtures, canonical)
+
+	for _, evaluation := range allEvaluatedTradeModels() {
 		originalMatches, originalRows := 0, 0
 		extraMatches, extraRows := 0, 0
-		var mismatches []string
+		var mismatches, changedPlayerRounds, aggregateShifts, negativeControls, caseLines []string
 		for i, fixture := range fixtures {
 			for _, expectedMap := range fixture.oracle.Maps {
+				key := hltvFixtureMapKey{FixtureID: fixture.oracle.FixtureID, MapID: expectedMap.MapID}
 				traces := fixture.maps[expectedMap.MapID]
-				gotByPlayer := modelKASTRounds(traces, model)
+				byRound := evaluatedKASTByRound(traces, evaluation.traded)
+				counts := kastVectorCounts(byRound)
 				for _, expectedPlayer := range expectedMap.Players {
-					got := gotByPlayer[expectedPlayer.SteamID]
-					want := kastRounds(expectedPlayer.KASTPercent, expectedMap.Rounds)
+					got := counts[expectedPlayer.SteamID]
+					want := wantKAST[key][expectedPlayer.SteamID]
 					if hltvOracleSpecs[i].Extra {
 						extraRows++
 						if got == want {
@@ -126,13 +223,79 @@ func TestEvaluateHLTVTradeModels(t *testing.T) {
 						mismatches = append(mismatches, fmt.Sprintf("%s/%d/%s=%d:%d",
 							fixture.oracle.FixtureID, expectedMap.MapID, expectedPlayer.HLTVName, got, want))
 					}
+					prodVector := playerKASTVector(production[key], expectedPlayer.SteamID)
+					modelVector := playerKASTVector(byRound, expectedPlayer.SteamID)
+					if !slices.Equal(prodVector, modelVector) {
+						prodCount := productionCounts[key][expectedPlayer.SteamID]
+						shift := classifyAggregateShift(true, prodCount, got, want)
+						aggregateShifts = append(aggregateShifts, fmt.Sprintf("%s/%d/%s=%s(production=%d,model=%d,hltv=%d)",
+							fixture.oracle.FixtureID, expectedMap.MapID, expectedPlayer.HLTVName, shift, prodCount, got, want))
+						if prodCount == want && shift == hltvShiftFarther {
+							negativeControls = append(negativeControls, fmt.Sprintf("%s/%d/%s",
+								fixture.oracle.FixtureID, expectedMap.MapID, expectedPlayer.HLTVName))
+						}
+					}
+				}
+				for roundIndex := range byRound {
+					for _, id := range slices.Sorted(maps.Keys(byRound[roundIndex])) {
+						prodValue := production[key][roundIndex][id]
+						modelValue := byRound[roundIndex][id]
+						if prodValue != modelValue {
+							changedPlayerRounds = append(changedPlayerRounds, fmt.Sprintf("%s/%d/%s/round=%d:%t->%t",
+								fixture.oracle.FixtureID, expectedMap.MapID, hltvPlayerLabel(names[key], id), roundIndex+1, prodValue, modelValue))
+						}
+					}
+				}
+				for _, tradeCase := range hltvTradeCases {
+					if tradeCase.fixtureID != key.FixtureID || tradeCase.mapID != key.MapID ||
+						tradeCase.round < 1 || tradeCase.round > len(traces) {
+						continue
+					}
+					tradedSet := evaluation.traded(&traces[tradeCase.round-1])
+					caseLines = append(caseLines, fmt.Sprintf("case=%s traded=%t kast=%t",
+						tradeCase.label, tradedSet[tradeCase.steamID], byRound[tradeCase.round-1][tradeCase.steamID]))
 				}
 			}
 		}
 		sort.Strings(mismatches)
-		t.Logf("model=%s original=%d/%d extra=%d/%d mismatches=%v",
-			model, originalMatches, originalRows, extraMatches, extraRows, mismatches)
+		t.Logf("model=%s original=%d/%d additional=%d/%d combined=%d/%d mismatches=%v",
+			evaluation.name, originalMatches, originalRows, extraMatches, extraRows,
+			originalMatches+extraMatches, originalRows+extraRows, mismatches)
+		t.Logf("model=%s changed_player_rounds=%d %v", evaluation.name, len(changedPlayerRounds), changedPlayerRounds)
+		t.Logf("model=%s aggregate_shifts=%v independent_negative_controls=%v",
+			evaluation.name, aggregateShifts, negativeControls)
+		for _, line := range caseLines {
+			t.Logf("model=%s %s", evaluation.name, line)
+		}
 	}
+
+	t.Logf("positive controls: none are independently observable; HLTV publishes only map-level KAST aggregates, and the only two production/HLTV KAST differences are the kairo-R9 and magixx-R22 target rows themselves")
+	reportChainStructure(t, fixtures, names)
+}
+
+type hltvEvaluatedTradeModel struct {
+	name   string
+	traded func(*hltvTradeRoundTrace) map[uint64]bool
+}
+
+// allEvaluatedTradeModels lists the original 18 direct combinations followed
+// by the six focused chain models. The chain dimension is deliberately not
+// multiplied across the unrelated attribution and boundary dimensions.
+func allEvaluatedTradeModels() []hltvEvaluatedTradeModel {
+	var evaluations []hltvEvaluatedTradeModel
+	for _, model := range allHLTVTradeModels() {
+		evaluations = append(evaluations, hltvEvaluatedTradeModel{
+			name:   model.String(),
+			traded: func(round *hltvTradeRoundTrace) map[uint64]bool { return modelTradedDeaths(round, model) },
+		})
+	}
+	for _, bridge := range allHLTVChainBridges() {
+		evaluations = append(evaluations, hltvEvaluatedTradeModel{
+			name:   bridge.String(),
+			traded: func(round *hltvTradeRoundTrace) map[uint64]bool { return chainTradedDeaths(round, bridge) },
+		})
+	}
+	return evaluations
 }
 
 func allHLTVTradeModels() []hltvTradeModel {
@@ -204,6 +367,7 @@ func collectHLTVRoundTraces(t *testing.T, demoPath string) []hltvTradeRoundTrace
 			killerTeam: tracePlayerTeam(event.Killer),
 			victim:     trackerID(event.Victim),
 			victimTeam: event.Victim.Team,
+			assister:   trackerID(event.Assister),
 			postRound:  analysis.tracker.isPostRound(),
 		})
 		snapshot()
@@ -220,19 +384,41 @@ func collectHLTVRoundTraces(t *testing.T, demoPath string) []hltvTradeRoundTrace
 	return traces
 }
 
-func modelKASTRounds(rounds []hltvTradeRoundTrace, model hltvTradeModel) map[uint64]int {
-	qualifying := make(map[uint64]int)
+// evaluatedKASTByRound derives the per-round classic-KAST booleans of every
+// round participant under one traded-death model.
+func evaluatedKASTByRound(rounds []hltvTradeRoundTrace, traded func(*hltvTradeRoundTrace) map[uint64]bool) []map[uint64]bool {
+	byRound := make([]map[uint64]bool, len(rounds))
 	for i := range rounds {
 		round := &rounds[i]
-		traded := modelTradedDeaths(round, model)
+		tradedSet := traded(round)
+		kast := make(map[uint64]bool, len(round.participants))
 		for player := range round.participants {
-			if round.enemyKills[player] > 0 || round.assists[player]&classicAssist != 0 ||
-				round.finalAlive[player] || traded[player] {
-				qualifying[player]++
+			kast[player] = round.enemyKills[player] > 0 || round.assists[player]&classicAssist != 0 ||
+				round.finalAlive[player] || tradedSet[player]
+		}
+		byRound[i] = kast
+	}
+	return byRound
+}
+
+func kastVectorCounts(byRound []map[uint64]bool) map[uint64]int {
+	counts := make(map[uint64]int)
+	for _, kast := range byRound {
+		for player, qualified := range kast {
+			if qualified {
+				counts[player]++
 			}
 		}
 	}
-	return qualifying
+	return counts
+}
+
+func playerKASTVector(byRound []map[uint64]bool, player uint64) []bool {
+	vector := make([]bool, len(byRound))
+	for i, kast := range byRound {
+		vector[i] = kast[player]
+	}
+	return vector
 }
 
 func modelTradedDeaths(round *hltvTradeRoundTrace, model hltvTradeModel) map[uint64]bool {
@@ -280,5 +466,538 @@ func (model hltvTradeModel) insideWindow(death, revenge hltvKillTrace, tickTime 
 		return insideTradeWindow(death.tick, revenge.tick, tickTime, tradeWindow)
 	default:
 		return false
+	}
+}
+
+// chainBridgePermits reports whether an intermediate kill may re-anchor the
+// chain from death towards revenge under the bridge rule.
+func chainBridgePermits(bridge hltvChainBridge, death, revenge, event hltvKillTrace) bool {
+	switch bridge {
+	case hltvChainKiller:
+		return chainKillerActivity(death, event)
+	case hltvChainRevengerAny:
+		return chainRevengerActivity(revenge, event)
+	case hltvChainRevengerAssister:
+		return chainRevengerKilledAssister(death, revenge, event)
+	case hltvChainKillerOrRevengerAny:
+		return chainKillerActivity(death, event) || chainRevengerActivity(revenge, event)
+	case hltvChainKillerOrRevengerAssister:
+		return chainKillerActivity(death, event) || chainRevengerKilledAssister(death, revenge, event)
+	default:
+		return false
+	}
+}
+
+// chainKillerActivity is a further enemy kill by the original killer.
+func chainKillerActivity(death, event hltvKillTrace) bool {
+	return event.killer != 0 && event.killer == death.killer && event.killerTeam != event.victimTeam
+}
+
+// chainRevengerActivity is any enemy kill by the eventual revenger.
+func chainRevengerActivity(revenge, event hltvKillTrace) bool {
+	return event.killer != 0 && event.killer == revenge.killer && event.killerTeam != event.victimTeam
+}
+
+// chainRevengerKilledAssister is the eventual revenger landing an enemy kill
+// on the nonzero assister of the original death. A teamkill never bridges,
+// even on the matching SteamID.
+func chainRevengerKilledAssister(death, revenge, event hltvKillTrace) bool {
+	return death.assister != 0 && event.killer == revenge.killer &&
+		event.victim == death.assister && event.killerTeam != event.victimTeam
+}
+
+// chainEligible walks the events between a candidate death and the terminal
+// revenge kill in order. A permitted bridge re-anchors the five-second window
+// only while the chain is still active; once more than five seconds passed
+// since the current anchor, no later event revives the candidate. Unrelated
+// events never re-anchor. The terminal revenge must land inside five seconds
+// of the final anchor, always through the normalized insideTradeWindow rule.
+func chainEligible(round *hltvTradeRoundTrace, deathIndex, revengeIndex int, bridge hltvChainBridge) bool {
+	death := round.kills[deathIndex]
+	revenge := round.kills[revengeIndex]
+	anchor := death
+	for _, event := range round.kills[deathIndex+1 : revengeIndex] {
+		if !chainBridgePermits(bridge, death, revenge, event) {
+			continue
+		}
+		if !insideTradeWindow(anchor.tick, event.tick, round.tickTime, tradeWindow) {
+			return false
+		}
+		anchor = event
+	}
+	return insideTradeWindow(anchor.tick, revenge.tick, round.tickTime, tradeWindow)
+}
+
+// chainTradedDeaths applies one chain model to a recorded round. Candidate
+// deaths for an enemy terminal revenge kill R are earlier deaths D with
+// D.killer == R.victim and D.victimTeam == R.killerTeam. Each terminal
+// revenge credits exactly one death: the earliest chain-eligible death by
+// event order.
+func chainTradedDeaths(round *hltvTradeRoundTrace, bridge hltvChainBridge) map[uint64]bool {
+	traded := make(map[uint64]bool)
+	for revengeIndex, revenge := range round.kills {
+		if revenge.killer == 0 || revenge.killerTeam == revenge.victimTeam {
+			continue
+		}
+		for deathIndex, death := range round.kills[:revengeIndex] {
+			if death.killer != revenge.victim || death.victimTeam != revenge.killerTeam {
+				continue
+			}
+			if chainEligible(round, deathIndex, revengeIndex, bridge) {
+				traded[death.victim] = true
+				break
+			}
+		}
+	}
+	return traded
+}
+
+type hltvAggregateShift string
+
+const (
+	hltvShiftUnchanged     hltvAggregateShift = "unchanged"
+	hltvShiftCloser        hltvAggregateShift = "closer"
+	hltvShiftFarther       hltvAggregateShift = "farther"
+	hltvShiftIndeterminate hltvAggregateShift = "aggregate-indeterminate"
+)
+
+// classifyAggregateShift compares one player-map against production and HLTV.
+// Counts alone cannot prove per-round agreement, so an unchanged verdict
+// requires the exact per-round vector to match production.
+func classifyAggregateShift(vectorChanged bool, productionCount, modelCount, hltvCount int) hltvAggregateShift {
+	if !vectorChanged {
+		return hltvShiftUnchanged
+	}
+	productionDistance := intAbs(productionCount - hltvCount)
+	modelDistance := intAbs(modelCount - hltvCount)
+	switch {
+	case modelDistance < productionDistance:
+		return hltvShiftCloser
+	case modelDistance > productionDistance:
+		return hltvShiftFarther
+	default:
+		return hltvShiftIndeterminate
+	}
+}
+
+func intAbs(value int) int {
+	if value < 0 {
+		return -value
+	}
+	return value
+}
+
+func hltvPlayerLabel(names map[uint64]string, id uint64) string {
+	if id == 0 {
+		return "World"
+	}
+	if name, ok := names[id]; ok {
+		return name
+	}
+	return strconv.FormatUint(id, 10)
+}
+
+// logHLTVTradeCaseRounds prints the full kill sequence of the three pinned
+// rounds once so every model verdict can be checked against the raw events.
+func logHLTVTradeCaseRounds(t *testing.T, fixtures []hltvModelFixture, names map[hltvFixtureMapKey]map[uint64]string) {
+	t.Helper()
+	for _, tradeCase := range hltvTradeCases {
+		round := findHLTVTradeCaseRound(fixtures, tradeCase)
+		if round == nil {
+			t.Errorf("case %s references missing fixture/map/round %s/%d/%d",
+				tradeCase.label, tradeCase.fixtureID, tradeCase.mapID, tradeCase.round)
+			continue
+		}
+		key := hltvFixtureMapKey{FixtureID: tradeCase.fixtureID, MapID: tradeCase.mapID}
+		kills := make([]string, len(round.kills))
+		for i, kill := range round.kills {
+			label := fmt.Sprintf("%s->%s@%d", hltvPlayerLabel(names[key], kill.killer),
+				hltvPlayerLabel(names[key], kill.victim), kill.tick)
+			if kill.assister != 0 {
+				label += fmt.Sprintf("(+%s)", hltvPlayerLabel(names[key], kill.assister))
+			}
+			kills[i] = label
+		}
+		t.Logf("case=%s round=%d kills=%s", tradeCase.label, tradeCase.round, strings.Join(kills, ","))
+	}
+}
+
+func findHLTVTradeCaseRound(fixtures []hltvModelFixture, tradeCase hltvTradeCase) *hltvTradeRoundTrace {
+	for _, fixture := range fixtures {
+		if fixture.oracle.FixtureID != tradeCase.fixtureID {
+			continue
+		}
+		traces := fixture.maps[tradeCase.mapID]
+		if tradeCase.round >= 1 && tradeCase.round <= len(traces) {
+			return &traces[tradeCase.round-1]
+		}
+	}
+	return nil
+}
+
+// assertProductionControlInvariant fails when the production-control chain
+// model diverges from the canonical direct model on any player-round KAST
+// boolean or on any scored round's traded-death set. Aggregate equality
+// would be insufficient: opposite round changes cancel. The traded-set check
+// matters separately because another K/A/S reason could conceal a different
+// trade attribution behind an identical KAST boolean.
+func assertProductionControlInvariant(t *testing.T, fixtures []hltvModelFixture, canonical hltvTradeModel) {
+	t.Helper()
+	mismatched := 0
+	for _, fixture := range fixtures {
+		for _, expectedMap := range fixture.oracle.Maps {
+			traces := fixture.maps[expectedMap.MapID]
+			direct := evaluatedKASTByRound(traces, func(round *hltvTradeRoundTrace) map[uint64]bool {
+				return modelTradedDeaths(round, canonical)
+			})
+			control := evaluatedKASTByRound(traces, func(round *hltvTradeRoundTrace) map[uint64]bool {
+				return chainTradedDeaths(round, hltvChainNone)
+			})
+			for roundIndex := range traces {
+				directTraded := modelTradedDeaths(&traces[roundIndex], canonical)
+				controlTraded := chainTradedDeaths(&traces[roundIndex], hltvChainNone)
+				if !maps.Equal(directTraded, controlTraded) {
+					mismatched++
+					t.Errorf("production-control traded set diverges from %s on %s/%d round %d: direct=%v control=%v",
+						canonical, fixture.oracle.FixtureID, expectedMap.MapID, roundIndex+1,
+						slices.Sorted(maps.Keys(directTraded)), slices.Sorted(maps.Keys(controlTraded)))
+				}
+				for _, id := range slices.Sorted(maps.Keys(direct[roundIndex])) {
+					if direct[roundIndex][id] != control[roundIndex][id] {
+						mismatched++
+						t.Errorf("production-control diverges from %s on %s/%d round %d player %d: direct=%t control=%t",
+							canonical, fixture.oracle.FixtureID, expectedMap.MapID, roundIndex+1, id,
+							direct[roundIndex][id], control[roundIndex][id])
+					}
+				}
+			}
+		}
+	}
+	if mismatched == 0 {
+		t.Logf("invariant: production-control matches %s on every player-round KAST boolean and every scored round's traded-death set across all eight maps", canonical)
+	}
+}
+
+// reportChainStructure enumerates the deterministic structural material the
+// chain models could act on. These are structural counts, not independent
+// controls. The counting unit for the three bridge categories is one
+// (scored round, death index D, bridge index B, revenge index R) kill tuple
+// with D.killer == R.victim, D.victimTeam == R.killerTeam and D < B < R in
+// event order. A chain-only row is one (bridge model, D, R) pair whose direct
+// gap is outside the normalized five-second window while every permitted
+// chain link stays inside it. Output follows fixture, oracle map, round and
+// kill order, so it is deterministic.
+func reportChainStructure(t *testing.T, fixtures []hltvModelFixture, names map[hltvFixtureMapKey]map[uint64]string) {
+	t.Helper()
+	t.Logf("structure counting unit: bridge triples are (scored round, D, B, R) kill tuples per category; chain-only rows are (bridge model, D, R) pairs with the direct gap outside the normalized window and every permitted link inside it")
+	for _, fixture := range fixtures {
+		for _, expectedMap := range fixture.oracle.Maps {
+			key := hltvFixtureMapKey{FixtureID: fixture.oracle.FixtureID, MapID: expectedMap.MapID}
+			traces := fixture.maps[expectedMap.MapID]
+			killerTriples, revengerAnyTriples, revengerAssisterTriples := 0, 0, 0
+			var chainOnly []string
+			for roundIndex := range traces {
+				round := &traces[roundIndex]
+				for revengeIndex, revenge := range round.kills {
+					if revenge.killer == 0 || revenge.killerTeam == revenge.victimTeam {
+						continue
+					}
+					for deathIndex, death := range round.kills[:revengeIndex] {
+						if death.killer != revenge.victim || death.victimTeam != revenge.killerTeam {
+							continue
+						}
+						for _, event := range round.kills[deathIndex+1 : revengeIndex] {
+							if chainKillerActivity(death, event) {
+								killerTriples++
+							}
+							if chainRevengerActivity(revenge, event) {
+								revengerAnyTriples++
+							}
+							if chainRevengerKilledAssister(death, revenge, event) {
+								revengerAssisterTriples++
+							}
+						}
+						if insideTradeWindow(death.tick, revenge.tick, round.tickTime, tradeWindow) {
+							continue
+						}
+						for _, bridge := range allHLTVChainBridges()[1:] {
+							if chainEligible(round, deathIndex, revengeIndex, bridge) {
+								chainOnly = append(chainOnly, fmt.Sprintf(
+									"round=%d bridge=%s victim=%s death_tick=%d revenge_tick=%d direct_ticks=%d revenger=%s",
+									roundIndex+1, bridge, hltvPlayerLabel(names[key], death.victim), death.tick,
+									revenge.tick, revenge.tick-death.tick, hltvPlayerLabel(names[key], revenge.killer)))
+							}
+						}
+					}
+				}
+			}
+			t.Logf("structure %s/%d/%s killer_bridge_triples=%d revenger_any_triples=%d revenger_assister_triples=%d chain_only_rows=%d",
+				fixture.oracle.FixtureID, expectedMap.MapID, expectedMap.Name,
+				killerTriples, revengerAnyTriples, revengerAssisterTriples, len(chainOnly))
+			for _, row := range chainOnly {
+				t.Logf("chain_only %s/%d/%s %s", fixture.oracle.FixtureID, expectedMap.MapID, expectedMap.Name, row)
+			}
+		}
+	}
+}
+
+const (
+	chainOriginalKiller   uint64 = 1 // dies to the terminal revenge kill
+	chainRevenger         uint64 = 2
+	chainFirstVictim      uint64 = 3
+	chainSecondVictim     uint64 = 4
+	chainOriginalAssister uint64 = 5 // enemy assister on the first death
+	chainThirdVictim      uint64 = 6
+	chainOtherEnemy       uint64 = 7 // enemy unrelated to the first death
+	chainBystander        uint64 = 8 // revenger-side teammate; bridges nothing
+)
+
+func chainTestKill(tick int, killer, victim uint64, killerTeam, victimTeam common.Team, assister uint64) hltvKillTrace {
+	return hltvKillTrace{
+		tick:       tick,
+		killer:     killer,
+		victim:     victim,
+		killerTeam: killerTeam,
+		victimTeam: victimTeam,
+		assister:   assister,
+	}
+}
+
+// TestChainTradeSemantics drives the chain models with synthetic rounds at 64
+// ticks per second, where the normalized five-second window admits direct
+// gaps up to 321 ticks. Every scenario asserts all six models, and the
+// production-control result must equal the canonical direct model.
+func TestChainTradeSemantics(t *testing.T) {
+	attacker := common.TeamTerrorists
+	defender := common.TeamCounterTerrorists
+	tests := []struct {
+		name   string
+		kills  []hltvKillTrace
+		expect map[hltvChainBridge][]uint64
+	}{
+		{
+			name: "killer activity bridges the chain and moves credit to the earliest death",
+			kills: []hltvKillTrace{
+				chainTestKill(1000, chainOriginalKiller, chainFirstVictim, attacker, defender, 0),
+				chainTestKill(1300, chainOriginalKiller, chainSecondVictim, attacker, defender, 0),
+				chainTestKill(1600, chainRevenger, chainOriginalKiller, defender, attacker, 0),
+			},
+			expect: map[hltvChainBridge][]uint64{
+				hltvChainNone:                     {chainSecondVictim},
+				hltvChainKiller:                   {chainFirstVictim},
+				hltvChainRevengerAny:              {chainSecondVictim},
+				hltvChainRevengerAssister:         {chainSecondVictim},
+				hltvChainKillerOrRevengerAny:      {chainFirstVictim},
+				hltvChainKillerOrRevengerAssister: {chainFirstVictim},
+			},
+		},
+		{
+			name: "revenger activity bridges the chain",
+			kills: []hltvKillTrace{
+				chainTestKill(1000, chainOriginalKiller, chainFirstVictim, attacker, defender, 0),
+				chainTestKill(1200, chainRevenger, chainOtherEnemy, defender, attacker, 0),
+				chainTestKill(1500, chainRevenger, chainOriginalKiller, defender, attacker, 0),
+			},
+			expect: map[hltvChainBridge][]uint64{
+				hltvChainNone:                     {},
+				hltvChainKiller:                   {},
+				hltvChainRevengerAny:              {chainFirstVictim},
+				hltvChainRevengerAssister:         {},
+				hltvChainKillerOrRevengerAny:      {chainFirstVictim},
+				hltvChainKillerOrRevengerAssister: {},
+			},
+		},
+		{
+			name: "assister bridge accepts the original nonzero assister",
+			kills: []hltvKillTrace{
+				chainTestKill(1000, chainOriginalKiller, chainFirstVictim, attacker, defender, chainOriginalAssister),
+				chainTestKill(1200, chainRevenger, chainOriginalAssister, defender, attacker, 0),
+				chainTestKill(1500, chainRevenger, chainOriginalKiller, defender, attacker, 0),
+			},
+			expect: map[hltvChainBridge][]uint64{
+				hltvChainNone:                     {},
+				hltvChainKiller:                   {},
+				hltvChainRevengerAny:              {chainFirstVictim},
+				hltvChainRevengerAssister:         {chainFirstVictim},
+				hltvChainKillerOrRevengerAny:      {chainFirstVictim},
+				hltvChainKillerOrRevengerAssister: {chainFirstVictim},
+			},
+		},
+		{
+			name: "assister bridge rejects a kill on another victim",
+			kills: []hltvKillTrace{
+				chainTestKill(1000, chainOriginalKiller, chainFirstVictim, attacker, defender, chainOriginalAssister),
+				chainTestKill(1200, chainRevenger, chainOtherEnemy, defender, attacker, 0),
+				chainTestKill(1500, chainRevenger, chainOriginalKiller, defender, attacker, 0),
+			},
+			expect: map[hltvChainBridge][]uint64{
+				hltvChainNone:                     {},
+				hltvChainKiller:                   {},
+				hltvChainRevengerAny:              {chainFirstVictim},
+				hltvChainRevengerAssister:         {},
+				hltvChainKillerOrRevengerAny:      {chainFirstVictim},
+				hltvChainKillerOrRevengerAssister: {},
+			},
+		},
+		{
+			name: "assister bridge rejects a death without an assister",
+			kills: []hltvKillTrace{
+				chainTestKill(1000, chainOriginalKiller, chainFirstVictim, attacker, defender, 0),
+				chainTestKill(1200, chainRevenger, chainOriginalAssister, defender, attacker, 0),
+				chainTestKill(1500, chainRevenger, chainOriginalKiller, defender, attacker, 0),
+			},
+			expect: map[hltvChainBridge][]uint64{
+				hltvChainNone:                     {},
+				hltvChainKiller:                   {},
+				hltvChainRevengerAny:              {chainFirstVictim},
+				hltvChainRevengerAssister:         {},
+				hltvChainKillerOrRevengerAny:      {chainFirstVictim},
+				hltvChainKillerOrRevengerAssister: {},
+			},
+		},
+		{
+			name: "a teamkill on the assister's SteamID does not bridge",
+			kills: []hltvKillTrace{
+				chainTestKill(1000, chainOriginalKiller, chainFirstVictim, attacker, defender, chainOriginalAssister),
+				chainTestKill(1200, chainRevenger, chainOriginalAssister, defender, defender, 0),
+				chainTestKill(1500, chainRevenger, chainOriginalKiller, defender, attacker, 0),
+			},
+			expect: map[hltvChainBridge][]uint64{
+				hltvChainNone:                     {},
+				hltvChainKiller:                   {},
+				hltvChainRevengerAny:              {},
+				hltvChainRevengerAssister:         {},
+				hltvChainKillerOrRevengerAny:      {},
+				hltvChainKillerOrRevengerAssister: {},
+			},
+		},
+		{
+			name: "an unrelated kill does not bridge",
+			kills: []hltvKillTrace{
+				chainTestKill(1000, chainOriginalKiller, chainFirstVictim, attacker, defender, 0),
+				chainTestKill(1200, chainBystander, chainOtherEnemy, defender, attacker, 0),
+				chainTestKill(1500, chainRevenger, chainOriginalKiller, defender, attacker, 0),
+			},
+			expect: map[hltvChainBridge][]uint64{
+				hltvChainNone:                     {},
+				hltvChainKiller:                   {},
+				hltvChainRevengerAny:              {},
+				hltvChainRevengerAssister:         {},
+				hltvChainKillerOrRevengerAny:      {},
+				hltvChainKillerOrRevengerAssister: {},
+			},
+		},
+		{
+			name: "a link outside five seconds expires the chain",
+			kills: []hltvKillTrace{
+				chainTestKill(1000, chainOriginalKiller, chainFirstVictim, attacker, defender, 0),
+				chainTestKill(1400, chainOriginalKiller, chainSecondVictim, attacker, defender, 0),
+				chainTestKill(1500, chainRevenger, chainOriginalKiller, defender, attacker, 0),
+			},
+			expect: map[hltvChainBridge][]uint64{
+				hltvChainNone:                     {chainSecondVictim},
+				hltvChainKiller:                   {chainSecondVictim},
+				hltvChainRevengerAny:              {chainSecondVictim},
+				hltvChainRevengerAssister:         {chainSecondVictim},
+				hltvChainKillerOrRevengerAny:      {chainSecondVictim},
+				hltvChainKillerOrRevengerAssister: {chainSecondVictim},
+			},
+		},
+		{
+			name: "the 358-tick no-bridge control stays excluded",
+			kills: []hltvKillTrace{
+				chainTestKill(37913, chainOriginalKiller, chainFirstVictim, attacker, defender, 0),
+				chainTestKill(38271, chainRevenger, chainOriginalKiller, defender, attacker, 0),
+			},
+			expect: map[hltvChainBridge][]uint64{
+				hltvChainNone:                     {},
+				hltvChainKiller:                   {},
+				hltvChainRevengerAny:              {},
+				hltvChainRevengerAssister:         {},
+				hltvChainKillerOrRevengerAny:      {},
+				hltvChainKillerOrRevengerAssister: {},
+			},
+		},
+		{
+			name: "one terminal revenge credits only the earliest eligible death",
+			kills: []hltvKillTrace{
+				chainTestKill(1000, chainOriginalKiller, chainFirstVictim, attacker, defender, 0),
+				chainTestKill(1100, chainOriginalKiller, chainSecondVictim, attacker, defender, 0),
+				chainTestKill(1300, chainRevenger, chainOriginalKiller, defender, attacker, 0),
+			},
+			expect: map[hltvChainBridge][]uint64{
+				hltvChainNone:                     {chainFirstVictim},
+				hltvChainKiller:                   {chainFirstVictim},
+				hltvChainRevengerAny:              {chainFirstVictim},
+				hltvChainRevengerAssister:         {chainFirstVictim},
+				hltvChainKillerOrRevengerAny:      {chainFirstVictim},
+				hltvChainKillerOrRevengerAssister: {chainFirstVictim},
+			},
+		},
+		{
+			name: "multiple permitted bridges extend one chain",
+			kills: []hltvKillTrace{
+				chainTestKill(1000, chainOriginalKiller, chainFirstVictim, attacker, defender, 0),
+				chainTestKill(1300, chainOriginalKiller, chainSecondVictim, attacker, defender, 0),
+				chainTestKill(1600, chainOriginalKiller, chainThirdVictim, attacker, defender, 0),
+				chainTestKill(1900, chainRevenger, chainOriginalKiller, defender, attacker, 0),
+			},
+			expect: map[hltvChainBridge][]uint64{
+				hltvChainNone:                     {chainThirdVictim},
+				hltvChainKiller:                   {chainFirstVictim},
+				hltvChainRevengerAny:              {chainThirdVictim},
+				hltvChainRevengerAssister:         {chainThirdVictim},
+				hltvChainKillerOrRevengerAny:      {chainFirstVictim},
+				hltvChainKillerOrRevengerAssister: {chainFirstVictim},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			round := &hltvTradeRoundTrace{tickTime: time.Second / 64, kills: test.kills}
+			for _, bridge := range allHLTVChainBridges() {
+				want, listed := test.expect[bridge]
+				if !listed {
+					t.Fatalf("scenario lists no expectation for %s", bridge)
+				}
+				got := slices.Sorted(maps.Keys(chainTradedDeaths(round, bridge)))
+				wantSorted := slices.Sorted(slices.Values(want))
+				if !slices.Equal(got, wantSorted) {
+					t.Errorf("%s traded %v, want %v", bridge, got, wantSorted)
+				}
+			}
+			direct := modelTradedDeaths(round, canonicalDirectTradeModel())
+			control := chainTradedDeaths(round, hltvChainNone)
+			if !maps.Equal(direct, control) {
+				t.Errorf("production-control traded %v, canonical direct model traded %v", control, direct)
+			}
+		})
+	}
+}
+
+func TestClassifyAggregateShift(t *testing.T) {
+	tests := []struct {
+		name          string
+		vectorChanged bool
+		production    int
+		model         int
+		hltv          int
+		want          hltvAggregateShift
+	}{
+		{name: "identical vector is unchanged", vectorChanged: false, production: 17, model: 17, hltv: 18, want: hltvShiftUnchanged},
+		{name: "changed vector approaching HLTV is closer", vectorChanged: true, production: 17, model: 18, hltv: 18, want: hltvShiftCloser},
+		{name: "changed vector leaving HLTV is farther", vectorChanged: true, production: 18, model: 19, hltv: 18, want: hltvShiftFarther},
+		{name: "changed vector with equal counts is indeterminate", vectorChanged: true, production: 17, model: 17, hltv: 18, want: hltvShiftIndeterminate},
+		{name: "changed vector equidistant from HLTV is indeterminate", vectorChanged: true, production: 17, model: 19, hltv: 18, want: hltvShiftIndeterminate},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := classifyAggregateShift(test.vectorChanged, test.production, test.model, test.hltv)
+			if got != test.want {
+				t.Errorf("classifyAggregateShift(%t, %d, %d, %d) = %s, want %s",
+					test.vectorChanged, test.production, test.model, test.hltv, got, test.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Extend the opt-in HLTV trade-model matrix from 18 direct combinations with six focused trade-chain models across eight audited maps and 80 player-map rows.
- Add assister SteamID tracing, per-player/per-round comparisons, aggregate-shift classification, structural-case enumeration, and invariants proving the no-chain control matches production trade attribution.
- Document why no evaluated chain model justifies a production change. The two exact classic-KAST exceptions from #38 remain pinned.

## Results

| Model | Combined parity | Target explained | Aggregate regressions |
| --- | ---: | --- | ---: |
| production control | 78/80 | neither | 0 |
| killer chain | 73/80 | kairo R9 | 6 |
| revenger-any chain | 73/80 | magixx R22 | 6 |
| revenger-assister chain | 78/80 | magixx R22 | 1 |
| combined killer/revenger-any | 71/80 | both | 9 |
| combined killer/revenger-assister | 73/80 | both | 7 |

Both combined models explain the two remaining aggregates and keep the 358-tick Mirage R4 no-bridge control excluded, but regress seven to nine player-map aggregates where production already matches HLTV. No independent per-round positive control is available because HLTV publishes only map-level KAST.

The retained production model remains one earliest eligible death, normalized five-second tick timing, and post-round inclusion. This PR changes diagnostics and documentation only; it does not modify parser behavior, oracle values, or expected differences.

Follow-up to #38.

## Test plan
- [x] `go test -count=1 ./...`
- [x] `go vet ./...`
- [x] Complete eight-map `TestHLTVRegression`: kills 80/80, deaths 80/80, classic KAST 78/80 with the two pinned exceptions
- [x] Expanded `TestEvaluateHLTVTradeModels`
- [x] Focused chain semantics and aggregate-classification tests
- [x] CI