### PR TITLE
feat(parser): fall back to ConVar ruleset when GameSessionConfig names no game mode

### DIFF
--- a/_docs/HLTV_REGRESSION.md
+++ b/_docs/HLTV_REGRESSION.md
@@ -87,9 +87,18 @@ extra/match-2396559/mirage-234956
 
 ## Comparison contract
 
-Each map requires exactly the ten oracle SteamIDs. Map name, round count,
-final score values, kills, and deaths are strict. Score values are sorted
-because the parser exposes final CT/T fields rather than stable team identity.
+Each map requires exactly the ten oracle SteamIDs. Map name, game mode, round
+count, final score values, kills, and deaths are strict. Score values are
+sorted because the parser exposes final CT/T fields rather than stable team
+identity.
+
+All eight oracle maps pin `game_mode` to `competitive`. Every audited demo
+ran on a tournament server whose `GameSessionConfig` carries an empty
+`gamemode`, so the pin exercises the parser's ConVar fallback rather than the
+primary path; the fallback rules live in [Player data](./PLAYER_DATA.MD). The
+comparison is exact, and the field is required: a fixture must pin the mode
+explicitly, with `""` declaring that the parser should report an unknown
+mode.
 
 ADR is compared after both values are formatted to one decimal. KAST is
 compared as an integer qualifying-round count:

--- a/_docs/PLAYER_DATA.MD
+++ b/_docs/PLAYER_DATA.MD
@@ -290,4 +290,8 @@ Saved JSON carries two match-level fields beside `players`. `map_data` is an obj
 
 `rounds_won_ct` and `rounds_won_t` are final side scores, not logical team identity. Sides swap at halftime, and the saved record does not map scores to the teams that earned them.
 
-`game_mode` is a top-level string, e.g. `"premier"`. It is written even when empty: a demo whose metadata does not expose the mode saves `"game_mode": ""`.
+`game_mode` is a top-level string, e.g. `"premier"`. The primary source is the demo's `ServerInfo.GameSessionConfig`, whose `gamemode` field names the mode directly on Valve servers; a non-empty value there is always reported as-is and takes precedence over everything below.
+
+Tournament servers (the FACEIT, BLAST and ESL demos behind HLTV downloads) send that config with an empty `gamemode`. When the primary value is empty, the parser falls back to the game rules the demo records as ConVars: a demo that explicitly recorded `mp_maxrounds` `24`, `mp_halftime` on and `mp_friendlyfire` on — the regulation MR12 competitive ruleset — reports `"competitive"`. That is the only value the fallback can produce, chosen to match the string Valve servers use for classic competitive play.
+
+Anything less specific stays empty: a demo that names no mode and does not record that full ruleset saves `"game_mode": ""`. An unrecorded ConVar reads as unknown, never as a default, and the mode is never inferred from context outside the demo's own metadata, such as the filename.

--- a/cmd/demo_parser/demo_parser.go
+++ b/cmd/demo_parser/demo_parser.go
@@ -115,6 +115,45 @@ func ProcessDemo(demoPath string) (*ProcessedDemo, error) {
 	}, nil
 }
 
+// resolveGameMode picks the game mode to report. GameSessionConfig's gamemode
+// is authoritative whenever the demo names one; the FACEIT, BLAST and ESL
+// servers behind the HLTV fixtures all send the config with an empty
+// gamemode, so an empty primary value falls back to the ruleset recorded in
+// the match's ConVars. The fallback reports "competitive" — the string Valve
+// servers use for classic competitive play — and a demo that satisfies
+// neither source stays "" rather than guessing. Resolution waits for parse
+// end because SetConVar messages accumulate throughout the demo.
+func resolveGameMode(primary string, conVars map[string]string) string {
+	if primary != "" {
+		return primary
+	}
+	if hasCompetitiveRuleset(conVars) {
+		return "competitive"
+	}
+	return ""
+}
+
+// hasCompetitiveRuleset reports whether the demo's recorded ConVars pin the
+// classic competitive ruleset: a regulation MR12 match with a halftime side
+// swap and friendly fire on. Wingman's 16 rounds fail the length check;
+// casual, deathmatch and the other respawn modes fail the friendly-fire or
+// halftime rules. Each value must have been explicitly recorded in the demo —
+// absence reads as unknown, never as a default. Stricter markers were
+// rejected as server quirks rather than mode evidence: FACEIT retransmits
+// the default mp_startmoney 800 but BLAST and ESL tournament servers do not,
+// and freeze time varies between tournaments (15 on FACEIT, 20 on ESL).
+func hasCompetitiveRuleset(conVars map[string]string) bool {
+	return conVars["mp_maxrounds"] == "24" &&
+		conVarOn(conVars["mp_halftime"]) &&
+		conVarOn(conVars["mp_friendlyfire"])
+}
+
+// conVarOn reports whether a boolean ConVar was recorded as enabled; demos
+// spell recorded booleans both as "true"/"false" and as "1"/"0".
+func conVarOn(value string) bool {
+	return value == "true" || value == "1"
+}
+
 func (p DemoPlayer) String() string {
 	return fmt.Sprintf("Player: %s (SteamID: %d)\nKills: %d, Deaths: %d, Headshots: %d, Precision: %.1f%%\n",
 		p.Name, p.SteamID, p.KillStats.Total, p.Deaths, p.KillStats.HeadShots, p.KillStats.Precision*100)
@@ -694,8 +733,8 @@ func (a *analyser) applyScoreboardMVPs(mvps map[uint64]int) {
 	}
 }
 
