### PR TITLE
feat(export): save map data and game mode with players in JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,27 @@ analyse --demo path/to/demo --players "player1,player2" --save --save-type csv
 
 This will analyse only "player1" and "player2" from the specified demo and save the data in CSV format.
 
+#### Saved files
+
+Saved JSON is a complete analysis record, not a bare player map:
+
+```json
+{
+  "players": {
+    "76561198000000000": { "...": "player data" }
+  },
+  "map_data": {
+    "map_name": "de_mirage",
+    "total_rounds": 24,
+    "rounds_won_ct": 11,
+    "rounds_won_t": 13
+  },
+  "game_mode": "premier"
+}
+```
+
+Read players from `.players`, keyed by SteamID (a JSON string). `map_data` and `game_mode` describe the whole match and always accompany the players; `--players` limits only `.players`. `game_mode` can be `""` when the demo metadata does not expose it, and `rounds_won_ct`/`rounds_won_t` are the final side scores, not team identities. CSV remains a flat player-only table with the same columns as before. This is an intentional breaking change from the previous format, which was the bare `{ "<steam-id>": ... }` map now nested under `players`.
+
 #### Analyzed data
 
 The data output showed in the terminal table is not all the analyzed data, to get more info about the available data, go to [PLAYER_DATA](./_docs/PLAYER_DATA.MD). The `Rating` column is an HLTV Rating 3.0-style approximation; how it is calculated, constant by constant, is documented in [RATING](./_docs/RATING.MD).

--- a/_docs/PLAYER_DATA.MD
+++ b/_docs/PLAYER_DATA.MD
@@ -1,10 +1,29 @@
 # Player data
 
