### PR TITLE
feat(parser): expose approximate eKAST and round swing percentages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ analyse [flags]
 - `-p, --players <players>`: A list of players to analyse. This should be provided as a comma-separated list of player names.
 - `-s, --save`: Flag to save the demo player's data.
 - `--save-type <type>`: Type of file to save the data. Options are `json` and `csv`. The default is `json`.
-- `--details`: Print the extra stat tables that do not fit the main one: the rating breakdown, multi-kill rounds, trades, CT/T side splits, utility effectiveness and grenades thrown.
+- `--details`: Print the extra stat tables that do not fit the main one: the rating breakdown, approximate Rating 3.0 metrics, multi-kill rounds, trades, CT/T side splits, utility effectiveness and grenades thrown.
 
 #### Options
 

--- a/_docs/PLAYER_DATA.MD
+++ b/_docs/PLAYER_DATA.MD
@@ -110,6 +110,38 @@ All utility scalars are appended to CSV after the existing columns. `--details` 
 | MultiKills | `multi_kills` | Multi-kill rounds bucketed by kill count: `{k2, k3, k4, k5}`. See [multi-kill rounds](#multi-kill-rounds). |
 | ClutchesWon | `clutches_won` | Rounds won after being the last player alive on the team against at least one enemy (1v1 counts). Winning by defuse or time counts — no kills required. |
 | KAST | `kast` | Percentage of the match's rounds with a Kill, non-flash demo Assist, Survival or Traded death. Flash assists are excluded from classic KAST. `RoundEnd` does not award survival immediately: exit frags and C4 deaths before `RoundEndOfficial` still cancel it. This round/KAST treatment is separate from raw death totals, where a C4 event emitted after `RoundEnd` during `GamePhaseGameHalfEnded` is excluded. Match-end World cleanup does not cancel survival. |
+| ApproxEKASTPercent | `approx_ekast_percent` | Approximate eKAST: eco-weighted rating-KAST credits per match round, as a percentage. This is the pre-normalization value behind `rating.kast`, and can exceed 100 because economy weighting makes a qualifying round on a weak buy worth more than 1 — it is never clamped. See [KAST and swing side by side](#kast-and-swing-side-by-side). |
+| ApproxRoundSwingPercent | `approx_round_swing_percent` | Approximate round swing: summed modeled round-win-probability deltas per match round, as a signed percentage. This is the pre-floor value behind `rating.round_swing`; a negative match stays negative here. See [KAST and swing side by side](#kast-and-swing-side-by-side). |
+
+#### KAST and swing side by side
+
+Five related values, and none of them interchangeable — three are percentages, two are normalized sub-ratings:
+
+```
+classic KAST (%) = qualifying classic rounds / match rounds × 100
+
+Approx. eKAST (%) =
+    eco-weighted rating-KAST credits / match rounds × 100
+
+eKAST sub-rating =
+    (Approx. eKAST (%) / 100) / 0.79
+
+Approx. swing (%) =
+    summed modeled win-probability deltas / match rounds × 100
+
+Round swing sub-rating =
+    max(0, 1 + (Approx. swing (%) / 100) × 2.5)
+```
+
+- **`kast`** is the classic public KAST definition and the only KAST value in the main table. It is exact, not approximate.
+- **`approx_ekast_percent`** is an approximation in the Rating 3.0 style: it adds the [40-damage assist rule](#rating-kast) and weights each qualifying round by the player's buy, so it can exceed 100% and does not claim exact HLTV eKAST parity.
+- **`rating.kast`** — displayed and documented as the **eKAST sub-rating** — is the same per-round value divided by the 0.79 baseline, so 1.00 is average. It is not a percentage.
+- **`approx_round_swing_percent`** is the signed average modeled win-probability contribution per match round from the [round swing](#round-swing) model, with all of that model's limits; it does not claim exact HLTV Round Swing parity.
+- **`rating.round_swing`** — displayed as the **Round swing sub-rating** — scales that value around 1.00 and floors it at 0. It is not a percentage, and the floor means an extreme negative match reads 0 here while the percentage stays visibly negative.
+
+Worked examples: an approximate eKAST of 79.0% is a sub-rating of exactly 1.00, and 100.0% is ~1.27; an approximate swing of +4.0% is a 1.10 sub-rating, −4.0% is 0.90, and a −45% disaster still prints −45.0% while the sub-rating sits at the 0 floor.
+
+Both approximate percentages divide by the whole match's rounds, exactly as ADR and the sub-ratings do, so a late joiner is diluted rather than rated only on the rounds they played. Zero match rounds leave both fields 0. The two are in JSON, appended to CSV as `Approx. eKAST (%)` and `Approx. swing (%)` after all existing columns — the CSV's `Rating KAST` and `Rating Round Swing` columns keep carrying the normalized sub-ratings under their existing names for compatibility — and in the `Approximate Rating 3.0 metrics` table that `--details` prints, with swing explicitly signed. The main table is unchanged.
 
 #### Authoritative scored rounds
 
@@ -192,9 +224,9 @@ An HLTV Rating 3.0-style rating. **HLTV's exact formula is proprietary, so this 
 | Kills | `kills` | Eco-adjusted kill points per round, against the baseline. |
 | Damage | `damage` | Eco-adjusted damage per round, against the baseline. |
 | Survival | `survival` | Eco-weighted rounds survived per round, against the baseline. |
-| KAST | `kast` | Eco-weighted rating-KAST rounds per round, against the baseline. See [rating KAST](#rating-kast). |
+| KAST | `kast` | Eco-weighted rating-KAST rounds per round, against the baseline. Displayed as `eKAST sub-rating`; the pre-baseline percentage is `player_map_stats.approx_ekast_percent`. See [rating KAST](#rating-kast). |
 | MultiKill | `multi_kill` | Multi-kill points per round, against the baseline. |
-| RoundSwing | `round_swing` | Round-win-probability swing per round, scaled around 1.00. See [round swing](#round-swing). |
+| RoundSwing | `round_swing` | Round-win-probability swing per round, scaled around 1.00. Displayed as `Round swing sub-rating`; the signed pre-floor percentage is `player_map_stats.approx_round_swing_percent`. See [round swing](#round-swing). |
 
 Every sub-rating is normalized so 1.0 is average on that axis, and `value` is their weighted blend: kills 25%, damage 20%, round swing 20%, KAST 15%, survival 10%, multi-kills 10%. HLTV does not publish its weights; these follow the emphasis of their Rating 3.0 announcement. All constants named below live in `cmd/demo_parser/rating.go`.
 
@@ -210,17 +242,21 @@ Survival and KAST credit use a per-round weight from the player's own buy, captu
 
 The rating's KAST axis differs from the classic `player_map_stats.kast` in its assist rule. Classic KAST counts non-flash demo assists. Rating KAST keeps every demo assist, including flash assists, and additionally credits any player who dealt at least 40 damage to an enemy who died that round — Rating 3.0's threshold, raised from the 25 of Rating 2.0 — whoever or whatever finished them. Kill, survival and traded-death facts are shared. The classic KAST field itself remains separate from this approximate rating logic.
 
+The eco-weighted credits per match round are exposed before the baseline division as `player_map_stats.approx_ekast_percent`; the normalized `rating.kast` — the eKAST sub-rating — is that percentage over 100 divided by the 0.79 baseline. See [KAST and swing side by side](#kast-and-swing-side-by-side).
+
 #### Round swing
 
 Round swing measures how much each kill moved the round towards being won. A win-probability model — a lookup table over both sides' alive counts, with a planted bomb applied as a log-odds shift towards the T side — is evaluated before and after every kill; the killer gains the difference and the victim loses it, so swing sums to zero across each round and, per round, across each 5v5. Diminishing returns are built in: the fifth kill of a wipe moves an almost-decided round far less than an opening kill moves an even one. Post-round kills move nothing. In this first version suicides, teamkills and world deaths move no swing either, and neither does planting or defusing itself — only kills.
 
 The sub-rating is `1 + swing per round × 2.5`, floored at 0. An average player sits at exactly 1.00 by construction, because the swing they gain is swing an opponent lost.
 
+The swing per match round is exposed before that normalization as the signed `player_map_stats.approx_round_swing_percent`, which keeps the negative information the floor discards. See [KAST and swing side by side](#kast-and-swing-side-by-side).
+
 #### Calibration
 
 The per-round baselines that define "average" (0.69 kill points, 70 eco-damage, 0.37 eco-weighted survivals, 0.79 eco-weighted KAST rounds, 0.22 multi-kill points — multi-kill rounds score 1/2/4/7 points for a 2k/3k/4k/5k) were measured over five real matches: the three integration fixtures plus one HLTV pro match and one FACEIT match. Over that set the rounds-weighted mean rating is 1.000 and each sub-rating mean is within 2% of it. The set is small and skews towards standard competitive play; ratings in respawn or wingman modes are computed but not meaningful, since the swing table and the baselines assume 5v5 rounds.
 
-The rating is in JSON, in CSV as `Rating` plus one column per sub-rating, and in the main table as the `Rating` column beside KAST; `--details` prints the full breakdown in the `Rating breakdown` table.
+The rating is in JSON, in CSV as `Rating` plus one column per sub-rating, and in the main table as the `Rating` column beside KAST; `--details` prints the full breakdown in the `Rating breakdown` table, with the KAST and round-swing columns headed `eKAST sub-rating` and `Round swing sub-rating`, and the pre-normalization percentages in the `Approximate Rating 3.0 metrics` table beneath it.
 
 ## Match data
 

--- a/_docs/RATING.MD
+++ b/_docs/RATING.MD
@@ -93,6 +93,15 @@ ecoRoundWeight(tier) = 2 × winProb(tier-1 rifle, tier)
 
 The direction is our assumption: survival on an eco exceeds expectation, so it is worth more. The rating's KAST credit itself is kill, survival, traded death (same rules as the classic `kast`), a demo assist event (which keeps flash assists), or at least 40 damage into an enemy who died that round. Match-end cleanup deaths settle no assists, because their victim keeps survival and damage into a survivor is no assist.
 
+The KAST axis's pre-baseline value is published as `player_map_stats.approx_ekast_percent`:
+
+```
+Approx. eKAST (%)  = eco-weighted rating-KAST credits / match rounds × 100
+eKAST sub-rating   = (Approx. eKAST (%) / 100) / 0.79
+```
+
+79.0% is a sub-rating of exactly 1.00 and 100.0% is ~1.27. Because the eco weights above make a qualifying round worth more than 1 on a weak buy, the percentage can exceed 100 and is not clamped. Like every eKAST number in this tool it is an approximation — HLTV publishes eKAST values but not its economy weights, so no exact parity is claimed — and it is not the classic `kast`, which stays the exact public definition.
+
 ## Round swing
 
 Round swing measures how much each kill moved the round. The win-probability model is a lookup table over both sides' alive counts; the value is the probability that the T side wins the round with the bomb not planted:
@@ -119,6 +128,15 @@ round_swing = max(0, 1 + 2.5 × swing per round)
 ```
 
 A player who single-handedly moves 4% of win probability per round rates 1.10 on this axis, roughly the spread the other axes show between an average and a strong player.
+
+The signed pre-normalization value is published as `player_map_stats.approx_round_swing_percent`:
+
+```
+Approx. swing (%)      = summed modeled win-probability deltas / match rounds × 100
+Round swing sub-rating = max(0, 1 + (Approx. swing (%) / 100) × 2.5)
+```
+
++4.0% maps to the 1.10 sub-rating and −4.0% to 0.90. The percentage skips the floor, so an extreme negative match can display below −40% while `rating.round_swing` reads 0 — the sub-rating is not a percentage and the percentage is never clamped. It is an approximation from this same alive-count and bomb-state model, with every limitation listed here unchanged, and claims no exact HLTV Round Swing parity.
 
 ## Multi-kill points
 

--- a/cmd/dataexport/player_export.go
+++ b/cmd/dataexport/player_export.go
@@ -20,8 +20,13 @@ func WritePlayersToFile(players map[uint64]*demoparser.DemoPlayer, saveType stri
 		}
 		defer csvFile.Close()
 
+		// New columns are appended after all existing ones so legacy column
+		// positions stay stable. "Rating KAST" and "Rating Round Swing" keep
+		// their headers for the same reason: they remain the normalized
+		// sub-ratings, while the two appended "Approx." columns carry the
+		// pre-normalization percentages.
 		csvRecords := [][]string{
-			{"Name", "Kills", "Deaths", "K/D", "HS", "Assists", "Flash Assists", "Damage Given", "ADR", "KAST (%)", "Precision (%)", "Trade Kills", "Deaths Traded", "Opening Kills", "Opening Deaths", "Opening Success (%)", "MVPs", "ACEs", "2K", "3K", "4K", "5K", "Clutches Won", "Rounds CT", "Rounds T", "Kills CT", "Kills T", "Deaths CT", "Deaths T", "Deaths Traded CT", "Deaths Traded T", "ADR CT", "ADR T", "KAST CT (%)", "KAST T (%)", "Best Weapon", "Enemies Flashed", "Friends Flashed", "Enemy Flash Time (s)", "Average Enemy Flash Time (s)", "Utility Damage Total", "HE Utility Damage", "Fire Utility Damage", "Grenades Thrown Total", "Flashbangs Thrown", "Smokes Thrown", "HE Grenades Thrown", "Molotovs Thrown", "Incendiaries Thrown", "Decoys Thrown", "Unused Utility Value", "Rating", "Rating Kills", "Rating Damage", "Rating Survival", "Rating KAST", "Rating Multi-kill", "Rating Round Swing"},
+			{"Name", "Kills", "Deaths", "K/D", "HS", "Assists", "Flash Assists", "Damage Given", "ADR", "KAST (%)", "Precision (%)", "Trade Kills", "Deaths Traded", "Opening Kills", "Opening Deaths", "Opening Success (%)", "MVPs", "ACEs", "2K", "3K", "4K", "5K", "Clutches Won", "Rounds CT", "Rounds T", "Kills CT", "Kills T", "Deaths CT", "Deaths T", "Deaths Traded CT", "Deaths Traded T", "ADR CT", "ADR T", "KAST CT (%)", "KAST T (%)", "Best Weapon", "Enemies Flashed", "Friends Flashed", "Enemy Flash Time (s)", "Average Enemy Flash Time (s)", "Utility Damage Total", "HE Utility Damage", "Fire Utility Damage", "Grenades Thrown Total", "Flashbangs Thrown", "Smokes Thrown", "HE Grenades Thrown", "Molotovs Thrown", "Incendiaries Thrown", "Decoys Thrown", "Unused Utility Value", "Rating", "Rating Kills", "Rating Damage", "Rating Survival", "Rating KAST", "Rating Multi-kill", "Rating Round Swing", "Approx. eKAST (%)", "Approx. swing (%)"},
 		}
 		for _, player := range sortedByKills(players) {
 			csvRecords = append(csvRecords, []string{
@@ -83,6 +88,8 @@ func WritePlayersToFile(players map[uint64]*demoparser.DemoPlayer, saveType stri
 				fmt.Sprintf("%.2f", player.Rating.KAST),
 				fmt.Sprintf("%.2f", player.Rating.MultiKill),
 				fmt.Sprintf("%.2f", player.Rating.RoundSwing),
+				fmt.Sprintf("%.1f", player.PlayerMapStats.ApproxEKASTPercent),
+				fmt.Sprintf("%.1f", player.PlayerMapStats.ApproxRoundSwingPercent),
 			})
 		}
 

--- a/cmd/dataexport/table_print.go
+++ b/cmd/dataexport/table_print.go
@@ -74,6 +74,7 @@ func PrintCLIDataTable(playerToAnalyse map[uint64]*demoparser.DemoPlayer, mapDat
 func PrintCLIDetailTables(playerToAnalyse map[uint64]*demoparser.DemoPlayer) {
 	players := sortedByKills(playerToAnalyse)
 	printRatingTable(players, os.Stdout)
+	printApproxMetricsTable(players, os.Stdout)
 	printMultiKillTable(players, os.Stdout)
 	printTradeTable(players, os.Stdout)
 	printSideSplitTable(players, os.Stdout)
@@ -82,12 +83,14 @@ func PrintCLIDetailTables(playerToAnalyse map[uint64]*demoparser.DemoPlayer) {
 }
 
 // printRatingTable breaks the rating into its six sub-ratings, each
-// normalized so 1.00 is an average performance on that axis.
+// normalized so 1.00 is an average performance on that axis. The KAST and
+// round-swing columns are headed as sub-ratings to keep them apart from the
+// approximate percentages printed below them.
 func printRatingTable(players []*demoparser.DemoPlayer, output io.Writer) {
 	t := table.NewWriter()
 	t.SetOutputMirror(output)
 	t.SetTitle("Rating breakdown (1.00 = average)")
-	t.AppendHeader(table.Row{"Name", "Rating", "Kills", "Damage", "Survival", "KAST", "Multi-kill", "Round swing"})
+	t.AppendHeader(table.Row{"Name", "Rating", "Kills", "Damage", "Survival", "eKAST sub-rating", "Multi-kill", "Round swing sub-rating"})
 	for _, player := range players {
 		rating := player.Rating
 		t.AppendRow(table.Row{
@@ -99,6 +102,26 @@ func printRatingTable(players []*demoparser.DemoPlayer, output io.Writer) {
 			fmt.Sprintf("%.2f", rating.KAST),
 			fmt.Sprintf("%.2f", rating.MultiKill),
 			fmt.Sprintf("%.2f", rating.RoundSwing),
+		})
+	}
+	t.Render()
+}
+
+// printApproxMetricsTable shows the interpretable pre-normalization values
+// behind the eKAST and round-swing sub-ratings. Both are Rating 3.0-style
+// approximations: eKAST weights qualifying rounds by economy, so it can
+// exceed 100%, and swing keeps its sign instead of the sub-rating's floor.
+func printApproxMetricsTable(players []*demoparser.DemoPlayer, output io.Writer) {
+	t := table.NewWriter()
+	t.SetOutputMirror(output)
+	t.SetTitle("Approximate Rating 3.0 metrics")
+	t.AppendHeader(table.Row{"Name", "Approx. eKAST (%)", "Approx. swing (%)"})
+	for _, player := range players {
+		stats := player.PlayerMapStats
+		t.AppendRow(table.Row{
+			player.Name,
+			fmt.Sprintf("%.1f", stats.ApproxEKASTPercent),
+			fmt.Sprintf("%+.1f", stats.ApproxRoundSwingPercent),
 		})
 	}
 	t.Render()

--- a/cmd/dataexport/utility_export_test.go
+++ b/cmd/dataexport/utility_export_test.go
@@ -67,6 +67,8 @@ func TestCSVAppendsStableUtilityAndRatingColumns(t *testing.T) {
 	player.Rating = demoparser.RatingStats{
 		Value: 1.234, Kills: 1.1, Damage: 0.9, Survival: 1, KAST: 1.05, MultiKill: 0.5, RoundSwing: 1.2,
 	}
+	player.PlayerMapStats.ApproxEKASTPercent = 104.3
+	player.PlayerMapStats.ApproxRoundSwingPercent = -4.5
 
 	fileName, err := WritePlayersToFile(map[uint64]*demoparser.DemoPlayer{player.SteamID: player}, "csv")
 	if err != nil {
@@ -88,7 +90,9 @@ func TestCSVAppendsStableUtilityAndRatingColumns(t *testing.T) {
 	legacyHeader := []string{"Name", "Kills", "Deaths", "K/D", "HS", "Assists", "Flash Assists", "Damage Given", "ADR", "KAST (%)", "Precision (%)", "Trade Kills", "Deaths Traded", "Opening Kills", "Opening Deaths", "Opening Success (%)", "MVPs", "ACEs", "2K", "3K", "4K", "5K", "Clutches Won", "Rounds CT", "Rounds T", "Kills CT", "Kills T", "Deaths CT", "Deaths T", "Deaths Traded CT", "Deaths Traded T", "ADR CT", "ADR T", "KAST CT (%)", "KAST T (%)", "Best Weapon"}
 	utilityHeader := []string{"Enemies Flashed", "Friends Flashed", "Enemy Flash Time (s)", "Average Enemy Flash Time (s)", "Utility Damage Total", "HE Utility Damage", "Fire Utility Damage", "Grenades Thrown Total", "Flashbangs Thrown", "Smokes Thrown", "HE Grenades Thrown", "Molotovs Thrown", "Incendiaries Thrown", "Decoys Thrown", "Unused Utility Value"}
 	ratingHeader := []string{"Rating", "Rating Kills", "Rating Damage", "Rating Survival", "Rating KAST", "Rating Multi-kill", "Rating Round Swing"}
-	wantHeader := slices.Concat(legacyHeader, utilityHeader, ratingHeader)
+	// Appended last so every legacy column keeps its position.
+	approxHeader := []string{"Approx. eKAST (%)", "Approx. swing (%)"}
+	wantHeader := slices.Concat(legacyHeader, utilityHeader, ratingHeader, approxHeader)
 	if !reflect.DeepEqual(records[0], wantHeader) {
 		t.Errorf("CSV header = %q, want %q", records[0], wantHeader)
 	}
@@ -98,8 +102,13 @@ func TestCSVAppendsStableUtilityAndRatingColumns(t *testing.T) {
 		t.Errorf("CSV utility values = %q, want %q", utilityValues, wantUtilityValues)
 	}
 	wantRatingValues := []string{"1.23", "1.10", "0.90", "1.00", "1.05", "0.50", "1.20"}
-	if got := records[1][len(legacyHeader)+len(utilityHeader):]; !reflect.DeepEqual(got, wantRatingValues) {
+	ratingStart := len(legacyHeader) + len(utilityHeader)
+	if got := records[1][ratingStart : ratingStart+len(ratingHeader)]; !reflect.DeepEqual(got, wantRatingValues) {
 		t.Errorf("CSV rating values = %q, want %q", got, wantRatingValues)
+	}
+	wantApproxValues := []string{"104.3", "-4.5"}
+	if got := records[1][ratingStart+len(ratingHeader):]; !reflect.DeepEqual(got, wantApproxValues) {
+		t.Errorf("CSV approx metric values = %q, want %q", got, wantApproxValues)
 	}
 }
 
@@ -132,9 +141,69 @@ func TestRatingDetailTable(t *testing.T) {
 
 	var breakdown strings.Builder
 	printRatingTable(sorted, &breakdown)
-	for _, text := range []string{"Rating breakdown", "Round swing", "1.23", "utility-player"} {
+	for _, text := range []string{"Rating breakdown", "eKAST sub-rating", "Round swing sub-rating", "1.23", "utility-player"} {
 		if !strings.Contains(strings.ToLower(breakdown.String()), strings.ToLower(text)) {
 			t.Errorf("rating table missing %q:\n%s", text, breakdown.String())
+		}
+	}
+}
+
+// TestApproxMetricsDetailTable checks the compact derived-metrics table: both
+// approximate labels, one-decimal eKAST, and explicitly signed swing.
+func TestApproxMetricsDetailTable(t *testing.T) {
+	up := utilityPlayer()
+	up.PlayerMapStats.ApproxEKASTPercent = 104.3
+	up.PlayerMapStats.ApproxRoundSwingPercent = 4
+	down := &demoparser.DemoPlayer{
+		SteamID: 2,
+		Name:    "down-player",
+		PlayerMapStats: demoparser.PlayerMapStats{
+			ApproxEKASTPercent:      51.9,
+			ApproxRoundSwingPercent: -4,
+		},
+	}
+	sorted := sortedByKills(map[uint64]*demoparser.DemoPlayer{up.SteamID: up, down.SteamID: down})
+
+	var out strings.Builder
+	printApproxMetricsTable(sorted, &out)
+	rendered := strings.ToLower(out.String())
+	for _, text := range []string{"Approximate Rating 3.0 metrics", "Approx. eKAST (%)", "Approx. swing (%)", "104.3", "+4.0", "51.9", "-4.0", "utility-player", "down-player"} {
+		if !strings.Contains(rendered, strings.ToLower(text)) {
+			t.Errorf("approx metrics table missing %q:\n%s", text, out.String())
+		}
+	}
+}
+
+// TestJSONExportsApproxMetricsAndPreservesRatingKeys pins the exact new JSON
+// keys and the normalized rating keys they must not replace.
+func TestJSONExportsApproxMetricsAndPreservesRatingKeys(t *testing.T) {
+	t.Chdir(t.TempDir())
+	player := utilityPlayer()
+	player.PlayerMapStats = demoparser.PlayerMapStats{
+		KAST:                    75,
+		ApproxEKASTPercent:      104.3,
+		ApproxRoundSwingPercent: -4.5,
+	}
+	player.Rating = demoparser.RatingStats{KAST: 1.32, RoundSwing: 0.89}
+
+	fileName, err := WritePlayersToFile(map[uint64]*demoparser.DemoPlayer{player.SteamID: player}, "json")
+	if err != nil {
+		t.Fatalf("writing JSON: %v", err)
+	}
+	data, err := os.ReadFile(fileName)
+	if err != nil {
+		t.Fatalf("reading JSON: %v", err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		`"approx_ekast_percent": 104.3`,
+		`"approx_round_swing_percent": -4.5`,
+		`"kast": 75`,
+		`"kast": 1.32`,
+		`"round_swing": 0.89`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("JSON export missing %s:\n%s", want, content)
 		}
 	}
 }

--- a/cmd/demo_parser/demo_parser.go
+++ b/cmd/demo_parser/demo_parser.go
@@ -743,13 +743,20 @@ func (a *analyser) derive(totalRounds int) {
 			p.AssistStats.ADR = perRound(p.AssistStats.DamageGiven, totalRounds)
 			p.PlayerMapStats.KAST = 100 * perRound(a.kastRounds[id].Total, totalRounds)
 			rounds := float64(totalRounds)
+			// The approximate percentages publish the same per-round
+			// values the rating normalizes, before the KAST baseline
+			// division and before the swing floor can hide a negative.
+			ecoKastPerRound := a.ecoKast[id] / rounds
+			swingPerRound := a.roundSwing[id] / rounds
+			p.PlayerMapStats.ApproxEKASTPercent = 100 * ecoKastPerRound
+			p.PlayerMapStats.ApproxRoundSwingPercent = 100 * swingPerRound
 			p.Rating = blendRating(ratingRound{
 				killPoints: a.ecoKills[id] / rounds,
 				ecoDamage:  a.ecoDamage[id] / rounds,
 				survival:   a.ecoSurvival[id] / rounds,
-				kast:       a.ecoKast[id] / rounds,
+				kast:       ecoKastPerRound,
 				multiKill:  multiKillPoints(p.PlayerMapStats.MultiKills) / rounds,
-				swing:      a.roundSwing[id] / rounds,
+				swing:      swingPerRound,
 			})
 		}
 		// Their side splits cannot: sides swap at halftime, so there is no

--- a/cmd/demo_parser/rating_test.go
+++ b/cmd/demo_parser/rating_test.go
@@ -184,6 +184,115 @@ func TestDeriveDividesRatingInputsByMatchRounds(t *testing.T) {
 	}
 }
 
+// TestDeriveSharesApproxPercentagesWithTheSubRatings pins the contract of
+// approx_ekast_percent and approx_round_swing_percent: they publish the same
+// per-round values blendRating normalizes, so the documented algebra between
+// percentage and sub-rating holds exactly. Both accumulators are diluted by
+// the whole match's rounds, never a participant count, matching ADR.
+func TestDeriveSharesApproxPercentagesWithTheSubRatings(t *testing.T) {
+	a := liveAnalyser()
+	a.players[1] = &DemoPlayer{SteamID: 1}
+	a.players[2] = &DemoPlayer{SteamID: 2}
+	// Player 1 hits the baseline exactly; player 2 gives back the same
+	// swing player 1 gained and, as a late joiner, holds two full-buy
+	// KAST credits over the eight-round match.
+	a.ecoKast[1] = baselineKast * 8
+	a.roundSwing[1] = 0.32
+	a.ecoKast[2] = 2
+	a.roundSwing[2] = -0.32
+
+	a.derive(8)
+
+	one, two := a.players[1].PlayerMapStats, a.players[2].PlayerMapStats
+	if !closeTo(one.ApproxEKASTPercent, 100*baselineKast) {
+		t.Errorf("baseline eKAST percent = %v, want %v", one.ApproxEKASTPercent, 100*baselineKast)
+	}
+	if got := a.players[1].Rating.KAST; !closeTo(got, 1) {
+		t.Errorf("baseline eKAST sub-rating = %v, want 1.00", got)
+	}
+	if !closeTo(one.ApproxRoundSwingPercent, 4) {
+		t.Errorf("swing percent = %v, want +4.0", one.ApproxRoundSwingPercent)
+	}
+	if got := a.players[1].Rating.RoundSwing; !closeTo(got, 1.10) {
+		t.Errorf("swing sub-rating for +4%% = %v, want 1.10", got)
+	}
+	if !closeTo(two.ApproxRoundSwingPercent, -4) {
+		t.Errorf("negative swing percent = %v, want -4.0", two.ApproxRoundSwingPercent)
+	}
+	if got := a.players[2].Rating.RoundSwing; !closeTo(got, 0.90) {
+		t.Errorf("swing sub-rating for -4%% = %v, want 0.90", got)
+	}
+	if !closeTo(two.ApproxEKASTPercent, 25) {
+		t.Errorf("late joiner eKAST percent = %v, want 25 from 2 credits over all 8 match rounds", two.ApproxEKASTPercent)
+	}
+	if got := a.players[2].Rating.KAST; !closeTo(got, 0.25/baselineKast) {
+		t.Errorf("late joiner eKAST sub-rating = %v, want %v", got, 0.25/baselineKast)
+	}
+}
+
+// TestApproxEKASTOfFullBuyAndEcoCredit walks the two documented anchors: a
+// full-buy credit every round is exactly 100% (sub-rating ~1.27), and eco
+// weighting pushes the percentage past 100 without being clamped.
+func TestApproxEKASTOfFullBuyAndEcoCredit(t *testing.T) {
+	a := liveAnalyser()
+	a.players[1] = &DemoPlayer{SteamID: 1}
+	a.players[2] = &DemoPlayer{SteamID: 2}
+	a.ecoKast[1] = 2 * ecoRoundWeight(tierRifle1)
+	a.ecoKast[2] = 2 * ecoRoundWeight(tierStarterPistol)
+
+	a.derive(2)
+
+	if got := a.players[1].PlayerMapStats.ApproxEKASTPercent; !closeTo(got, 100) {
+		t.Errorf("full-buy credit every round = %v%%, want exactly 100", got)
+	}
+	if got := a.players[1].Rating.KAST; !closeTo(got, 1/baselineKast) {
+		t.Errorf("full-buy eKAST sub-rating = %v, want %v (~1.27)", got, 1/baselineKast)
+	}
+	got := a.players[2].PlayerMapStats.ApproxEKASTPercent
+	if want := 100 * ecoRoundWeight(tierStarterPistol); !closeTo(got, want) {
+		t.Errorf("eco credit every round = %v%%, want the unclamped %v (above 100)", got, want)
+	}
+}
+
+func TestDeriveZeroRoundsProducesZeroApproxMetrics(t *testing.T) {
+	a := liveAnalyser()
+	a.players[1] = &DemoPlayer{SteamID: 1}
+	a.ecoKast[1] = 3
+	a.roundSwing[1] = -0.5
+
+	a.derive(0)
+
+	stats := a.players[1].PlayerMapStats
+	for name, got := range map[string]float64{
+		"approx_ekast_percent":       stats.ApproxEKASTPercent,
+		"approx_round_swing_percent": stats.ApproxRoundSwingPercent,
+	} {
+		// NaN and ±Inf both fail this comparison, so one check covers
+		// "zero, and never a division artifact".
+		if got != 0 {
+			t.Errorf("%s = %v over zero rounds, want a finite 0", name, got)
+		}
+	}
+}
+
+// TestExtremeNegativeSwingStaysSignedWhileSubRatingFloors preserves the
+// information the sub-rating's floor discards: the percentage must not be
+// derived backward from the floored value.
+func TestExtremeNegativeSwingStaysSignedWhileSubRatingFloors(t *testing.T) {
+	a := liveAnalyser()
+	a.players[1] = &DemoPlayer{SteamID: 1}
+	a.roundSwing[1] = -0.45
+
+	a.derive(1)
+
+	if got := a.players[1].PlayerMapStats.ApproxRoundSwingPercent; !closeTo(got, -45) {
+		t.Errorf("extreme swing percent = %v, want -45", got)
+	}
+	if got := a.players[1].Rating.RoundSwing; got != 0 {
+		t.Errorf("swing sub-rating = %v, want the 0 floor", got)
+	}
+}
+
 func TestEcoRoundWeight(t *testing.T) {
 	if w := ecoRoundWeight(tierRifle1); w != 1 {
 		t.Errorf("tier-1 rifle round weighs %v, want exactly 1", w)

--- a/cmd/demo_parser/rating_tracker_test.go
+++ b/cmd/demo_parser/rating_tracker_test.go
@@ -64,6 +64,65 @@ func TestPostRoundKillMovesNoSwing(t *testing.T) {
 	}
 }
 
+// TestApproxSwingPercentagesAreZeroSum checks the exposed percentages keep
+// the tracker's zero-sum property: what the killers' percentages gain, the
+// victims' percentages lose.
+func TestApproxSwingPercentagesAreZeroSum(t *testing.T) {
+	rt := newRoundTracker()
+	rt.startRound(fiveVsFive())
+	recordKill(rt, 1, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10))
+	recordKill(rt, 12, 2, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(20))
+
+	a := liveAnalyser()
+	for _, id := range []uint64{1, 2, 3, 4, 5, 11, 12, 13, 14, 15} {
+		a.players[id] = &DemoPlayer{SteamID: id}
+	}
+	a.applyRoundOutcomeWithTiers(endRound(rt, common.TeamTerrorists), a.roundTiers)
+	a.derive(2)
+
+	var total float64
+	for _, p := range a.players {
+		total += p.PlayerMapStats.ApproxRoundSwingPercent
+	}
+	if !closeTo(total, 0) {
+		t.Errorf("approx swing percentages sum to %v across the round, want 0", total)
+	}
+	if got := a.players[1].PlayerMapStats.ApproxRoundSwingPercent; got <= 0 {
+		t.Errorf("killer's approx swing = %v%%, want positive", got)
+	}
+	if got := a.players[11].PlayerMapStats.ApproxRoundSwingPercent; got >= 0 {
+		t.Errorf("victim's approx swing = %v%%, want negative", got)
+	}
+}
+
+// TestDamageAssistRaisesApproxEKASTNotClassicKAST follows the 40-damage
+// rating assist proven in TestFortyDamageBecomesARatingAssist through
+// derive: the credit reaches the approximate eKAST percentage while the
+// classic KAST percentage stays untouched.
+func TestDamageAssistRaisesApproxEKASTNotClassicKAST(t *testing.T) {
+	rt := newRoundTracker()
+	rt.startRound(fiveVsFive())
+	rt.damage(2, 11, ratingAssistDamage)
+	recordKill(rt, 1, 11, common.TeamTerrorists, common.TeamCounterTerrorists, 0, false, at(10))
+	// Ts lose so that survival cannot grant the credit instead.
+	for _, victim := range []uint64{1, 2, 3, 4, 5} {
+		recordKill(rt, 12, victim, common.TeamCounterTerrorists, common.TeamTerrorists, 0, false, at(20))
+	}
+
+	a := liveAnalyser()
+	a.players[2] = &DemoPlayer{SteamID: 2}
+	a.applyRoundOutcomeWithTiers(endRound(rt, common.TeamCounterTerrorists), a.roundTiers)
+	a.derive(1)
+
+	stats := a.players[2].PlayerMapStats
+	if !closeTo(stats.ApproxEKASTPercent, 100) {
+		t.Errorf("damage assist gives approx eKAST %v%%, want 100 at the neutral weight", stats.ApproxEKASTPercent)
+	}
+	if stats.KAST != 0 {
+		t.Errorf("classic KAST = %v%%, want 0: damage assists are rating-only", stats.KAST)
+	}
+}
+
 // TestBombPlantShrinksTSwing compares the same T-side kill with and without
 // the bomb down. Post-plant the Ts are already favoured, so the same kill
 // moves the round less.

--- a/cmd/demo_parser/testdata/golden_ancient.json
+++ b/cmd/demo_parser/testdata/golden_ancient.json
@@ -37,7 +37,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 87.5
+        "kast": 87.5,
+        "approx_ekast_percent": 100.3048780487805,
+        "approx_round_swing_percent": -4.499999999999999
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -146,7 +148,9 @@
           "k5": 0
         },
         "clutches_won": 1,
-        "kast": 100
+        "kast": 100,
+        "approx_ekast_percent": 119.20731707317074,
+        "approx_round_swing_percent": 13.157695192683505
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -253,7 +257,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 37.5
+        "kast": 37.5,
+        "approx_ekast_percent": 56.707317073170735,
+        "approx_round_swing_percent": -7.685419283161144
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -358,7 +364,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 87.5
+        "kast": 87.5,
+        "approx_ekast_percent": 98.43540605735728,
+        "approx_round_swing_percent": -5.625000000000001
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -466,7 +474,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 75
+        "kast": 75,
+        "approx_ekast_percent": 87.22795497185743,
+        "approx_round_swing_percent": -2.0647853763574435
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -577,7 +587,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 100
+        "kast": 100,
+        "approx_ekast_percent": 115.60707585097829,
+        "approx_round_swing_percent": 12.297069017000226
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -686,7 +698,9 @@
           "k5": 0
         },
         "clutches_won": 1,
-        "kast": 62.5
+        "kast": 62.5,
+        "approx_ekast_percent": 76.52169220807254,
+        "approx_round_swing_percent": 3.787862096412748
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -793,7 +807,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 25
+        "kast": 25,
+        "approx_ekast_percent": 31.40243902439025,
+        "approx_round_swing_percent": -8.000000000000002
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -901,7 +917,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 25
+        "kast": 25,
+        "approx_ekast_percent": 31.40243902439025,
+        "approx_round_swing_percent": 4.540273546105611
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -1009,7 +1027,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 62.5
+        "kast": 62.5,
+        "approx_ekast_percent": 78.00095648015305,
+        "approx_round_swing_percent": -5.907695192683502
       },
       "opening_duel_stats": {
         "opening_kills": {

--- a/cmd/demo_parser/testdata/golden_inferno_shotgun.json
+++ b/cmd/demo_parser/testdata/golden_inferno_shotgun.json
@@ -784,9 +784,9 @@
       "user_id": 9,
       "deaths": 16,
       "deaths_traded": {
-        "total": 1,
+        "total": 0,
         "ct": 0,
-        "t": 1
+        "t": 0
       },
       "kill_stats": {
         "total": 11,
@@ -818,7 +818,7 @@
           "k5": 0
         },
         "clutches_won": 1,
-        "kast": 70
+        "kast": 60
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -855,7 +855,7 @@
         },
         "kast": {
           "ct": 50,
-          "t": 83.33333333333334
+          "t": 66.66666666666666
         }
       },
       "utility_stats": {
@@ -880,11 +880,11 @@
         "unused_utility_value": 2500
       },
       "rating": {
-        "value": 0.8921584681408217,
+        "value": 0.8778021853374872,
         "kills": 0.8283065637674779,
         "damage": 1.0674773548452143,
         "survival": 0.5959968297292607,
-        "kast": 0.9797404613969518,
+        "kast": 0.8840319093747225,
         "multi_kill": 0.9090909090909092,
         "round_swing": 0.8705825656917474
       }
@@ -1007,9 +1007,9 @@
       "user_id": 8,
       "deaths": 17,
       "deaths_traded": {
-        "total": 5,
+        "total": 3,
         "ct": 2,
-        "t": 3
+        "t": 1
       },
       "kill_stats": {
         "total": 18,
@@ -1043,7 +1043,7 @@
           "k5": 0
         },
         "clutches_won": 1,
-        "kast": 85
+        "kast": 80
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -1080,7 +1080,7 @@
         },
         "kast": {
           "ct": 75,
-          "t": 91.66666666666666
+          "t": 83.33333333333334
         }
       },
       "utility_stats": {
@@ -1105,11 +1105,11 @@
         "unused_utility_value": 3500
       },
       "rating": {
-        "value": 1.2584753369160344,
+        "value": 1.2489816660299584,
         "kills": 1.4752082209903699,
         "damage": 1.38974670477514,
         "survival": 0.717977217196374,
-        "kast": 1.1971990688799223,
+        "kast": 1.133907929639416,
         "multi_kill": 1.3636363636363635,
         "round_swing": 1.119913611490759
       }

--- a/cmd/demo_parser/testdata/golden_inferno_shotgun.json
+++ b/cmd/demo_parser/testdata/golden_inferno_shotgun.json
@@ -41,7 +41,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 75
+        "kast": 75,
+        "approx_ekast_percent": 84.8024444797594,
+        "approx_round_swing_percent": 4.879556423674314
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -152,7 +154,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 70
+        "kast": 70,
+        "approx_ekast_percent": 79.09200077779704,
+        "approx_round_swing_percent": 1.037740669329847
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -262,7 +266,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 75
+        "kast": 75,
+        "approx_ekast_percent": 89.54459457328898,
+        "approx_round_swing_percent": -2.501201804568263
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -375,7 +381,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 60
+        "kast": 60,
+        "approx_ekast_percent": 69.53555005491879,
+        "approx_round_swing_percent": -2.395280093635863
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -487,7 +495,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 60
+        "kast": 60,
+        "approx_ekast_percent": 72.2698692985637,
+        "approx_round_swing_percent": -7.454070900884709
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -597,7 +607,9 @@
           "k5": 0
         },
         "clutches_won": 1,
-        "kast": 70
+        "kast": 70,
+        "approx_ekast_percent": 77.50447649547458,
+        "approx_round_swing_percent": -1.8156765180674697
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -707,7 +719,9 @@
           "k5": 0
         },
         "clutches_won": 1,
-        "kast": 80
+        "kast": 80,
+        "approx_ekast_percent": 85.79626972740314,
+        "approx_round_swing_percent": -0.3694208422161848
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -818,7 +832,9 @@
           "k5": 0
         },
         "clutches_won": 1,
-        "kast": 60
+        "kast": 60,
+        "approx_ekast_percent": 69.83852084060308,
+        "approx_round_swing_percent": -5.176697372330106
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -930,7 +946,9 @@
           "k5": 0
         },
         "clutches_won": 2,
-        "kast": 65
+        "kast": 65,
+        "approx_ekast_percent": 69.4296435272045,
+        "approx_round_swing_percent": 8.998505979068076
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -1043,7 +1061,9 @@
           "k5": 0
         },
         "clutches_won": 1,
-        "kast": 80
+        "kast": 80,
+        "approx_ekast_percent": 89.57872644151387,
+        "approx_round_swing_percent": 4.79654445963036
       },
       "opening_duel_stats": {
         "opening_kills": {

--- a/cmd/demo_parser/testdata/golden_mirage.json
+++ b/cmd/demo_parser/testdata/golden_mirage.json
@@ -39,7 +39,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 100
+        "kast": 100,
+        "approx_ekast_percent": 113.3727592350261,
+        "approx_round_swing_percent": 9.144444755533794
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -148,7 +150,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 70
+        "kast": 70,
+        "approx_ekast_percent": 83.87027606539803,
+        "approx_round_swing_percent": -8.538862343269376
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -256,7 +260,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 80
+        "kast": 80,
+        "approx_ekast_percent": 93.87027606539802,
+        "approx_round_swing_percent": -1.610693189169926
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -367,7 +373,9 @@
           "k5": 0
         },
         "clutches_won": 1,
-        "kast": 50
+        "kast": 50,
+        "approx_ekast_percent": 64.84372739283165,
+        "approx_round_swing_percent": 4.69689712505041
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -476,7 +484,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 90
+        "kast": 90,
+        "approx_ekast_percent": 99.2257166194775,
+        "approx_round_swing_percent": 1.4934869982126187
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -585,7 +595,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 90
+        "kast": 90,
+        "approx_ekast_percent": 92.15686274509804,
+        "approx_round_swing_percent": 6.024181693460305
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -694,7 +706,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 60
+        "kast": 60,
+        "approx_ekast_percent": 76.33930498597023,
+        "approx_round_swing_percent": 0.04417813934961434
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -802,7 +816,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 100
+        "kast": 100,
+        "approx_ekast_percent": 107.25274725274727,
+        "approx_round_swing_percent": 5.157138787570088
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -911,7 +927,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 30
+        "kast": 30,
+        "approx_ekast_percent": 43.87027606539802,
+        "approx_round_swing_percent": -5.110771966737524
       },
       "opening_duel_stats": {
         "opening_kills": {
@@ -1019,7 +1037,9 @@
           "k5": 0
         },
         "clutches_won": 0,
-        "kast": 70
+        "kast": 70,
+        "approx_ekast_percent": 102.86250335030824,
+        "approx_round_swing_percent": -11.300000000000002
       },
       "opening_duel_stats": {
         "opening_kills": {

--- a/cmd/demo_parser/types.go
+++ b/cmd/demo_parser/types.go
@@ -32,6 +32,19 @@ type PlayerMapStats struct {
 	MultiKills  MultiKillRounds `json:"multi_kills"`
 	ClutchesWon int             `json:"clutches_won"`
 	KAST        float64         `json:"kast"`
+	// ApproxEKASTPercent is the Rating 3.0-style approximation behind the
+	// rating's KAST axis, before its baseline normalization: eco-weighted
+	// rating-KAST credits per match round, as a percentage. Economy
+	// weighting makes a qualifying round worth more than 1 on a weak buy,
+	// so the value can exceed 100 and is deliberately not clamped. It is
+	// distinct from the classic KAST above and from the normalized
+	// rating.kast sub-rating.
+	ApproxEKASTPercent float64 `json:"approx_ekast_percent"`
+	// ApproxRoundSwingPercent is the signed pre-normalization value behind
+	// the rating's round-swing axis: summed round-win-probability deltas
+	// per match round, as a percentage. Unlike the rating.round_swing
+	// sub-rating it is never floored, so a negative swing stays visible.
+	ApproxRoundSwingPercent float64 `json:"approx_round_swing_percent"`
 }
 
 // SideCount is a per-round counter split by the side the player was on.


### PR DESCRIPTION
Closes #43, closes #46.

Exposes the two interpretable pre-normalization values behind the Rating 3.0-style sub-ratings, without touching any rating formula, constant, weight, parser behavior, classic KAST, or trade semantics.

## What's new

Two typed fields on `PlayerMapStats`, computed once in `analyser.derive` from the same per-round values that feed `blendRating`:

```
Approx. eKAST (%) = eco-weighted rating-KAST credits / match rounds × 100
Approx. swing (%) = summed round-win-probability deltas / match rounds × 100
```

Their exact relationship to the existing normalized sub-ratings (which are unchanged):

```
rating.kast        = (Approx. eKAST (%) / 100) / 0.79
rating.round_swing = max(0, 1 + (Approx. swing (%) / 100) × 2.5)
```

Key properties:

- **eKAST can exceed 100%** because economy weighting makes a qualifying round on a weak buy worth more than 1; it is never clamped.
- **Swing is signed** and keeps the negative information the sub-rating's floor discards — an extreme negative map can show below −40% while `rating.round_swing` reads 0.
- Both divide by whole-match rounds (late joiners are diluted exactly as ADR is), and zero match rounds leave both fields a finite 0.
- Both are approximations of HLTV's eKAST / Round Swing; no exact parity is claimed, and the swing model's documented v1 limits are unchanged.

## Output changes

- **JSON**: `player_map_stats.approx_ekast_percent` and `player_map_stats.approx_round_swing_percent`. All existing keys — including `player_map_stats.kast`, `rating.kast`, `rating.round_swing` — are preserved unchanged.
- **CSV**: two columns appended after all existing ones (legacy positions stable): `Approx. eKAST (%)`, `Approx. swing (%)`, one decimal, negative swing keeps its sign. `Rating KAST` and `Rating Round Swing` keep their headers and remain the normalized sub-ratings for compatibility.
- **CLI**: the main table is unchanged. `--details` gains one compact table:

  ```
  | Approximate Rating 3.0 metrics                    |
  +-----------+-------------------+-------------------+
  | NAME      | APPROX. EKAST (%) | APPROX. SWING (%) |
  +-----------+-------------------+-------------------+
  | Dog       | 64.8              | +4.7              |
  | miu miu   | 83.9              | -8.5              |
  ```

  The rating-breakdown headings `KAST` and `Round swing` are renamed to `eKAST sub-rating` and `Round swing sub-rating` to keep them unambiguous next to the new percentages.
- **Docs**: `_docs/PLAYER_DATA.MD` gains a "KAST and swing side by side" section covering classic KAST, both approximate percentages, and both sub-ratings with formulas and worked examples; `_docs/RATING.MD` documents the same algebra in its eKAST and round-swing sections.

## Golden files

The first commit is a standalone baseline fix: `golden_inferno_shotgun.json` predated the scored-round stat gating from #44 (two players' traded deaths, KAST, and dependent rating values were stale). It is regenerated from the SHA-pinned demo against current `main`, isolated in its own commit so the feature diff stays purely additive.

The feature commit then regenerates all three goldens from the real pinned demos; per player the diff is exactly the two new fields — no existing value drifts.

## Testing

- Unit tests pin the shared derivation: percentage ↔ sub-rating algebra, full-buy vs eco-weighted credit (>100% unclamped), the 40-damage rating assist reaching approximate eKAST while classic KAST stays untouched, signed/zero-sum swing, whole-match-round dilution, zero-rounds behavior, and the extreme-negative case where the percentage stays visible under a floored sub-rating.
- Export tests pin the exact JSON keys, the appended CSV headers/positions, and the signed table formatting.
- `REQUIRE_TEST_DEMO=1 go test -count=1 ./...` passes with all three golden fixtures executing.
- The eight-map HLTV regression passes with the existing benchmark unchanged: kills 80/80, deaths 80/80, ADR 73/80, classic KAST 78/80.