-// finalise fills in everything that needs the full match: final score and
-// the per-player derived stats.
+// finalise fills in everything that needs the full match: final score, the
+// resolved game mode and the per-player derived stats.
 func (a *analyser) finalise() {
 	a.captureScoreboardMVPs()
 	a.finalizeRoundFacts()
@@ -713,6 +752,7 @@ func (a *analyser) finalise() {
 	a.mapData.TotalRounds = gs.TotalRoundsPlayed()
 	a.mapData.RoundsWonCT = gs.TeamCounterTerrorists().Score()
 	a.mapData.RoundsWonT = gs.TeamTerrorists().Score()
+	a.gameMode = resolveGameMode(a.gameMode, gs.Rules().ConVars())
 
 	a.derive(a.mapData.TotalRounds)
 }

--- a/cmd/demo_parser/demo_parser_test.go
+++ b/cmd/demo_parser/demo_parser_test.go
@@ -1,6 +1,7 @@
 package demoparser
 
 import (
+	"maps"
 	"math"
 	"testing"
 	"time"
@@ -75,6 +76,16 @@ func (g matchGameState) TeamTerrorists() *common.TeamState {
 func (g matchGameState) Participants() demoinfocs.Participants {
 	return matchParticipants{playing: g.playing}
 }
+
+// Rules reports no recorded ConVars, so finalise resolves the game mode from
+// the primary value alone.
+func (g matchGameState) Rules() demoinfocs.GameRules { return matchRules{} }
+
+type matchRules struct {
+	demoinfocs.GameRules
+}
+
+func (r matchRules) ConVars() map[string]string { return nil }
 
 type matchParticipants struct {
 	demoinfocs.Participants
@@ -1190,6 +1201,76 @@ func TestBotOnBotKillDoesNotStealTheOpeningDuel(t *testing.T) {
 
 	if got := a.players[shooterID].OpeningDuelStats.OpeningKills.Total; got != 0 {
 		t.Errorf("shooter opening kills = %d, want 0: the bot-on-bot kill opened the round first", got)
+	}
+}
+
+func TestResolveGameMode(t *testing.T) {
+	// The explicit ruleset the game-mode fallback needs, as the
+	// Rooster–Mindfreak HLTV demos of issue #31 record it.
+	competitiveConVars := func() map[string]string {
+		return map[string]string{
+			"mp_maxrounds":    "24",
+			"mp_halftime":     "true",
+			"mp_friendlyfire": "true",
+		}
+	}
+	withConVars := func(overrides map[string]string) map[string]string {
+		conVars := competitiveConVars()
+		maps.Copy(conVars, overrides)
+		return conVars
+	}
+	withoutHalftime := competitiveConVars()
+	delete(withoutHalftime, "mp_halftime")
+
+	tests := []struct {
+		name    string
+		primary string
+		conVars map[string]string
+		want    string
+	}{
+		{
+			name:    "primary premier wins over competitive rules",
+			primary: "premier",
+			conVars: competitiveConVars(),
+			want:    "premier",
+		},
+		{
+			name:    "tournament ruleset fills empty primary",
+			conVars: competitiveConVars(),
+			want:    "competitive",
+		},
+		{
+			name:    "numeric boolean spellings qualify",
+			conVars: withConVars(map[string]string{"mp_halftime": "1", "mp_friendlyfire": "1"}),
+			want:    "competitive",
+		},
+		{
+			name: "no metadata stays unknown",
+			want: "",
+		},
+		{
+			name:    "wingman round count stays unknown",
+			conVars: withConVars(map[string]string{"mp_maxrounds": "16"}),
+			want:    "",
+		},
+		{
+			name:    "casual friendly fire stays unknown",
+			conVars: withConVars(map[string]string{"mp_friendlyfire": "false"}),
+			want:    "",
+		},
+		{
+			name:    "unrecorded halftime stays unknown",
+			conVars: withoutHalftime,
+			want:    "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := resolveGameMode(test.primary, test.conVars); got != test.want {
+				t.Errorf("resolveGameMode(%q, %v) = %q, want %q",
+					test.primary, test.conVars, got, test.want)
+			}
+		})
 	}
 }
 

--- a/cmd/demo_parser/hltv_regression_test.go
+++ b/cmd/demo_parser/hltv_regression_test.go
@@ -40,6 +40,7 @@ type hltvMapExpected struct {
 	DemoFile      string               `json:"demo_file"`
 	DemoSHA256    string               `json:"demo_sha256"`
 	ParserMapName string               `json:"parser_map_name"`
+	GameMode      *string              `json:"game_mode"`
 	Rounds        int                  `json:"rounds"`
 	ScoreValues   [2]int               `json:"score_values"`
 	Players       []hltvPlayerExpected `json:"players"`
@@ -418,6 +419,13 @@ func validateHLTVOracle(t *testing.T, path string, oracle hltvOracle) {
 		if expectedMap.MapID == 0 || expectedMap.MapStatsURL == "" || expectedMap.DemoSHA256 == "" {
 			t.Fatalf("HLTV oracle %s map %q is missing source metadata", path, expectedMap.Name)
 		}
+		// game_mode must be pinned explicitly because "" is itself a valid
+		// expectation: the parser reports it for unknown modes. An omitted
+		// key is an unaudited fixture, not an unknown-mode assertion.
+		if expectedMap.GameMode == nil {
+			t.Fatalf("HLTV oracle %s map %q has no game_mode; pin the audited mode, %q for unknown",
+				path, expectedMap.Name, "")
+		}
 		if _, exists := mapsByID[expectedMap.MapID]; exists {
 			t.Fatalf("HLTV oracle %s repeats map ID %d", path, expectedMap.MapID)
 		}
@@ -533,6 +541,9 @@ func assertHLTVMap(t *testing.T, fixtureID string, result *ProcessedDemo, expect
 	label := fmt.Sprintf("%s/%d/%s", fixtureID, expected.MapID, expected.Name)
 	if result.Map.MapName != expected.ParserMapName {
 		t.Errorf("%s map name = %q, want %q", label, result.Map.MapName, expected.ParserMapName)
+	}
+	if result.GameMode != *expected.GameMode {
+		t.Errorf("%s game mode = %q, want %q", label, result.GameMode, *expected.GameMode)
 	}
 	if result.Map.TotalRounds != expected.Rounds {
 		t.Errorf("%s rounds = %d, want %d", label, result.Map.TotalRounds, expected.Rounds)

--- a/cmd/demo_parser/testdata/hltv-128974/expected.json
+++ b/cmd/demo_parser/testdata/hltv-128974/expected.json
@@ -10,6 +10,7 @@
       "demo_file": "spirit-vs-mouz-m1-dust2.dem",
       "demo_sha256": "06075d8cd46422ea9cfd989a4eb849556cd87bcce6b5c83c6343d8e031c9ae19",
       "parser_map_name": "de_dust2",
+      "game_mode": "competitive",
       "rounds": 21,
       "score_values": [8, 13],
       "players": [
@@ -32,6 +33,7 @@
       "demo_file": "spirit-vs-mouz-m2-mirage.dem",
       "demo_sha256": "a1d8cc6e2f9e709d17519157fd577f98db98ea80edd2177c12c9b8c666b11c89",
       "parser_map_name": "de_mirage",
+      "game_mode": "competitive",
       "rounds": 17,
       "score_values": [4, 13],
       "players": [
@@ -54,6 +56,7 @@
       "demo_file": "spirit-vs-mouz-m3-ancient.dem",
       "demo_sha256": "4ddc87a2b87ff604ccfeb5ee498f543b45afa1f22e8366163db73e828eeb0785",
       "parser_map_name": "de_ancient",
+      "game_mode": "competitive",
       "rounds": 22,
       "score_values": [9, 13],
       "players": [
@@ -76,6 +79,7 @@
       "demo_file": "spirit-vs-mouz-m4-nuke.dem",
       "demo_sha256": "11596e71c48615b49248b9b3e915ca0b1beaaf29230af90ceb8cbde9267b4337",
       "parser_map_name": "de_nuke",
+      "game_mode": "competitive",
       "rounds": 23,
       "score_values": [10, 13],
       "players": [

--- a/cmd/demo_parser/testdata/hltv-129241/expected.json
+++ b/cmd/demo_parser/testdata/hltv-129241/expected.json
@@ -10,6 +10,7 @@
       "demo_file": "rooster-vs-mindfreak-m1-inferno.dem",
       "demo_sha256": "60129e983bb529bd77b642d59bd2e172367b6ab0dbe73849bb656f7eb76d43c4",
       "parser_map_name": "de_inferno",
+      "game_mode": "competitive",
       "rounds": 22,
       "score_values": [9, 13],
       "players": [
@@ -32,6 +33,7 @@
       "demo_file": "rooster-vs-mindfreak-m2-anubis.dem",
       "demo_sha256": "7b2a1c89ea0b99be5d4874452716f25cfcbd49353c49b3402cc107f0c5a4bcae",
       "parser_map_name": "de_anubis",
+      "game_mode": "competitive",
       "rounds": 19,
       "score_values": [13, 6],
       "players": [
@@ -54,6 +56,7 @@
       "demo_file": "rooster-vs-mindfreak-m3-mirage.dem",
       "demo_sha256": "53a3ab2814af90cb9898f2e8f3d7d14ae254d94f020de418ec307e57abd7008a",
       "parser_map_name": "de_mirage",
+      "game_mode": "competitive",
       "rounds": 23,
       "score_values": [10, 13],
       "players": [

--- a/cmd/demo_parser/testdata/hltv-2396559/expected.json
+++ b/cmd/demo_parser/testdata/hltv-2396559/expected.json
@@ -10,6 +10,7 @@
       "demo_file": "spirit-vs-jijiehao-mirage.dem",
       "demo_sha256": "d68a4453645332f2a1da37acb07b1e4621362145e678e056f5252b213df2dd38",
       "parser_map_name": "de_mirage",
+      "game_mode": "competitive",
       "rounds": 23,
       "score_values": [10, 13],
       "players": [


### PR DESCRIPTION
Closes #31.

## Problem

`game_mode` was read only from `CSVCMsg_ServerInfo.GameSessionConfig`. Valve servers fill it (`"premier"`, `"competitive"`, ...), but the tournament servers behind HLTV demo downloads (FACEIT, BLAST, ESL) send the config with an empty `gamemode` string, so all three Rooster vs Mindfreak maps reported `""` and the CLI dropped its game-mode caption.

## Approach

Game-mode resolution now happens in `finalise`, through a small pure function:

- **Primary source unchanged and authoritative**: a non-empty `GameSessionConfig.GetGamemode()` is reported as-is.
- **Fallback**: when the primary is empty, the ConVars the demo itself recorded (`SetConVar` messages, exposed via `GameState().Rules().ConVars()`) are checked for the classic competitive ruleset — `mp_maxrounds` `24`, `mp_halftime` on, `mp_friendlyfire` on. A demo that explicitly records all three reports `"competitive"`, the same string Valve servers use for that ruleset. Resolution waits for parse end because ConVars accumulate throughout the demo.
- **Unknown stays unknown**: any missing or contradicting ConVar leaves `game_mode` as `""`. An unrecorded ConVar reads as unknown, never as a default, and nothing outside the demo's own metadata (filename, map, player count, score) is ever consulted.

### Why these three ConVars

I inspected the metadata of all eight external harness demos plus the two Premier fixtures. Every tournament demo carries an empty primary `gamemode`, no `game_mode`/`game_type` ConVars, and an unhelpful rules entity (`m_bIsQueuedMatchmaking=false`). The three chosen ConVars are the regulation rules every tournament server explicitly records; wingman (16 rounds), casual and the respawn modes each contradict at least one. Stricter markers were rejected with evidence: FACEIT retransmits the default `mp_startmoney 800` but BLAST/ESL servers do not, and freeze time varies between tournaments (15 vs 20).

## Tests

- `TestResolveGameMode` covers primary precedence, the fallback ruleset, both recorded boolean spellings (`"true"`/`"1"`), and unknown-stays-empty for missing or contradicting metadata.
- The HLTV oracles now pin `game_mode` per map, asserted strictly by `TestHLTVRegression`. The field is required in fixtures; an explicit `""` declares that the parser should report an unknown mode.
- Existing Premier goldens are byte-identical: the primary path still wins for `mirage`, `ancient` and `inferno-shotgun`, exercising precedence on real demos whose ConVars also satisfy the fallback.

## Verification

- `go test -count=1 ./...`, `go vet ./...`, `go build ./...`, `gofmt` clean.
- Three-map harness (`HLTV_DEMO_DIR` + `REQUIRE_HLTV_DEMOS=1`): Inferno, Anubis and Mirage all report `competitive`; parity unchanged (kills 30/30, deaths 30/30, ADR 30/30, KAST 29/30 with the known #38 exception).
- Full eight-map harness (with `HLTV_EXTRA_DEMO_DIRS`): all pass; the five extra tournament maps also resolve to `competitive` through the fallback, and additional-fixture aggregates are unchanged.

## Notes for review

- Competitive vs premier is genuinely undecidable from ConVars alone (same ruleset); in practice premier runs only on Valve servers, which always fill the primary field.
- A custom server configured with exactly MR12 + halftime + friendly fire would report `"competitive"`; those three rules are what the label describes. MR15 leagues, wingman and hostage-only configs stay `""` by design.
- Docs: `_docs/PLAYER_DATA.MD` owns the fallback definition; `_docs/HLTV_REGRESSION.md` documents the strict per-map pin.