-The `--save` flag writes every analysed player to a file. JSON contains all fields below; CSV contains a flattened selection of them plus the computed K/D. The CLI table shows a narrower selection still, with `--details` printing the rest in extra tables below it. Stats never include warmup. Bots are never listed, but kills on bots count like any other kill.
+The `--save` flag writes the analysis to a file. Saved JSON is a complete analysis record:
+
+```json
+{
+  "players": {
+    "<steam-id>": { "...": "the player fields below" }
+  },
+  "map_data": {
+    "map_name": "de_mirage",
+    "total_rounds": 24,
+    "rounds_won_ct": 11,
+    "rounds_won_t": 13
+  },
+  "game_mode": "premier"
+}
+```
+
+Consumers read players from `.players`, keyed by SteamID, a numeric key that JSON renders as a string. Player selection (`--players` or the interactive picker) limits only `.players`; `map_data` and `game_mode` always describe the whole match, from the same parse. This intentionally breaks the previous saved shape, which was the bare `{ "<steam-id>": ... }` player map now nested under `players`. There is no compatibility mode. See [Match data](#match-data) for the two match-level fields.
+
+Each `.players` entry contains all fields below; CSV stays a flat player-only file with a flattened selection of them plus the computed K/D, and carries no match-level columns. The CLI table shows a narrower selection still, with `--details` printing the rest in extra tables below it. Stats never include warmup. Bots are never listed, but kills on bots count like any other kill.
 
 ## Fields
 
-### Top level
+### Player top level
 
 | Field | JSON key | Description |
 | --- | --- | --- |
@@ -260,7 +279,7 @@ The rating is in JSON, in CSV as `Rating` plus one column per sub-rating, and in
 
 ## Match data
 
-The JSON table output also carries match-level data:
+Saved JSON carries two match-level fields beside `players`. `map_data` is an object:
 
 | Field | JSON key | Description |
 | --- | --- | --- |
@@ -268,3 +287,7 @@ The JSON table output also carries match-level data:
 | TotalRounds | `total_rounds` | Rounds played. |
 | RoundsWonCT | `rounds_won_ct` | Final score of the side finishing as CT. |
 | RoundsWonT | `rounds_won_t` | Final score of the side finishing as T. |
+
+`rounds_won_ct` and `rounds_won_t` are final side scores, not logical team identity. Sides swap at halftime, and the saved record does not map scores to the teams that earned them.
+
+`game_mode` is a top-level string, e.g. `"premier"`. It is written even when empty: a demo whose metadata does not expose the mode saves `"game_mode": ""`.

--- a/cmd/analyse.go
+++ b/cmd/analyse.go
@@ -98,7 +98,9 @@ var analyseCmd = &cobra.Command{
 
 		if save {
 			lipgloss.Println(printstyle.StyleSuccess.Render("\nWritting data to file..."))
-			fileName, err := dataexport.WritePlayersToFile(playersToAnalyse, saveType)
+			analysisToSave := *processedDemoData
+			analysisToSave.Players = playersToAnalyse
+			fileName, err := dataexport.WriteAnalysisToFile(&analysisToSave, saveType)
 			if err != nil {
 				return fmt.Errorf("writing to file: %w", err)
 			}

--- a/cmd/dataexport/analysis_export_test.go
+++ b/cmd/dataexport/analysis_export_test.go
@@ -1,0 +1,148 @@
+package dataexport
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"maps"
+	"os"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	demoparser "github.com/taua-almeida/cs2-analyser-tool/cmd/demo_parser"
+)
+
+// analysisWith wraps players into the analysis record the writer takes,
+// standing in for the selected copy cmd/analyse.go builds.
+func analysisWith(players ...*demoparser.DemoPlayer) *demoparser.ProcessedDemo {
+	byID := make(map[uint64]*demoparser.DemoPlayer, len(players))
+	for _, player := range players {
+		byID[player.SteamID] = player
+	}
+	return &demoparser.ProcessedDemo{Players: byID}
+}
+
+// selectedAnalysis is a one-player analysis with full match-level data, as
+// the writer receives it after player selection.
+func selectedAnalysis() *demoparser.ProcessedDemo {
+	selected := utilityPlayer()
+	selected.SteamID = 76561198000000000
+	analysis := analysisWith(selected)
+	analysis.Map = demoparser.MapData{
+		MapName:     "de_mirage",
+		TotalRounds: 24,
+		RoundsWonCT: 11,
+		RoundsWonT:  13,
+	}
+	analysis.GameMode = "premier"
+	return analysis
+}
+
+func writeAndRead(t *testing.T, analysis *demoparser.ProcessedDemo, saveType string) []byte {
+	t.Helper()
+	t.Chdir(t.TempDir())
+	fileName, err := WriteAnalysisToFile(analysis, saveType)
+	if err != nil {
+		t.Fatalf("writing %s: %v", saveType, err)
+	}
+	data, err := os.ReadFile(fileName)
+	if err != nil {
+		t.Fatalf("reading %s: %v", saveType, err)
+	}
+	return data
+}
+
+// TestJSONEnvelopeTopLevelShape pins the saved document contract: exactly
+// the three envelope keys, never the previous bare SteamID-keyed player map.
+func TestJSONEnvelopeTopLevelShape(t *testing.T) {
+	data := writeAndRead(t, selectedAnalysis(), "json")
+
+	var topLevel map[string]json.RawMessage
+	if err := json.Unmarshal(data, &topLevel); err != nil {
+		t.Fatalf("unmarshalling top level: %v", err)
+	}
+	gotKeys := slices.Sorted(maps.Keys(topLevel))
+	wantKeys := []string{"game_mode", "map_data", "players"}
+	if !reflect.DeepEqual(gotKeys, wantKeys) {
+		t.Fatalf("top-level keys = %q, want %q", gotKeys, wantKeys)
+	}
+
+	var playersByID map[string]json.RawMessage
+	if err := json.Unmarshal(topLevel["players"], &playersByID); err != nil {
+		t.Fatalf("unmarshalling players object: %v", err)
+	}
+	if _, ok := playersByID["76561198000000000"]; !ok || len(playersByID) != 1 {
+		t.Errorf("players object keys = %v, want only the selected SteamID string", slices.Sorted(maps.Keys(playersByID)))
+	}
+}
+
+// TestJSONEnvelopeDecodesAsProcessedDemo round-trips the selected player and
+// match-level data through the shared struct.
+func TestJSONEnvelopeDecodesAsProcessedDemo(t *testing.T) {
+	analysis := selectedAnalysis()
+	data := writeAndRead(t, analysis, "json")
+
+	var got demoparser.ProcessedDemo
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshalling as ProcessedDemo: %v", err)
+	}
+	want := analysis.Players[76561198000000000]
+	gotPlayer := got.Players[want.SteamID]
+	if gotPlayer == nil {
+		t.Fatal("selected player missing from players")
+	}
+	if !reflect.DeepEqual(gotPlayer, want) {
+		t.Errorf("selected player = %+v, want %+v", gotPlayer, want)
+	}
+	if len(got.Players) != 1 {
+		t.Errorf("players = %d entries, want only the selected player", len(got.Players))
+	}
+	if !reflect.DeepEqual(got.Map, analysis.Map) {
+		t.Errorf("map_data = %+v, want %+v", got.Map, analysis.Map)
+	}
+	if got.GameMode != "premier" {
+		t.Errorf("game_mode = %q, want %q", got.GameMode, "premier")
+	}
+}
+
+// TestJSONEnvelopeKeepsEmptyGameMode pins that an empty mode is written as "".
+func TestJSONEnvelopeKeepsEmptyGameMode(t *testing.T) {
+	analysis := selectedAnalysis()
+	analysis.GameMode = ""
+	data := writeAndRead(t, analysis, "json")
+
+	var topLevel map[string]json.RawMessage
+	if err := json.Unmarshal(data, &topLevel); err != nil {
+		t.Fatalf("unmarshalling top level: %v", err)
+	}
+	raw, ok := topLevel["game_mode"]
+	if !ok {
+		t.Fatal("game_mode omitted, want it serialized as \"\"")
+	}
+	if string(raw) != `""` {
+		t.Errorf("game_mode = %s, want \"\"", raw)
+	}
+}
+
+// TestCSVIgnoresMatchLevelData pins that the envelope changed nothing for
+// CSV: one row per selected player and no map or game-mode values anywhere.
+func TestCSVIgnoresMatchLevelData(t *testing.T) {
+	data := writeAndRead(t, selectedAnalysis(), "csv")
+
+	records, err := csv.NewReader(strings.NewReader(string(data))).ReadAll()
+	if err != nil {
+		t.Fatalf("reading CSV: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("CSV records = %d, want header and the one selected player", len(records))
+	}
+	if records[0][0] != "Name" || records[1][0] != "utility-player" {
+		t.Errorf("CSV first column = %q/%q, want Name/utility-player", records[0][0], records[1][0])
+	}
+	for _, matchValue := range []string{"de_mirage", "premier", "map_data", "game_mode"} {
+		if strings.Contains(string(data), matchValue) {
+			t.Errorf("CSV contains match-level value %q, want players only", matchValue)
+		}
+	}
+}

--- a/cmd/dataexport/player_export.go
+++ b/cmd/dataexport/player_export.go
@@ -10,7 +10,9 @@ import (
 	demoparser "github.com/taua-almeida/cs2-analyser-tool/cmd/demo_parser"
 )
 
-func WritePlayersToFile(players map[uint64]*demoparser.DemoPlayer, saveType string) (string, error) {
+// WriteAnalysisToFile writes the complete analysis as JSON or its players as
+// the existing flat CSV format.
+func WriteAnalysisToFile(analysis *demoparser.ProcessedDemo, saveType string) (string, error) {
 	fileName := fmt.Sprintf("%d_data.%s", time.Now().Unix(), saveType)
 
 	if saveType == "csv" {
@@ -28,7 +30,7 @@ func WritePlayersToFile(players map[uint64]*demoparser.DemoPlayer, saveType stri
 		csvRecords := [][]string{
 			{"Name", "Kills", "Deaths", "K/D", "HS", "Assists", "Flash Assists", "Damage Given", "ADR", "KAST (%)", "Precision (%)", "Trade Kills", "Deaths Traded", "Opening Kills", "Opening Deaths", "Opening Success (%)", "MVPs", "ACEs", "2K", "3K", "4K", "5K", "Clutches Won", "Rounds CT", "Rounds T", "Kills CT", "Kills T", "Deaths CT", "Deaths T", "Deaths Traded CT", "Deaths Traded T", "ADR CT", "ADR T", "KAST CT (%)", "KAST T (%)", "Best Weapon", "Enemies Flashed", "Friends Flashed", "Enemy Flash Time (s)", "Average Enemy Flash Time (s)", "Utility Damage Total", "HE Utility Damage", "Fire Utility Damage", "Grenades Thrown Total", "Flashbangs Thrown", "Smokes Thrown", "HE Grenades Thrown", "Molotovs Thrown", "Incendiaries Thrown", "Decoys Thrown", "Unused Utility Value", "Rating", "Rating Kills", "Rating Damage", "Rating Survival", "Rating KAST", "Rating Multi-kill", "Rating Round Swing", "Approx. eKAST (%)", "Approx. swing (%)"},
 		}
-		for _, player := range sortedByKills(players) {
+		for _, player := range sortedByKills(analysis.Players) {
 			csvRecords = append(csvRecords, []string{
 				player.Name,
 				fmt.Sprintf("%d", player.KillStats.Total),
@@ -100,7 +102,7 @@ func WritePlayersToFile(players map[uint64]*demoparser.DemoPlayer, saveType stri
 		return fileName, nil
 	}
 
-	jsonData, err := json.MarshalIndent(players, "", " ")
+	jsonData, err := json.MarshalIndent(analysis, "", " ")
 	if err != nil {
 		return "", err
 	}

--- a/cmd/dataexport/utility_export_test.go
+++ b/cmd/dataexport/utility_export_test.go
@@ -37,7 +37,7 @@ func TestJSONExportsUtilityStatsAndExistingFlashAssists(t *testing.T) {
 	t.Chdir(t.TempDir())
 	want := utilityPlayer()
 
-	fileName, err := WritePlayersToFile(map[uint64]*demoparser.DemoPlayer{want.SteamID: want}, "json")
+	fileName, err := WriteAnalysisToFile(analysisWith(want), "json")
 	if err != nil {
 		t.Fatalf("writing JSON: %v", err)
 	}
@@ -45,11 +45,11 @@ func TestJSONExportsUtilityStatsAndExistingFlashAssists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reading JSON: %v", err)
 	}
-	var players map[uint64]*demoparser.DemoPlayer
-	if err := json.Unmarshal(data, &players); err != nil {
+	var analysis demoparser.ProcessedDemo
+	if err := json.Unmarshal(data, &analysis); err != nil {
 		t.Fatalf("unmarshalling JSON: %v", err)
 	}
-	got := players[want.SteamID]
+	got := analysis.Players[want.SteamID]
 	if got == nil {
 		t.Fatal("exported player missing")
 	}
@@ -70,7 +70,7 @@ func TestCSVAppendsStableUtilityAndRatingColumns(t *testing.T) {
 	player.PlayerMapStats.ApproxEKASTPercent = 104.3
 	player.PlayerMapStats.ApproxRoundSwingPercent = -4.5
 
-	fileName, err := WritePlayersToFile(map[uint64]*demoparser.DemoPlayer{player.SteamID: player}, "csv")
+	fileName, err := WriteAnalysisToFile(analysisWith(player), "csv")
 	if err != nil {
 		t.Fatalf("writing CSV: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestJSONExportsApproxMetricsAndPreservesRatingKeys(t *testing.T) {
 	}
 	player.Rating = demoparser.RatingStats{KAST: 1.32, RoundSwing: 0.89}
 
-	fileName, err := WritePlayersToFile(map[uint64]*demoparser.DemoPlayer{player.SteamID: player}, "json")
+	fileName, err := WriteAnalysisToFile(analysisWith(player), "json")
 	if err != nil {
 		t.Fatalf("writing JSON: %v", err)
 	}


### PR DESCRIPTION
Closes #27

Saved JSON is now a self-contained analysis record instead of a bare SteamID-keyed player map. The file reuses the existing `demoparser.ProcessedDemo` shape, so the same match-level data shown in the CLI table travels with the exported players:

```json
{
  "players": {
    "76561198000000000": { "...": "selected player data" }
  },
  "map_data": {
    "map_name": "de_mirage",
    "total_rounds": 24,
    "rounds_won_ct": 11,
    "rounds_won_t": 13
  },
  "game_mode": "premier"
}
```

## Changes

- `WritePlayersToFile` is renamed to `WriteAnalysisToFile` and takes a `*demoparser.ProcessedDemo`. JSON marshals the whole record; CSV keeps reading only the players.
- `cmd/analyse.go` shallow-copies the parse result and swaps in the selected player map, so `--players` limits only `.players` while `map_data` and `game_mode` come from the same parse. The full in-memory result is never mutated.
- `game_mode` is always serialized, as `""` when the demo metadata does not expose it — fallback detection stays with #31, and `rounds_won_ct`/`rounds_won_t` remain final side scores, with team identity left to #28.
- CSV is untouched: same flat player-only format, headers, ordering and formatting, no match-level columns.
- README and `_docs/PLAYER_DATA.MD` document the new saved shape, that consumers must read players from `.players`, and the boundaries above.

## Breaking change

This is an intentional migration of the saved JSON: the previous top-level `{ "<steam-id>": ... }` map now lives under `players`. There is no compatibility mode, schema version or legacy writer — consumers should switch to `.players`. Filenames and timestamp behavior are unchanged, and parsing/`ProcessedDemo` production is untouched.

## Tests

New `cmd/dataexport/analysis_export_test.go` pins the envelope contract structurally (decoding into `ProcessedDemo` / `json.RawMessage`, not substring checks):

- exactly the top-level keys `players`, `map_data`, `game_mode`, with SteamIDs as string object keys
- round-trip through `ProcessedDemo` with nested player stats intact, unselected players absent, and map/game-mode values preserved exactly
- empty `game_mode` written as `""`, not omitted
- CSV still emits header plus one row per selected player and no match-level values

Existing export tests were moved to the new writer signature; the CSV test still asserts the complete legacy header and values. `go test -count=1 ./...` and `go vet ./...` pass, with no golden or parser changes.
