### PR TITLE
fix(parser): reject unmatched --players instead of partial output

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ analyse [flags]
 #### Flags
 
 - `-d, --demo <path>`: Path to the CS2 demo file.
-- `-p, --players <players>`: A list of players to analyse. This should be provided as a comma-separated list of player names.
+- `-p, --players <players>`: A list of players to analyse. This should be provided as a comma-separated list of player names. Names match case-insensitively, and if any requested name is not in the demo the command fails and lists the available players.
 - `-s, --save`: Flag to save the demo player's data.
 - `--save-type <type>`: Type of file to save the data. Options are `json` and `csv`. The default is `json`.
 - `--details`: Print the extra stat tables that do not fit the main one: the rating breakdown, approximate Rating 3.0 metrics, multi-kill rounds, trades, CT/T side splits, utility effectiveness and grenades thrown.

--- a/cmd/analyse.go
+++ b/cmd/analyse.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -87,10 +86,9 @@ var analyseCmd = &cobra.Command{
 			players = availablePlayers
 		}
 
-		playersToAnalyse := demoparser.GetPlayersToAnalyse(processedDemoData.Players, players)
-		if len(playersToAnalyse) == 0 {
-			return fmt.Errorf("no players named %s in this demo, available players: %s",
-				strings.Join(players, ", "), strings.Join(availablePlayers, ", "))
+		playersToAnalyse, err := demoparser.GetPlayersToAnalyse(processedDemoData.Players, players)
+		if err != nil {
+			return err
 		}
 
 		dataexport.PrintCLIDataTable(playersToAnalyse, &processedDemoData.Map, processedDemoData.GameMode)

--- a/cmd/demo_parser/demo_parser.go
+++ b/cmd/demo_parser/demo_parser.go
@@ -804,15 +804,39 @@ func GetPlayersName(players map[uint64]*DemoPlayer) []string {
 	return playerNames
 }
 
-func GetPlayersToAnalyse(players map[uint64]*DemoPlayer, playersToAnalyse []string) map[uint64]*DemoPlayer {
-	playersToAnalyseMap := make(map[uint64]*DemoPlayer)
-	for _, player := range players {
-		match := slices.ContainsFunc(playersToAnalyse, func(name string) bool {
-			return strings.EqualFold(name, player.Name)
+// GetPlayersToAnalyse resolves the requested names against the demo players.
+// Names match case-insensitively and duplicate requests count once. Selection
+// is all-or-nothing: if any requested name has no matching player, it returns
+// no selection and an error listing the unmatched names in first-request order
+// along with every available demo name.
+func GetPlayersToAnalyse(players map[uint64]*DemoPlayer, requestedNames []string) (map[uint64]*DemoPlayer, error) {
+	distinct := make([]string, 0, len(requestedNames))
+	for _, name := range requestedNames {
+		duplicate := slices.ContainsFunc(distinct, func(seen string) bool {
+			return strings.EqualFold(seen, name)
 		})
-		if match {
-			playersToAnalyseMap[player.SteamID] = player
+		if !duplicate {
+			distinct = append(distinct, name)
 		}
 	}
-	return playersToAnalyseMap
+
+	selected := make(map[uint64]*DemoPlayer)
+	var unmatched []string
+	for _, name := range distinct {
+		matched := false
+		for _, player := range players {
+			if strings.EqualFold(name, player.Name) {
+				selected[player.SteamID] = player
+				matched = true
+			}
+		}
+		if !matched {
+			unmatched = append(unmatched, name)
+		}
+	}
+	if len(unmatched) > 0 {
+		return nil, fmt.Errorf("players not found in demo: %s; available players: %s",
+			strings.Join(unmatched, ", "), strings.Join(GetPlayersName(players), ", "))
+	}
+	return selected, nil
 }

--- a/cmd/demo_parser/round_tracker_test.go
+++ b/cmd/demo_parser/round_tracker_test.go
@@ -694,8 +694,107 @@ func TestGetPlayersToAnalyseMatchesCaseInsensitive(t *testing.T) {
 		100: {SteamID: 100, Name: "s1mple"},
 		200: {SteamID: 200, Name: "NiKo"},
 	}
-	got := GetPlayersToAnalyse(players, []string{"S1MPLE"})
+	got, err := GetPlayersToAnalyse(players, []string{"S1MPLE"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(got) != 1 || got[100] == nil {
 		t.Errorf("expected to match s1mple case-insensitively, got %v", got)
+	}
+}
+
+func TestGetPlayersToAnalyseSelectsAllRequested(t *testing.T) {
+	players := map[uint64]*DemoPlayer{
+		100: {SteamID: 100, Name: "s1mple"},
+		200: {SteamID: 200, Name: "NiKo"},
+		300: {SteamID: 300, Name: "device"},
+	}
+	got, err := GetPlayersToAnalyse(players, []string{"s1mple", "device"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 || got[100] == nil || got[300] == nil {
+		t.Errorf("expected s1mple and device, got %v", got)
+	}
+}
+
+func TestGetPlayersToAnalyseRejectsPartialMatches(t *testing.T) {
+	players := map[uint64]*DemoPlayer{
+		100: {SteamID: 100, Name: "s1mple"},
+		200: {SteamID: 200, Name: "NiKo"},
+	}
+	got, err := GetPlayersToAnalyse(players, []string{"NiKo", "SkulL"})
+	if got != nil {
+		t.Errorf("a failed selection must not return players, got %v", got)
+	}
+	if err == nil {
+		t.Fatal("expected an error for the unmatched name")
+	}
+	want := "players not found in demo: SkulL; available players: NiKo, s1mple"
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestGetPlayersToAnalyseRejectsWhenNothingMatches(t *testing.T) {
+	players := map[uint64]*DemoPlayer{
+		100: {SteamID: 100, Name: "zywoo"},
+		200: {SteamID: 200, Name: "device"},
+		300: {SteamID: 300, Name: "NiKo"},
+	}
+	got, err := GetPlayersToAnalyse(players, []string{"void", "SkulL"})
+	if got != nil {
+		t.Errorf("a failed selection must not return players, got %v", got)
+	}
+	if err == nil {
+		t.Fatal("expected an error when nothing matches")
+	}
+	// Unmatched names keep first-request order; available names are sorted.
+	want := "players not found in demo: void, SkulL; available players: NiKo, device, zywoo"
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestGetPlayersToAnalyseTreatsDuplicateRequestsAsOne(t *testing.T) {
+	players := map[uint64]*DemoPlayer{
+		100: {SteamID: 100, Name: "s1mple"},
+	}
+	got, err := GetPlayersToAnalyse(players, []string{"s1mple", "S1MPLE"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[100] == nil {
+		t.Errorf("expected a single s1mple selection, got %v", got)
+	}
+}
+
+func TestGetPlayersToAnalyseReportsDuplicateUnmatchedOnce(t *testing.T) {
+	players := map[uint64]*DemoPlayer{
+		100: {SteamID: 100, Name: "s1mple"},
+	}
+	_, err := GetPlayersToAnalyse(players, []string{"SkulL", "skull", "SKULL"})
+	if err == nil {
+		t.Fatal("expected an error for the unmatched name")
+	}
+	// The first spelling of a duplicated unmatched request is preserved.
+	want := "players not found in demo: SkulL; available players: s1mple"
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestGetPlayersToAnalyseKeepsAllSameNamePlayers(t *testing.T) {
+	players := map[uint64]*DemoPlayer{
+		100: {SteamID: 100, Name: "smurf"},
+		200: {SteamID: 200, Name: "Smurf"},
+		300: {SteamID: 300, Name: "NiKo"},
+	}
+	got, err := GetPlayersToAnalyse(players, []string{"SMURF"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 || got[100] == nil || got[200] == nil {
+		t.Errorf("expected both smurf players, got %v", got)
 	}
 }


### PR DESCRIPTION
Closes #32

## Problem

`analyse --players` returned the intersection of requested and available names. When one name matched and another did not, the command silently rendered and saved incomplete output — it only errored when zero players matched.

## Change

An explicit player list is now all-or-nothing, enforced inside `GetPlayersToAnalyse` itself:

- Names still match case-insensitively (`strings.EqualFold`), and duplicate requests count once.
- If every requested name resolves, all matching players are returned; players sharing the same case-insensitive name are all selected, as before.
- If any name is unmatched, the function returns no selection and an error listing the unmatched names in first-request order plus all available demo names (alphabetically sorted):

```
players not found in demo: SkulL, void; available players: Chelleos, HARRYPOTTER-, ...
```

`cmd/analyse.go` now propagates that error before any table rendering or file saving, and its old zero-match fallback is gone since the strict path covers it.

## Tests

Extended the selection tests in `cmd/demo_parser/round_tracker_test.go` to cover: full resolution, case-insensitive matching, partial matches failing with no usable selection, zero matches, multiple unmatched names reported in request order, sorted available names in the error, case-insensitive dedup of valid and unmatched duplicates, and same-name players staying selected together.

Verified with `go test -count=1 ./...`, `go vet ./...`, `gofmt`, and `git diff --check` — all clean. Parser statistics are untouched, so no demo fixtures were needed.