### PR TITLE
feat(parser): export map-local logical teams with scores and player team assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,18 @@ Saved JSON is a complete analysis record, not a bare player map:
 ```json
 {
   "players": {
-    "76561198000000000": { "...": "player data" }
+    "76561198000000000": { "team_id": 1, "...": "player data" }
   },
+  "teams": [
+    {
+      "team_id": 1,
+      "name": "Rooster",
+      "aliases": ["Rooster"],
+      "score": 13,
+      "roster": [76561198000000000]
+    },
+    { "team_id": 2, "...": "the other logical team" }
+  ],
   "map_data": {
     "map_name": "de_mirage",
     "total_rounds": 24,
@@ -62,7 +72,7 @@ Saved JSON is a complete analysis record, not a bare player map:
 }
 ```
 
-Read players from `.players`, keyed by SteamID (a JSON string). `map_data` and `game_mode` describe the whole match and always accompany the players; `--players` limits only `.players`. `game_mode` can be `""` when the demo metadata does not expose it, and `rounds_won_ct`/`rounds_won_t` are the final side scores, not team identities. CSV remains a flat player-only table with the same columns as before. This is an intentional breaking change from the previous format, which was the bare `{ "<steam-id>": ... }` map now nested under `players`.
+Read players from `.players`, keyed by SteamID (a JSON string). `map_data`, `teams` and `game_mode` describe the whole match and always accompany the players; `--players` limits only `.players`. `game_mode` can be `""` when the demo metadata does not expose it, and `rounds_won_ct`/`rounds_won_t` are the final side scores, not team identities. `teams` carries the two logical teams of the map — the lineups that persist through halftime and overtime side switches — with each team's map-local ID, clan-name aliases, final round wins and SteamID roster; each player references their team through `team_id`. The details, including how identity is resolved and when parsing fails instead of guessing, are in [PLAYER_DATA](./_docs/PLAYER_DATA.MD#logical-teams-teams). CSV remains a flat player-only table with the same columns as before. This is an intentional breaking change from the previous format, which was the bare `{ "<steam-id>": ... }` map now nested under `players`.
 
 #### Analyzed data
 

--- a/_docs/HLTV_REGRESSION.md
+++ b/_docs/HLTV_REGRESSION.md
@@ -89,8 +89,27 @@ extra/match-2396559/mirage-234956
 
 Each map requires exactly the ten oracle SteamIDs. Map name, game mode, round
 count, final score values, kills, and deaths are strict. Score values are
-sorted because the parser exposes final CT/T fields rather than stable team
-identity.
+sorted because the `map_data` CT/T fields describe final sides rather than
+stable team identity.
+
+Every map additionally pins its two logical teams (issue #28): the scoreboard
+clan name the tournament server used — audited against the HLTV team pages —
+the rounds that lineup won, and its five SteamID64s. The field is required,
+like `game_mode`: an omitted `teams` key is an unaudited fixture. Fixture
+validation checks that the two lineups partition the map's ten players and
+that their scores add up to the rounds and agree with `score_values`. At run
+time the harness requires exactly two parsed teams whose scores reconcile
+with the final side scores, matches each fixture team to a parsed team by
+exact roster — never by the parser's map-local team numbering — and asserts
+its display name, its aliases (exactly the one observed clan name for these
+demos), its score, and every rostered player's `team_id`. Because the same
+lineups are matched across all maps of a fixture while sides swap between
+and inside maps, this pins identity stability through halftime and overtime
+switches on real tournament demos. The Rooster–Mindfreak BO3 resolves as
+Inferno Rooster 9 – Mindfreak 13, Anubis Rooster 13 – Mindfreak 6, and
+Mirage Rooster 10 – Mindfreak 13. The EWC fixture also pins that the same
+Spirit lineup is labeled `Team Spirit` there but `Spirit` on the BLAST
+server: clan names are per-demo labels, not identity.
 
 All eight oracle maps pin `game_mode` to `competitive`. Every audited demo
 ran on a tournament server whose `GameSessionConfig` carries an empty

--- a/_docs/PLAYER_DATA.MD
+++ b/_docs/PLAYER_DATA.MD
@@ -7,6 +7,9 @@ The `--save` flag writes the analysis to a file. Saved JSON is a complete analys
   "players": {
     "<steam-id>": { "...": "the player fields below" }
   },
+  "teams": [
+    { "...": "the two logical teams, see Logical teams" }
+  ],
   "map_data": {
     "map_name": "de_mirage",
     "total_rounds": 24,
@@ -17,7 +20,7 @@ The `--save` flag writes the analysis to a file. Saved JSON is a complete analys
 }
 ```
 
-Consumers read players from `.players`, keyed by SteamID, a numeric key that JSON renders as a string. Player selection (`--players` or the interactive picker) limits only `.players`; `map_data` and `game_mode` always describe the whole match, from the same parse. This intentionally breaks the previous saved shape, which was the bare `{ "<steam-id>": ... }` player map now nested under `players`. There is no compatibility mode. See [Match data](#match-data) for the two match-level fields.
+Consumers read players from `.players`, keyed by SteamID, a numeric key that JSON renders as a string. Player selection (`--players` or the interactive picker) limits only `.players`; `teams`, `map_data` and `game_mode` always describe the whole match, from the same parse, so a team roster can reference SteamIDs that selection removed from `.players`. This intentionally breaks the previous saved shape, which was the bare `{ "<steam-id>": ... }` player map now nested under `players`. There is no compatibility mode. See [Match data](#match-data) and [Logical teams](#logical-teams-teams) for the match-level fields.
 
 Each `.players` entry contains all fields below; CSV stays a flat player-only file with a flattened selection of them plus the computed K/D, and carries no match-level columns. The CLI table shows a narrower selection still, with `--details` printing the rest in extra tables below it. Stats never include warmup. Bots are never listed, but kills on bots count like any other kill.
 
@@ -30,6 +33,7 @@ Each `.players` entry contains all fields below; CSV stays a flat player-only fi
 | SteamID | `steam_id` | 64-bit SteamID of the player. |
 | Name | `name` | Last name the player used in the demo. |
 | UserID | `user_id` | Server user ID in this demo. |
+| TeamID | `team_id` | Map-local ID of the [logical team](#logical-teams-teams) the player played for, or 0 for a player who never participated in an authoritative scored round. |
 | Deaths | `deaths` | Deaths, including suicides, ordinary World deaths such as falls, and C4 deaths. A round-ending C4 blast can emit deaths after `RoundEnd`; they still count during `GamePhaseStartGamePhase`. A C4 death emitted after `RoundEnd` during `GamePhaseGameHalfEnded`, plus match-end World cleanup, is excluded. |
 | DeathsTraded | `deaths_traded` | Per-round traded-death count: `{total, ct, t}`. A round contributes once when at least one of the player's deaths was avenged inside the trade window. |
 
@@ -288,10 +292,65 @@ Saved JSON carries two match-level fields beside `players`. `map_data` is an obj
 | RoundsWonCT | `rounds_won_ct` | Final score of the side finishing as CT. |
 | RoundsWonT | `rounds_won_t` | Final score of the side finishing as T. |
 
-`rounds_won_ct` and `rounds_won_t` are final side scores, not logical team identity. Sides swap at halftime, and the saved record does not map scores to the teams that earned them.
+`rounds_won_ct` and `rounds_won_t` are final side scores, not logical team identity: `rounds_won_ct` belongs to whichever lineup happened to finish the map as CT. They are kept for compatibility. The mapping from scores to the lineups that earned them lives in [`teams`](#logical-teams-teams), whose per-team scores reconcile with these two fields without depending on final sides.
 
 `game_mode` is a top-level string, e.g. `"premier"`. The primary source is the demo's `ServerInfo.GameSessionConfig`, whose `gamemode` field names the mode directly on Valve servers; a non-empty value there is always reported as-is and takes precedence over everything below.
 
 Tournament servers (the FACEIT, BLAST and ESL demos behind HLTV downloads) send that config with an empty `gamemode`. When the primary value is empty, the parser falls back to the game rules the demo records as ConVars: a demo that explicitly recorded `mp_maxrounds` `24`, `mp_halftime` on and `mp_friendlyfire` on — the regulation MR12 competitive ruleset — reports `"competitive"`. That is the only value the fallback can produce, chosen to match the string Valve servers use for classic competitive play.
 
 Anything less specific stays empty: a demo that names no mode and does not record that full ruleset saves `"game_mode": ""`. An unrecorded ConVar reads as unknown, never as a default, and the mode is never inferred from context outside the demo's own metadata, such as the filename.
+
+## Logical teams (`teams`)
+
+CT and T are temporary sides: lineups swap ends at halftime and with every overtime half. `teams` exports the two *logical* teams of the map — the lineups that persist across those swaps — and each player references theirs through `team_id`:
+
+```json
+"teams": [
+  {
+    "team_id": 1,
+    "name": "Rooster",
+    "aliases": ["Rooster"],
+    "score": 9,
+    "roster": [76561198050779850, 76561198081702155]
+  },
+  { "team_id": 2, "...": "the second team" }
+]
+```
+
+| Field | JSON key | Description |
+| --- | --- | --- |
+| TeamID | `team_id` | Deterministic map-local ID. Team 1 played CT in the seeding round, team 2 played T. See [ID scope](#team-id-scope). |
+| Name | `name` | Display name: the alias observed in the most accepted rounds, ties broken by first observation. `""` when the demo never showed a nonempty clan name — a name is never invented. |
+| Aliases | `aliases` | Deduplicated nonempty clan names observed while the team held a side, in first-observation order. |
+| Score | `score` | The team's accepted round wins. See [team scores](#team-scores). |
+| Roster | `roster` | Every eligible SteamID64 that played an accepted round for the team, substitutes included, sorted ascending. |
+
+Serialization is deterministic: teams are ordered by `team_id`, rosters are sorted, and aliases keep observation order.
+
+### Identity evidence
+
+Identity is seeded once, from the first authoritative scored round (the same [gate](#authoritative-scored-rounds) every round-derived stat uses) that has at least one eligible participant. Warmup, pregame knife rounds, restarts and unscored setup rounds can therefore never seed a team, and neither can rounds played only by bots. Eligible means a real competitor: nonzero SteamID64, not a bot, not a coach, not a spectator.
+
+A round's team-roster evidence is the players on a side when live play begins — the end of freeze time — not the round-start snapshot the player stats keep. The difference matters at halftime and in overtime: the side switch can land during freeze time, after the round started, and a player who disconnects inside that window would otherwise be presented on their stale pre-switch side, among the other lineup. Such a leaver keeps their player-stat participation for the round but contributes no team facts to it; their membership from earlier rounds is untouched.
+
+Team facts are also resolved once at parse end rather than while streaming, because a setup round that received `RoundEnd` and then restarted at the same score is indistinguishable in the moment from a genuine round whose authoritative count replicated late. The parse-end queue reveals which shape occurred: decided rounds left without a scored slot mean an equal number of the earliest decided candidates were setup restarts, and exactly that many are excluded from team identity, aliases and scores. Player statistics keep their existing streaming gate unchanged.
+
+From then on every accepted round's two side rosters are mapped back to the seeded teams through shared SteamIDs — the strongest identity evidence a demo offers. A mapping is *confident* when it has roster evidence (at least one shared eligible SteamID) and no conflict (no player it would place on both teams). Substitutes resolve through their teammates and join the uniquely matched team; a reconnecting player is already a member and cannot be duplicated; even a side of entirely new players resolves by elimination when the other side maps uniquely.
+
+Anything less confident is an *ambiguity* and fails the parse with an error carrying the competing evidence — the sides' rosters, the overlap with each team, and both teams' members — instead of guessing. In particular, a SteamID that appears to participate for both logical teams is an explicit error, never a silent `team_id` overwrite.
+
+The following are never identity: sides (current or final), clan names, `TeamState.ID()`, display names, user IDs, entity IDs, filenames, map names.
+
+### Clan names are labels
+
+Clan names corroborate identity but never define it. They are captured per side per round, follow the side entities across swaps, and attach to whichever logical team held that side. A team whose clan name changes mid-match keeps every nonempty spelling in `aliases`; `name` deterministically picks the most-observed one (first observation wins ties). An empty clan name stays unknown — no organization name is fabricated — and two teams sharing the same clan name remain two teams, because names never merge identity.
+
+### Team scores
+
+A round win is attributed to a logical team only when the authoritative scored-round gate accepted the round, the demo recorded its winning side, and that side's roster resolved to the team. Each team's `score` therefore equals its accepted round wins, and the two scores reconcile with `map_data.rounds_won_ct`/`rounds_won_t` — which stay exactly as before for compatibility — without ever deriving a team's score from the side it finished the map on. Rounds with no eligible participants (bots only) move no team score; their wins still appear in the side-based `map_data` fields, so the two views can differ in such demos.
+
+### Team ID scope
+
+`team_id` is scoped to one map: the numbering says only which lineup started the seeding round on which side of *this* demo. It makes no claim about organization identity across demos — the same organization can be team 1 on one map and team 2 on the next. Matching teams across the maps of a BO3/BO5 series is issue #34's job, deliberately not this field's.
+
+Players keep their existing CT/T side splits (`side_stats`), which remain attributed round by round and are unaffected by logical team identity. A player with `team_id` 0 exists in the demo's raw events but never played an accepted round (for example, someone only present during an unscored setup round).

--- a/cmd/dataexport/analysis_export_test.go
+++ b/cmd/dataexport/analysis_export_test.go
@@ -24,11 +24,18 @@ func analysisWith(players ...*demoparser.DemoPlayer) *demoparser.ProcessedDemo {
 }
 
 // selectedAnalysis is a one-player analysis with full match-level data, as
-// the writer receives it after player selection.
+// the writer receives it after player selection. The teams keep describing
+// the whole match: selection narrows players only, so the roster references
+// a SteamID that is not among the selected players.
 func selectedAnalysis() *demoparser.ProcessedDemo {
 	selected := utilityPlayer()
 	selected.SteamID = 76561198000000000
+	selected.TeamID = 1
 	analysis := analysisWith(selected)
+	analysis.Teams = []demoparser.DemoTeam{
+		{TeamID: 1, Name: "AlphaSquad", Aliases: []string{"AlphaSquad"}, Score: 11, Roster: []uint64{76561198000000000}},
+		{TeamID: 2, Name: "BravoCrew", Aliases: []string{"BravoCrew", "BravoCrew GG"}, Score: 13, Roster: []uint64{76561198000000001}},
+	}
 	analysis.Map = demoparser.MapData{
 		MapName:     "de_mirage",
 		TotalRounds: 24,
@@ -54,7 +61,7 @@ func writeAndRead(t *testing.T, analysis *demoparser.ProcessedDemo, saveType str
 }
 
 // TestJSONEnvelopeTopLevelShape pins the saved document contract: exactly
-// the three envelope keys, never the previous bare SteamID-keyed player map.
+// the four envelope keys, never the previous bare SteamID-keyed player map.
 func TestJSONEnvelopeTopLevelShape(t *testing.T) {
 	data := writeAndRead(t, selectedAnalysis(), "json")
 
@@ -63,7 +70,7 @@ func TestJSONEnvelopeTopLevelShape(t *testing.T) {
 		t.Fatalf("unmarshalling top level: %v", err)
 	}
 	gotKeys := slices.Sorted(maps.Keys(topLevel))
-	wantKeys := []string{"game_mode", "map_data", "players"}
+	wantKeys := []string{"game_mode", "map_data", "players", "teams"}
 	if !reflect.DeepEqual(gotKeys, wantKeys) {
 		t.Fatalf("top-level keys = %q, want %q", gotKeys, wantKeys)
 	}
@@ -104,6 +111,12 @@ func TestJSONEnvelopeDecodesAsProcessedDemo(t *testing.T) {
 	if got.GameMode != "premier" {
 		t.Errorf("game_mode = %q, want %q", got.GameMode, "premier")
 	}
+	if !reflect.DeepEqual(got.Teams, analysis.Teams) {
+		t.Errorf("teams = %+v, want %+v", got.Teams, analysis.Teams)
+	}
+	if gotPlayer.TeamID != 1 {
+		t.Errorf("selected player team_id = %d, want 1", gotPlayer.TeamID)
+	}
 }
 
 // TestJSONEnvelopeKeepsEmptyGameMode pins that an empty mode is written as "".
@@ -140,7 +153,7 @@ func TestCSVIgnoresMatchLevelData(t *testing.T) {
 	if records[0][0] != "Name" || records[1][0] != "utility-player" {
 		t.Errorf("CSV first column = %q/%q, want Name/utility-player", records[0][0], records[1][0])
 	}
-	for _, matchValue := range []string{"de_mirage", "premier", "map_data", "game_mode"} {
+	for _, matchValue := range []string{"de_mirage", "premier", "map_data", "game_mode", "teams", "team_id", "AlphaSquad", "BravoCrew"} {
 		if strings.Contains(string(data), matchValue) {
 			t.Errorf("CSV contains match-level value %q, want players only", matchValue)
 		}

--- a/cmd/demo_parser/demo_parser.go
+++ b/cmd/demo_parser/demo_parser.go
@@ -40,7 +40,12 @@ type analyser struct {
 	appliedRounds  int                      // authoritative round count already represented in player facts
 	roundsStarted  bool                     // whether appliedRounds has been initialized
 	eventMVPs      map[uint64]int           // MVP announcements from authoritative scored rounds
-	parseErr       error                    // delayed handler error returned after parsing
+	teamIdentity   *teamTracker             // logical teams resolved from accepted rounds
+	roundCTClan    string                   // CT-side clan name captured for the current round
+	roundTClan     string                   // T-side clan name captured for the current round
+	roundHistory   []*pendingRoundFacts     // every finalized round in order, for parse-end team resolution
+	teams          []DemoTeam
+	parseErr       error // delayed handler error returned after parsing
 	mapData        MapData
 	gameMode       string
 }
@@ -51,6 +56,8 @@ type pendingRoundFacts struct {
 	mvps       map[uint64]int
 	ecoKills   []playerRatingFact
 	ecoDamage  []playerRatingFact
+	ctClan     string // clan name shown for the CT side during the round
+	tClan      string // clan name shown for the T side during the round
 	scored     bool
 	mvpCounted bool
 }
@@ -67,23 +74,24 @@ type worldDamageSource struct {
 
 func newAnalyser(parser demoinfocs.Parser) *analyser {
 	return &analyser{
-		parser:      parser,
-		players:     make(map[uint64]*DemoPlayer),
-		tracker:     newRoundTracker(),
-		kastRounds:  make(map[uint64]SideCount),
-		sideDamage:  make(map[uint64]SideCount),
-		openingWins: make(map[uint64]int),
-		lastHealth:  make(map[uint64]int),
-		worldSource: make(map[uint64]worldDamageSource),
-		flashEnds:   make(map[uint64]time.Duration),
-		ecoKills:    make(map[uint64]float64),
-		ecoDamage:   make(map[uint64]float64),
-		roundSwing:  make(map[uint64]float64),
-		ecoSurvival: make(map[uint64]float64),
-		ecoKast:     make(map[uint64]float64),
-		roundTiers:  make(map[uint64]equipTier),
-		roundMVPs:   make(map[uint64]int),
-		eventMVPs:   make(map[uint64]int),
+		parser:       parser,
+		players:      make(map[uint64]*DemoPlayer),
+		tracker:      newRoundTracker(),
+		kastRounds:   make(map[uint64]SideCount),
+		sideDamage:   make(map[uint64]SideCount),
+		openingWins:  make(map[uint64]int),
+		lastHealth:   make(map[uint64]int),
+		worldSource:  make(map[uint64]worldDamageSource),
+		flashEnds:    make(map[uint64]time.Duration),
+		ecoKills:     make(map[uint64]float64),
+		ecoDamage:    make(map[uint64]float64),
+		roundSwing:   make(map[uint64]float64),
+		ecoSurvival:  make(map[uint64]float64),
+		ecoKast:      make(map[uint64]float64),
+		roundTiers:   make(map[uint64]equipTier),
+		roundMVPs:    make(map[uint64]int),
+		eventMVPs:    make(map[uint64]int),
+		teamIdentity: newTeamTracker(),
 	}
 }
 
@@ -106,10 +114,13 @@ func ProcessDemo(demoPath string) (*ProcessedDemo, error) {
 		return nil, fmt.Errorf("parsing demo: %w", a.parseErr)
 	}
 
-	a.finalise()
+	if err := a.finalise(); err != nil {
+		return nil, fmt.Errorf("parsing demo: %w", err)
+	}
 
 	return &ProcessedDemo{
 		Players:  a.players,
+		Teams:    a.teams,
 		Map:      a.mapData,
 		GameMode: a.gameMode,
 	}, nil
@@ -280,6 +291,17 @@ func (a *analyser) onRoundStart(e events.RoundStart) {
 	a.roundEcoDamage = a.roundEcoDamage[:0]
 	clear(a.worldSource)
 	a.tracker.startRound(a.playingRoster())
+	a.captureClanNames()
+}
+
+// captureClanNames snapshots the scoreboard clan name of each side for the
+// current round. The names follow the side entities, so after a halftime or
+// overtime swap the same team's name is read from its new side. They are
+// labels for the logical teams and never identity evidence.
+func (a *analyser) captureClanNames() {
+	gs := a.parser.GameState()
+	a.roundCTClan = gs.TeamCounterTerrorists().ClanName()
+	a.roundTClan = gs.TeamTerrorists().ClanName()
 }
 
 // onRoundFreezetimeEnd folds the players who picked a side during freeze
@@ -291,6 +313,9 @@ func (a *analyser) onRoundFreezetimeEnd(e events.RoundFreezetimeEnd) {
 		return
 	}
 	a.tracker.joinRound(a.playingRoster())
+	// Refresh the clan names too: a name configured while the round-start
+	// snapshot was still empty is present by the time live play begins.
+	a.captureClanNames()
 }
 
 // onBombPlanted feeds the round tracker the bomb state its round-swing
@@ -659,8 +684,11 @@ func (a *analyser) finalizeRoundFacts() {
 			mvps:      maps.Clone(a.roundMVPs),
 			ecoKills:  slices.Clone(a.roundEcoKills),
 			ecoDamage: slices.Clone(a.roundEcoDamage),
+			ctClan:    a.roundCTClan,
+			tClan:     a.roundTClan,
 		}
 		a.pendingRounds = append(a.pendingRounds, pending)
+		a.roundHistory = append(a.roundHistory, pending)
 		a.latestRound = pending
 	}
 	a.applyScoredRoundFacts()
@@ -688,6 +716,69 @@ func (a *analyser) applyScoredRoundFacts() {
 		a.appliedRounds++
 		available--
 	}
+}
+
+// applyTeamRounds feeds the accepted rounds to the logical-team tracker
+// once the whole match is known. Team identity cannot be attributed while
+// parsing: a setup round that received RoundEnd and then restarted at the
+// same score is indistinguishable in the moment from a genuine round whose
+// authoritative count replicated late, and the oldest-decided-first slot
+// policy the player facts use would let such a setup round seed the teams
+// and consume the scored slot that belonged to the last real round. Only
+// the parse-end queue reveals which shape occurred: decided rounds left
+// without a scored slot mean an equal number of the earliest decided
+// candidates were setup restarts, so exactly that many are excluded and the
+// remaining rounds are applied in match order.
+func (a *analyser) applyTeamRounds() error {
+	skip := 0
+	for _, round := range a.roundHistory {
+		if !round.scored && round.outcome.decided {
+			skip++
+		}
+	}
+	for i, round := range a.roundHistory {
+		if !round.scored && !round.outcome.decided {
+			continue
+		}
+		if skip > 0 && round.outcome.decided {
+			skip--
+			continue
+		}
+		if err := a.applyTeamFacts(round, i+1); err != nil {
+			// An identity conflict fails the parse: guessing would silently
+			// attach players and scores to the wrong team.
+			return err
+		}
+	}
+	return nil
+}
+
+// applyTeamFacts feeds one accepted round to the logical-team tracker: the
+// eligible players split by the side they held when live play began, the
+// sides' clan names, and the winning side. Eligibility is the players map
+// itself, which ensurePlayer only ever fills with real competitors — never
+// bots, coaches or zero SteamIDs.
+func (a *analyser) applyTeamFacts(pending *pendingRoundFacts, round int) error {
+	facts := teamRoundFacts{
+		round:    round,
+		ctClan:   pending.ctClan,
+		tClan:    pending.tClan,
+		winner:   pending.outcome.winner,
+		ctRoster: make([]uint64, 0, len(pending.outcome.liveSides)),
+		tRoster:  make([]uint64, 0, len(pending.outcome.liveSides)),
+	}
+	for id, side := range pending.outcome.liveSides {
+		if a.players[id] == nil {
+			continue
+		}
+		switch side {
+		case common.TeamCounterTerrorists:
+			facts.ctRoster = append(facts.ctRoster, id)
+		case common.TeamTerrorists:
+			facts.tRoster = append(facts.tRoster, id)
+		}
+	}
+	return a.teamIdentity.applyRound(facts)
 }
 
 // nextScoredRound prefers rounds that received RoundEnd. If only unended
@@ -734,8 +825,10 @@ func (a *analyser) applyScoreboardMVPs(mvps map[uint64]int) {
 }
 
 // finalise fills in everything that needs the full match: final score, the
-// resolved game mode and the per-player derived stats.
-func (a *analyser) finalise() {
+// resolved game mode, the logical teams and the per-player derived stats.
+// It reports the team-identity conflicts that only the finished match can
+// reveal; handler-time failures stay on parseErr, which callers check first.
+func (a *analyser) finalise() error {
 	a.captureScoreboardMVPs()
 	a.finalizeRoundFacts()
 	// The final scoreboard is authoritative and catches MVP entity updates
@@ -754,7 +847,22 @@ func (a *analyser) finalise() {
 	a.mapData.RoundsWonT = gs.TeamTerrorists().Score()
 	a.gameMode = resolveGameMode(a.gameMode, gs.Rules().ConVars())
 
+	if err := a.applyTeamRounds(); err != nil {
+		return err
+	}
+	// The tracker guarantees a SteamID is on at most one roster, so this
+	// assignment can never overwrite one team reference with another.
+	a.teams = a.teamIdentity.export()
+	for _, team := range a.teams {
+		for _, id := range team.Roster {
+			if p := a.players[id]; p != nil {
+				p.TeamID = team.TeamID
+			}
+		}
+	}
+
 	a.derive(a.mapData.TotalRounds)
+	return nil
 }
 
 // perRound divides by the rounds the value was accumulated over, reporting

--- a/cmd/demo_parser/demo_parser_test.go
+++ b/cmd/demo_parser/demo_parser_test.go
@@ -27,12 +27,15 @@ type matchParser struct {
 	roundsPlayed int
 	ctScore      int
 	tScore       int
+	ctClan       string
+	tClan        string
 }
 
 func (p *matchParser) GameState() demoinfocs.GameState {
 	return matchGameState{
 		playing: p.playing, warmup: p.warmup, gamePhase: p.gamePhase, ingameTick: p.ingameTick,
 		roundsPlayed: p.roundsPlayed, ctScore: p.ctScore, tScore: p.tScore,
+		ctClan: p.ctClan, tClan: p.tClan,
 	}
 }
 
@@ -51,6 +54,8 @@ type matchGameState struct {
 	roundsPlayed int
 	ctScore      int
 	tScore       int
+	ctClan       string
+	tClan        string
 }
 
 func (g matchGameState) IsWarmupPeriod() bool { return g.warmup }
@@ -63,13 +68,15 @@ func (g matchGameState) TotalRoundsPlayed() int { return g.roundsPlayed }
 
 func (g matchGameState) TeamCounterTerrorists() *common.TeamState {
 	return &common.TeamState{Entity: matchEntity{properties: map[string]st.PropertyValue{
-		"m_iScore": {Any: int32(g.ctScore)},
+		"m_iScore":         {Any: int32(g.ctScore)},
+		"m_szClanTeamname": {Any: g.ctClan},
 	}}}
 }
 
 func (g matchGameState) TeamTerrorists() *common.TeamState {
 	return &common.TeamState{Entity: matchEntity{properties: map[string]st.PropertyValue{
-		"m_iScore": {Any: int32(g.tScore)},
+		"m_iScore":         {Any: int32(g.tScore)},
+		"m_szClanTeamname": {Any: g.tClan},
 	}}}
 }
 

--- a/cmd/demo_parser/hltv_regression_test.go
+++ b/cmd/demo_parser/hltv_regression_test.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -43,7 +44,19 @@ type hltvMapExpected struct {
 	GameMode      *string              `json:"game_mode"`
 	Rounds        int                  `json:"rounds"`
 	ScoreValues   [2]int               `json:"score_values"`
+	Teams         *[2]hltvTeamExpected `json:"teams"`
 	Players       []hltvPlayerExpected `json:"players"`
+}
+
+// hltvTeamExpected pins one logical team of a map: the clan name the
+// tournament server showed on the scoreboard (audited against the HLTV team
+// pages), the rounds that lineup won, and its five SteamID64s. Order within
+// the fixture array is presentational; the parser's teams are matched to
+// these rows by exact roster.
+type hltvTeamExpected struct {
+	Name     string   `json:"name"`
+	Score    int      `json:"score"`
+	SteamIDs []uint64 `json:"steam_ids"`
 }
 
 type hltvPlayerExpected struct {
@@ -224,6 +237,7 @@ func TestHLTVRegression(t *testing.T) {
 
 				assertHLTVMap(t, oracle.FixtureID, result, expectedMap)
 				assertHLTVRoster(t, oracle.FixtureID, result.Players, expectedMap)
+				assertHLTVTeams(t, oracle.FixtureID, result, expectedMap)
 				for _, expectedPlayer := range expectedMap.Players {
 					player := result.Players[expectedPlayer.SteamID]
 					assertHLTVPlayer(t, oracle.FixtureID, expectedMap, expectedPlayer, player)
@@ -443,6 +457,50 @@ func validateHLTVOracle(t *testing.T, path string, oracle hltvOracle) {
 			}
 			seenPlayers[player.SteamID] = true
 		}
+		// Teams must be pinned explicitly, like game_mode: they carry the
+		// issue #28 logical-team contract, so an omitted key is an
+		// unaudited fixture rather than a no-team assertion.
+		if expectedMap.Teams == nil {
+			t.Fatalf("HLTV oracle %s map %q has no teams; pin the audited rosters and per-team scores", path, expectedMap.Name)
+		}
+		validateHLTVTeamsFixture(t, path, expectedMap, seenPlayers)
+	}
+}
+
+// validateHLTVTeamsFixture checks a map's pinned teams for internal
+// consistency: two distinct named lineups of five that partition the map's
+// ten players, with scores that add up to the rounds and agree with the
+// existing side-based score_values.
+func validateHLTVTeamsFixture(t *testing.T, path string, expectedMap hltvMapExpected, mapPlayers map[uint64]bool) {
+	t.Helper()
+	teams := *expectedMap.Teams
+	if teams[0].Name == "" || teams[1].Name == "" || teams[0].Name == teams[1].Name {
+		t.Fatalf("HLTV oracle %s map %s teams need two distinct nonempty names, got %q and %q",
+			path, expectedMap.Name, teams[0].Name, teams[1].Name)
+	}
+	onTeams := make(map[uint64]bool, len(mapPlayers))
+	for _, team := range teams {
+		if len(team.SteamIDs) != 5 {
+			t.Fatalf("HLTV oracle %s map %s team %s has %d SteamIDs, want 5",
+				path, expectedMap.Name, team.Name, len(team.SteamIDs))
+		}
+		for _, id := range team.SteamIDs {
+			if !mapPlayers[id] {
+				t.Fatalf("HLTV oracle %s map %s team %s lists SteamID %d that is not among the map's players",
+					path, expectedMap.Name, team.Name, id)
+			}
+			if onTeams[id] {
+				t.Fatalf("HLTV oracle %s map %s lists SteamID %d on both teams", path, expectedMap.Name, id)
+			}
+			onTeams[id] = true
+		}
+	}
+	if got, want := sortedScore(teams[0].Score, teams[1].Score), sortedScore(expectedMap.ScoreValues[0], expectedMap.ScoreValues[1]); got != want {
+		t.Fatalf("HLTV oracle %s map %s team scores %v disagree with score_values %v", path, expectedMap.Name, got, want)
+	}
+	if teams[0].Score+teams[1].Score != expectedMap.Rounds {
+		t.Fatalf("HLTV oracle %s map %s team scores add to %d, want the %d rounds",
+			path, expectedMap.Name, teams[0].Score+teams[1].Score, expectedMap.Rounds)
 	}
 }
 
@@ -580,6 +638,62 @@ func assertHLTVRoster(t *testing.T, fixtureID string, players map[uint64]*DemoPl
 			fixtureID, expected.MapID, expected.Name,
 			len(players), missing, unexpected)
 	}
+}
+
+// assertHLTVTeams checks the issue #28 logical-team contract on a real
+// tournament demo: exactly two teams whose rosters, display names, aliases
+// and per-team scores survive every side switch, whose scores reconcile with
+// the final side-based scoreboard, and whose players reference them through
+// team_id. Parsed teams are matched to the fixture rows by exact roster, so
+// the assertion is independent of the parser's map-local team numbering.
+func assertHLTVTeams(t *testing.T, fixtureID string, result *ProcessedDemo, expected hltvMapExpected) {
+	t.Helper()
+	label := fmt.Sprintf("%s/%d/%s", fixtureID, expected.MapID, expected.Name)
+	if len(result.Teams) != 2 {
+		t.Errorf("%s parsed %d teams, want 2", label, len(result.Teams))
+		return
+	}
+	gotScores := sortedScore(result.Teams[0].Score, result.Teams[1].Score)
+	sideScores := sortedScore(result.Map.RoundsWonCT, result.Map.RoundsWonT)
+	if gotScores != sideScores {
+		t.Errorf("%s team scores %v do not reconcile with final side scores %v", label, gotScores, sideScores)
+	}
+	for _, expectedTeam := range *expected.Teams {
+		team, found := findTeamByRoster(result.Teams, expectedTeam.SteamIDs)
+		if !found {
+			t.Errorf("%s no parsed team has %s's roster %v; parsed teams %+v",
+				label, expectedTeam.Name, sortedIDs(expectedTeam.SteamIDs), result.Teams)
+			continue
+		}
+		if team.Name != expectedTeam.Name {
+			t.Errorf("%s team with %s's roster is named %q, want %q",
+				label, expectedTeam.Name, team.Name, expectedTeam.Name)
+		}
+		if !slices.Equal(team.Aliases, []string{expectedTeam.Name}) {
+			t.Errorf("%s team %s aliases = %v, want exactly the observed clan name",
+				label, expectedTeam.Name, team.Aliases)
+		}
+		if team.Score != expectedTeam.Score {
+			t.Errorf("%s team %s score = %d, want %d", label, expectedTeam.Name, team.Score, expectedTeam.Score)
+		}
+		for _, id := range expectedTeam.SteamIDs {
+			// A missing player is already reported by assertHLTVRoster.
+			if player := result.Players[id]; player != nil && player.TeamID != team.TeamID {
+				t.Errorf("%s player %d team_id = %d, want %d (%s)",
+					label, id, player.TeamID, team.TeamID, expectedTeam.Name)
+			}
+		}
+	}
+}
+
+func findTeamByRoster(teams []DemoTeam, steamIDs []uint64) (DemoTeam, bool) {
+	want := sortedIDs(steamIDs)
+	for _, team := range teams {
+		if slices.Equal(team.Roster, want) {
+			return team, true
+		}
+	}
+	return DemoTeam{}, false
 }
 
 func assertHLTVPlayer(t *testing.T, fixtureID string, expectedMap hltvMapExpected, expected hltvPlayerExpected, player *DemoPlayer) {

--- a/cmd/demo_parser/round_tracker.go
+++ b/cmd/demo_parser/round_tracker.go
@@ -49,6 +49,7 @@ type openingDuel struct {
 type roundOutcome struct {
 	played       bool
 	decided      bool
+	winner       common.Team // side that won, TeamUnassigned when undecided
 	mvp          uint64
 	aces         []uint64
 	multiKills   map[uint64]int // enemy kills of the players that got at least a 2k
@@ -57,24 +58,31 @@ type roundOutcome struct {
 	opening      openingDuel
 	openingWon   bool // the opening killer's team won the round
 	participants map[uint64]common.Team
-	deathsTraded map[uint64]bool    // players with a death avenged inside the trade window
-	kast         map[uint64]bool    // players that got a Kill, Assist, Survived or were Traded
-	swing        map[uint64]float64 // per-player round-win-probability swing, zero-sum per round
-	survived     map[uint64]bool    // players still alive when the round closed
-	ratingKast   map[uint64]bool    // players with rating KAST credit; see finalize
+	liveSides    map[uint64]common.Team // roster when live play began; see the tracker field
+	deathsTraded map[uint64]bool        // players with a death avenged inside the trade window
+	kast         map[uint64]bool        // players that got a Kill, Assist, Survived or were Traded
+	swing        map[uint64]float64     // per-player round-win-probability swing, zero-sum per round
+	survived     map[uint64]bool        // players still alive when the round closed
+	ratingKast   map[uint64]bool        // players with rating KAST credit; see finalize
 }
 
 // roundTracker keeps the per-round state needed for clutches, aces, trades
 // and KAST. It is fed plain values instead of parser types so tests can
 // drive it without a demo file.
 type roundTracker struct {
-	live          bool
-	decided       bool
-	winner        common.Team
-	mvp           uint64
-	bombPlanted   bool
-	startAlive    map[uint64]common.Team
-	alive         map[uint64]common.Team
+	live        bool
+	decided     bool
+	winner      common.Team
+	mvp         uint64
+	bombPlanted bool
+	startAlive  map[uint64]common.Team
+	alive       map[uint64]common.Team
+	// liveSides is the roster as of the moment live play begins. Unlike
+	// startAlive it is replaced outright by the freeze-time refresh, so a
+	// player who left during freeze time is absent instead of lingering on
+	// a stale side — which is what logical-team resolution needs when a
+	// halftime side switch lands inside freeze time.
+	liveSides     map[uint64]common.Team
 	enemyKills    map[uint64]int
 	assists       map[uint64]assistFacts
 	traded        map[uint64]bool
@@ -98,9 +106,11 @@ func (rt *roundTracker) startRound(alive map[uint64]common.Team) {
 	rt.mvp = 0
 	rt.startAlive = make(map[uint64]common.Team, len(alive))
 	rt.alive = make(map[uint64]common.Team, len(alive))
+	rt.liveSides = make(map[uint64]common.Team, len(alive))
 	for id, team := range alive {
 		rt.startAlive[id] = team
 		rt.alive[id] = team
+		rt.liveSides[id] = team
 	}
 	rt.enemyKills = make(map[uint64]int)
 	rt.assists = make(map[uint64]assistFacts)
@@ -154,7 +164,9 @@ func (rt *roundTracker) joinRound(alive map[uint64]common.Team) {
 	if !rt.live {
 		return
 	}
+	rt.liveSides = make(map[uint64]common.Team, len(alive))
 	for id, team := range alive {
+		rt.liveSides[id] = team
 		_, started := rt.startAlive[id]
 		_, stillAlive := rt.alive[id]
 		// A player who swapped sides during freeze time plays the round on
@@ -370,6 +382,7 @@ func (rt *roundTracker) finalize() roundOutcome {
 	outcome := roundOutcome{
 		played:       true,
 		decided:      rt.decided,
+		winner:       rt.winner,
 		mvp:          rt.mvp,
 		multiKills:   make(map[uint64]int),
 		tradeKills:   rt.tradeKills,
@@ -377,6 +390,7 @@ func (rt *roundTracker) finalize() roundOutcome {
 		opening:      rt.opening,
 		openingWon:   rt.opening.killer != 0 && rt.opening.killerTeam == rt.winner,
 		participants: rt.startAlive,
+		liveSides:    rt.liveSides,
 		deathsTraded: make(map[uint64]bool),
 		kast:         make(map[uint64]bool),
 		swing:        rt.swing,

--- a/cmd/demo_parser/team_tracker.go
+++ b/cmd/demo_parser/team_tracker.go
@@ -1,0 +1,222 @@
+package demoparser
+
+import (
+	"fmt"
+	"slices"
+
+	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
+)
+
+// teamRoundFacts is what one accepted scored round contributes to logical
+// team identity: the eligible SteamID64s that played each side, the clan
+// names the scoreboard showed for those sides, and the side that won (or
+// TeamUnassigned when the round's decision was never seen).
+type teamRoundFacts struct {
+	round             int // 1-based position among the match's finalized rounds, for errors
+	ctRoster, tRoster []uint64
+	ctClan, tClan     string
+	winner            common.Team
+}
+
+// aliasFact is one observed clan-name spelling and the number of accepted
+// rounds it was on the scoreboard for.
+type aliasFact struct {
+	name   string
+	rounds int
+}
+
+// logicalTeam accumulates one map-local team: the members that have played
+// an accepted round for it, every clan-name alias observed while they held a
+// side, and the accepted rounds they won.
+type logicalTeam struct {
+	id      int
+	members map[uint64]bool
+	aliases []aliasFact // deduplicated, in first-observation order
+	score   int
+}
+
+func newLogicalTeam(id int) *logicalTeam {
+	return &logicalTeam{id: id, members: make(map[uint64]bool)}
+}
+
+// recordRound folds one accepted round into the team. New roster members are
+// substitutes joining the team; a reconnecting member is already in the set
+// and cannot be duplicated. An empty clan name stays unknown rather than
+// becoming a fake alias.
+func (lt *logicalTeam) recordRound(roster []uint64, clan string, won bool) {
+	for _, id := range roster {
+		lt.members[id] = true
+	}
+	if clan != "" {
+		lt.recordAlias(clan)
+	}
+	if won {
+		lt.score++
+	}
+}
+
+func (lt *logicalTeam) recordAlias(clan string) {
+	for i := range lt.aliases {
+		if lt.aliases[i].name == clan {
+			lt.aliases[i].rounds++
+			return
+		}
+	}
+	lt.aliases = append(lt.aliases, aliasFact{name: clan, rounds: 1})
+}
+
+// displayName is the alias observed in the most accepted rounds, ties broken
+// by first observation. A mid-match rename therefore only takes over the
+// display name once it has been on the scoreboard longer than the old name,
+// and a team that never showed a nonempty clan name has no display name.
+func (lt *logicalTeam) displayName() string {
+	name, best := "", 0
+	for _, alias := range lt.aliases {
+		if alias.rounds > best {
+			name, best = alias.name, alias.rounds
+		}
+	}
+	return name
+}
+
+func (lt *logicalTeam) export() DemoTeam {
+	aliases := make([]string, len(lt.aliases))
+	for i, alias := range lt.aliases {
+		aliases[i] = alias.name
+	}
+	return DemoTeam{
+		TeamID:  lt.id,
+		Name:    lt.displayName(),
+		Aliases: aliases,
+		Score:   lt.score,
+		Roster:  lt.memberIDs(),
+	}
+}
+
+// memberIDs returns the sorted member SteamIDs, non-nil even when empty so
+// an empty roster serializes as [] rather than null.
+func (lt *logicalTeam) memberIDs() []uint64 {
+	ids := make([]uint64, 0, len(lt.members))
+	for id := range lt.members {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+// teamTracker resolves the two logical teams of one map. CT and T are
+// temporary sides that swap at halftime and with every overtime half, so
+// identity is carried by the eligible SteamID64 rosters alone: the tracker
+// is only fed rounds the authoritative scored-round gate accepted, seeds the
+// teams from the first of those rounds, and maps every later round's sides
+// back to the seeded teams through shared members. Clan names are labels
+// that never carry identity; the full contract is documented on DemoTeam.
+type teamTracker struct {
+	teams [2]*logicalTeam
+}
+
+func newTeamTracker() *teamTracker {
+	return &teamTracker{}
+}
+
+func (tt *teamTracker) seeded() bool {
+	return tt.teams[0] != nil
+}
+
+// applyRound folds one accepted round into the two teams. The first round
+// with any eligible participant seeds them: team 1 is the seeding round's CT
+// side and team 2 its T side, a deterministic map-local numbering that
+// claims nothing about the sides or organizations of any other demo. A
+// round with no eligible participant carries no identity evidence and
+// contributes nothing.
+func (tt *teamTracker) applyRound(facts teamRoundFacts) error {
+	if len(facts.ctRoster)+len(facts.tRoster) == 0 {
+		return nil
+	}
+	var ctTeam, tTeam *logicalTeam
+	if !tt.seeded() {
+		ctTeam, tTeam = newLogicalTeam(1), newLogicalTeam(2)
+		tt.teams[0], tt.teams[1] = ctTeam, tTeam
+	} else {
+		var err error
+		ctTeam, tTeam, err = tt.resolve(facts)
+		if err != nil {
+			return err
+		}
+	}
+	ctTeam.recordRound(facts.ctRoster, facts.ctClan, facts.winner == common.TeamCounterTerrorists)
+	tTeam.recordRound(facts.tRoster, facts.tClan, facts.winner == common.TeamTerrorists)
+	return nil
+}
+
+// resolve maps the round's two side rosters onto the seeded teams. A mapping
+// is confident when it has roster evidence (a shared eligible SteamID) and
+// no conflict (no player it would place on both teams); the straight and
+// crossed mappings cannot both qualify, because any evidence for one is a
+// conflict of the other. Substitutes resolve through their teammates, and a
+// side of entirely new players still resolves by elimination when the other
+// side maps uniquely. Anything less returns an error carrying the competing
+// evidence instead of guessing.
+func (tt *teamTracker) resolve(facts teamRoundFacts) (ctTeam, tTeam *logicalTeam, err error) {
+	first, second := tt.teams[0], tt.teams[1]
+	straight := overlapCount(facts.ctRoster, first) + overlapCount(facts.tRoster, second)
+	crossed := overlapCount(facts.ctRoster, second) + overlapCount(facts.tRoster, first)
+
+	if straight > 0 && crossed == 0 {
+		return first, second, nil
+	}
+	if crossed > 0 && straight == 0 {
+		return second, first, nil
+	}
+	evidence := fmt.Sprintf(
+		"CT roster %v shares %v with team 1 and %v with team 2; T roster %v shares %v with team 1 and %v with team 2",
+		sortedIDs(facts.ctRoster), overlap(facts.ctRoster, first), overlap(facts.ctRoster, second),
+		sortedIDs(facts.tRoster), overlap(facts.tRoster, first), overlap(facts.tRoster, second))
+	if straight+crossed == 0 {
+		return nil, nil, fmt.Errorf(
+			"finalized round %d: cannot resolve logical teams: neither side shares an eligible SteamID with a seeded team: %s; team 1 members %v, team 2 members %v",
+			facts.round, evidence, first.memberIDs(), second.memberIDs())
+	}
+	return nil, nil, fmt.Errorf(
+		"finalized round %d: eligible SteamIDs appear to participate for both logical teams: %s",
+		facts.round, evidence)
+}
+
+// export returns the two teams in team-ID order, or no teams when no
+// accepted round ever had an eligible participant.
+func (tt *teamTracker) export() []DemoTeam {
+	if !tt.seeded() {
+		return []DemoTeam{}
+	}
+	return []DemoTeam{tt.teams[0].export(), tt.teams[1].export()}
+}
+
+// overlapCount reports how many of the roster IDs are members of the team.
+func overlapCount(roster []uint64, team *logicalTeam) int {
+	count := 0
+	for _, id := range roster {
+		if team.members[id] {
+			count++
+		}
+	}
+	return count
+}
+
+// overlap returns the roster IDs that are members of the team, sorted. It
+// only feeds error evidence; resolve decides on counts alone.
+func overlap(roster []uint64, team *logicalTeam) []uint64 {
+	var shared []uint64
+	for _, id := range roster {
+		if team.members[id] {
+			shared = append(shared, id)
+		}
+	}
+	slices.Sort(shared)
+	return shared
+}
+
+func sortedIDs(roster []uint64) []uint64 {
+	sorted := slices.Clone(roster)
+	slices.Sort(sorted)
+	return sorted
+}

--- a/cmd/demo_parser/team_tracker_test.go
+++ b/cmd/demo_parser/team_tracker_test.go
@@ -1,0 +1,489 @@
+package demoparser
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
+	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
+)
+
+// teamAnalyser is a liveAnalyser whose scoreboard shows the given clan names
+// for the CT and T sides.
+func teamAnalyser(ctClan, tClan string, playing ...*common.Player) *analyser {
+	a := liveAnalyser(playing...)
+	p := a.parser.(*matchParser)
+	p.ctClan, p.tClan = ctClan, tClan
+	return a
+}
+
+// swapSides flips every player to the other side and swaps the scoreboard
+// clan names with them, exactly as a halftime or overtime side switch does.
+func swapSides(a *analyser, players ...*common.Player) {
+	for _, pl := range players {
+		switch pl.Team {
+		case common.TeamTerrorists:
+			pl.Team = common.TeamCounterTerrorists
+		case common.TeamCounterTerrorists:
+			pl.Team = common.TeamTerrorists
+		}
+	}
+	p := a.parser.(*matchParser)
+	p.ctClan, p.tClan = p.tClan, p.ctClan
+}
+
+func TestFirstScoredRoundSeedsTwoLogicalTeams(t *testing.T) {
+	ct := player(11, "ct", common.TeamCounterTerrorists)
+	tPlayer := player(1, "t", common.TeamTerrorists)
+	a := teamAnalyser("Alpha", "Bravo", ct, tPlayer)
+
+	playRound(a, common.TeamCounterTerrorists)
+	a.finalise()
+
+	want := []DemoTeam{
+		{TeamID: 1, Name: "Alpha", Aliases: []string{"Alpha"}, Score: 1, Roster: []uint64{11}},
+		{TeamID: 2, Name: "Bravo", Aliases: []string{"Bravo"}, Score: 0, Roster: []uint64{1}},
+	}
+	if !reflect.DeepEqual(a.teams, want) {
+		t.Errorf("teams = %+v, want %+v", a.teams, want)
+	}
+	if got := a.players[11].TeamID; got != 1 {
+		t.Errorf("CT player team_id = %d, want 1", got)
+	}
+	if got := a.players[1].TeamID; got != 2 {
+		t.Errorf("T player team_id = %d, want 2", got)
+	}
+}
+
+func TestHalftimeSwapKeepsLogicalTeamIdentity(t *testing.T) {
+	first := player(1, "first", common.TeamTerrorists)
+	second := player(11, "second", common.TeamCounterTerrorists)
+	a := teamAnalyser("Alpha", "Bravo", first, second)
+
+	playRound(a, common.TeamTerrorists)
+	swapSides(a, first, second)
+	playRound(a, common.TeamCounterTerrorists)
+	playRound(a, common.TeamTerrorists)
+	a.finalise()
+
+	// Player 1's team won as T before the swap and as CT after it; player
+	// 11's team won the last round on its new T side. Identity, aliases and
+	// scores all stay with the lineups, not the sides.
+	want := []DemoTeam{
+		{TeamID: 1, Name: "Alpha", Aliases: []string{"Alpha"}, Score: 1, Roster: []uint64{11}},
+		{TeamID: 2, Name: "Bravo", Aliases: []string{"Bravo"}, Score: 2, Roster: []uint64{1}},
+	}
+	if !reflect.DeepEqual(a.teams, want) {
+		t.Errorf("teams after halftime = %+v, want %+v", a.teams, want)
+	}
+}
+
+func TestOvertimeSwapsKeepIdentityAndScores(t *testing.T) {
+	first := player(1, "first", common.TeamTerrorists)
+	second := player(11, "second", common.TeamCounterTerrorists)
+	a := teamAnalyser("Alpha", "Bravo", first, second)
+
+	// Player 1's side wins every round while the teams change ends before
+	// each one, as aggressively as any overtime format could.
+	for range 6 {
+		playRound(a, first.Team)
+		swapSides(a, first, second)
+	}
+	a.finalise()
+
+	want := []DemoTeam{
+		{TeamID: 1, Name: "Alpha", Aliases: []string{"Alpha"}, Score: 0, Roster: []uint64{11}},
+		{TeamID: 2, Name: "Bravo", Aliases: []string{"Bravo"}, Score: 6, Roster: []uint64{1}},
+	}
+	if !reflect.DeepEqual(a.teams, want) {
+		t.Errorf("teams after overtime swaps = %+v, want %+v", a.teams, want)
+	}
+}
+
+func TestSubstituteJoinsUniquelyMatchedTeam(t *testing.T) {
+	starter := player(1, "starter", common.TeamTerrorists)
+	teammate := player(2, "teammate", common.TeamTerrorists)
+	opponent := player(11, "opponent", common.TeamCounterTerrorists)
+	a := teamAnalyser("", "", starter, teammate, opponent)
+
+	playRound(a, common.TeamTerrorists)
+	substitute := player(3, "substitute", common.TeamTerrorists)
+	a.parser.(*matchParser).playing = []*common.Player{starter, substitute, opponent}
+	playRound(a, common.TeamTerrorists)
+	a.finalise()
+
+	if got, want := a.teams[1].Roster, []uint64{1, 2, 3}; !reflect.DeepEqual(got, want) {
+		t.Errorf("team 2 roster = %v, want the substitute added to %v", got, want)
+	}
+	if got := a.players[3].TeamID; got != 2 {
+		t.Errorf("substitute team_id = %d, want 2", got)
+	}
+	if got := a.teams[1].Score; got != 2 {
+		t.Errorf("team 2 score = %d, want 2", got)
+	}
+}
+
+func TestReconnectDoesNotDuplicateParticipation(t *testing.T) {
+	returning := player(1, "returning", common.TeamTerrorists)
+	teammate := player(2, "teammate", common.TeamTerrorists)
+	opponent := player(11, "opponent", common.TeamCounterTerrorists)
+	a := teamAnalyser("", "", returning, teammate, opponent)
+	p := a.parser.(*matchParser)
+
+	playRound(a, common.TeamTerrorists)
+	p.playing = []*common.Player{teammate, opponent}
+	playRound(a, common.TeamTerrorists)
+	p.playing = []*common.Player{returning, teammate, opponent}
+	playRound(a, common.TeamTerrorists)
+	a.finalise()
+
+	if got, want := a.teams[1].Roster, []uint64{1, 2}; !reflect.DeepEqual(got, want) {
+		t.Errorf("team 2 roster after reconnect = %v, want %v", got, want)
+	}
+	if got := a.teams[1].Score; got != 3 {
+		t.Errorf("team 2 score = %d, want all three rounds", got)
+	}
+}
+
+func TestWarmupKnifeAndSetupRoundsDoNotSeedTeams(t *testing.T) {
+	knifer := player(99, "knifer", common.TeamCounterTerrorists)
+	starterCT := player(11, "starter-ct", common.TeamCounterTerrorists)
+	extraCT := player(98, "extra-ct", common.TeamCounterTerrorists)
+	starterT := player(1, "starter-t", common.TeamTerrorists)
+	a := teamAnalyser("Alpha", "Bravo", knifer, starterT)
+	p := a.parser.(*matchParser)
+
+	// A pregame knife round with its own roster is gated out entirely.
+	p.gamePhase = common.GamePhasePregame
+	a.onRoundStart(events.RoundStart{})
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamCounterTerrorists})
+	a.onRoundEndOfficial(events.RoundEndOfficial{})
+
+	// An unscored setup round restarts at the same score; its roster still
+	// contains a player who leaves before the real first round.
+	p.gamePhase = common.GamePhaseStartGamePhase
+	p.playing = []*common.Player{starterCT, extraCT, starterT}
+	a.onRoundStart(events.RoundStart{})
+
+	p.playing = []*common.Player{starterCT, starterT}
+	playRound(a, common.TeamCounterTerrorists)
+	a.finalise()
+
+	want := []DemoTeam{
+		{TeamID: 1, Name: "Alpha", Aliases: []string{"Alpha"}, Score: 1, Roster: []uint64{11}},
+		{TeamID: 2, Name: "Bravo", Aliases: []string{"Bravo"}, Score: 0, Roster: []uint64{1}},
+	}
+	if !reflect.DeepEqual(a.teams, want) {
+		t.Errorf("teams = %+v, want seeding from the first scored round only: %+v", a.teams, want)
+	}
+	if a.players[99] != nil {
+		t.Error("pregame knife-round participant became a player")
+	}
+	if got := a.players[98].TeamID; got != 0 {
+		t.Errorf("setup-round participant team_id = %d, want 0: they never played a scored round", got)
+	}
+}
+
+func TestBotsAndCoachesAreNotTeamMembers(t *testing.T) {
+	competitor := player(1, "competitor", common.TeamTerrorists)
+	bot := botPlayer(101, "bot", common.TeamTerrorists)
+	coach := playerWithCoachingTeam(50, "coach", common.TeamCounterTerrorists, common.TeamCounterTerrorists)
+	opponent := player(11, "opponent", common.TeamCounterTerrorists)
+	a := teamAnalyser("", "", competitor, bot, coach, opponent)
+
+	playRound(a, common.TeamTerrorists)
+	a.finalise()
+
+	if got, want := a.teams[0].Roster, []uint64{11}; !reflect.DeepEqual(got, want) {
+		t.Errorf("team 1 roster = %v, want the coach excluded: %v", got, want)
+	}
+	if got, want := a.teams[1].Roster, []uint64{1}; !reflect.DeepEqual(got, want) {
+		t.Errorf("team 2 roster = %v, want the bot excluded: %v", got, want)
+	}
+}
+
+func TestEmptyClanNamesStayUnknown(t *testing.T) {
+	ct := player(11, "ct", common.TeamCounterTerrorists)
+	tPlayer := player(1, "t", common.TeamTerrorists)
+	a := teamAnalyser("", "", ct, tPlayer)
+
+	playRound(a, common.TeamCounterTerrorists)
+	a.finalise()
+
+	want := []DemoTeam{
+		{TeamID: 1, Name: "", Aliases: []string{}, Score: 1, Roster: []uint64{11}},
+		{TeamID: 2, Name: "", Aliases: []string{}, Score: 0, Roster: []uint64{1}},
+	}
+	if !reflect.DeepEqual(a.teams, want) {
+		t.Errorf("teams = %+v, want unknown names with no invented alias: %+v", a.teams, want)
+	}
+}
+
+func TestDuplicateClanNamesDoNotMergeTeams(t *testing.T) {
+	ct := player(11, "ct", common.TeamCounterTerrorists)
+	tPlayer := player(1, "t", common.TeamTerrorists)
+	a := teamAnalyser("MIX", "MIX", ct, tPlayer)
+
+	playRound(a, common.TeamCounterTerrorists)
+	playRound(a, common.TeamTerrorists)
+	a.finalise()
+
+	want := []DemoTeam{
+		{TeamID: 1, Name: "MIX", Aliases: []string{"MIX"}, Score: 1, Roster: []uint64{11}},
+		{TeamID: 2, Name: "MIX", Aliases: []string{"MIX"}, Score: 1, Roster: []uint64{1}},
+	}
+	if !reflect.DeepEqual(a.teams, want) {
+		t.Errorf("teams = %+v, want two same-named teams kept apart: %+v", a.teams, want)
+	}
+}
+
+func TestChangingClanNamesBecomeAliasesDeterministically(t *testing.T) {
+	ct := player(11, "ct", common.TeamCounterTerrorists)
+	tPlayer := player(1, "t", common.TeamTerrorists)
+	a := teamAnalyser("Alpha", "Bravo", ct, tPlayer)
+	p := a.parser.(*matchParser)
+
+	playRound(a, common.TeamCounterTerrorists)
+	p.ctClan = "Alpha GG"
+	playRound(a, common.TeamCounterTerrorists)
+	playRound(a, common.TeamCounterTerrorists)
+	a.finalise()
+
+	team := a.teams[0]
+	if want := []string{"Alpha", "Alpha GG"}; !reflect.DeepEqual(team.Aliases, want) {
+		t.Errorf("aliases = %v, want first-observation order %v", team.Aliases, want)
+	}
+	if team.Name != "Alpha GG" {
+		t.Errorf("name = %q, want the alias observed in the most rounds, %q", team.Name, "Alpha GG")
+	}
+}
+
+func TestDisplayNameTieBreaksToFirstObservedAlias(t *testing.T) {
+	tracker := newTeamTracker()
+	rounds := []teamRoundFacts{
+		{ctRoster: []uint64{11}, tRoster: []uint64{1}, ctClan: "Alpha", tClan: "Bravo"},
+		{ctRoster: []uint64{11}, tRoster: []uint64{1}, ctClan: "Alpha GG", tClan: "Bravo"},
+	}
+	for _, facts := range rounds {
+		if err := tracker.applyRound(facts); err != nil {
+			t.Fatalf("applyRound: %v", err)
+		}
+	}
+
+	if got := tracker.export()[0].Name; got != "Alpha" {
+		t.Errorf("tied aliases resolved to %q, want the first observed, %q", got, "Alpha")
+	}
+}
+
+func TestFullSideOfSubstitutesResolvesByElimination(t *testing.T) {
+	tracker := newTeamTracker()
+	seed := teamRoundFacts{ctRoster: []uint64{11}, tRoster: []uint64{1}}
+	if err := tracker.applyRound(seed); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	// The whole T lineup is new; the CT side still maps uniquely, so the
+	// new players can only be the other team.
+	replaced := teamRoundFacts{ctRoster: []uint64{11}, tRoster: []uint64{5}, winner: common.TeamTerrorists}
+	if err := tracker.applyRound(replaced); err != nil {
+		t.Fatalf("elimination round: %v", err)
+	}
+
+	teams := tracker.export()
+	if got, want := teams[1].Roster, []uint64{1, 5}; !reflect.DeepEqual(got, want) {
+		t.Errorf("team 2 roster = %v, want %v", got, want)
+	}
+	if got := teams[1].Score; got != 1 {
+		t.Errorf("team 2 score = %d, want the eliminated-side win counted", got)
+	}
+}
+
+func TestRoundsWithoutEligiblePlayersCarryNoTeamFacts(t *testing.T) {
+	tracker := newTeamTracker()
+
+	// A bots-only round cannot seed identity.
+	if err := tracker.applyRound(teamRoundFacts{winner: common.TeamTerrorists}); err != nil {
+		t.Fatalf("bots-only round before seeding: %v", err)
+	}
+	if got := tracker.export(); len(got) != 0 {
+		t.Fatalf("teams = %+v, want none before an eligible participant", got)
+	}
+
+	seed := teamRoundFacts{ctRoster: []uint64{11}, tRoster: []uint64{1}, ctClan: "Alpha", tClan: "Bravo"}
+	if err := tracker.applyRound(seed); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	// After seeding, another bots-only round moves no score to either team.
+	if err := tracker.applyRound(teamRoundFacts{winner: common.TeamTerrorists}); err != nil {
+		t.Fatalf("bots-only round after seeding: %v", err)
+	}
+
+	teams := tracker.export()
+	if teams[0].Score != 0 || teams[1].Score != 0 {
+		t.Errorf("scores = %d/%d, want no win attributed without roster evidence", teams[0].Score, teams[1].Score)
+	}
+}
+
+func TestUndecidedAcceptedRoundMovesNoTeamScore(t *testing.T) {
+	tracker := newTeamTracker()
+	facts := teamRoundFacts{ctRoster: []uint64{11}, tRoster: []uint64{1}, winner: common.TeamUnassigned}
+	if err := tracker.applyRound(facts); err != nil {
+		t.Fatalf("applyRound: %v", err)
+	}
+
+	teams := tracker.export()
+	if teams[0].Score != 0 || teams[1].Score != 0 {
+		t.Errorf("scores = %d/%d, want 0/0 for a round with no recorded winner", teams[0].Score, teams[1].Score)
+	}
+}
+
+func TestAmbiguousRosterReturnsActionableError(t *testing.T) {
+	first := player(1, "first", common.TeamTerrorists)
+	second := player(11, "second", common.TeamCounterTerrorists)
+	a := teamAnalyser("", "", first, second)
+	p := a.parser.(*matchParser)
+
+	playRound(a, common.TeamTerrorists)
+	// The next scored round is played by entirely different SteamIDs, so
+	// neither side can be mapped to a seeded team.
+	p.playing = []*common.Player{
+		player(3, "unknown-t", common.TeamTerrorists),
+		player(13, "unknown-ct", common.TeamCounterTerrorists),
+	}
+	playRound(a, common.TeamTerrorists)
+
+	err := a.finalise()
+	if err == nil {
+		t.Fatal("fully replaced rosters did not produce an ambiguity error")
+	}
+	msg := err.Error()
+	for _, evidence := range []string{"cannot resolve logical teams", "finalized round 2", "[13]", "[3]", "team 1 members [11]", "team 2 members [1]"} {
+		if !strings.Contains(msg, evidence) {
+			t.Errorf("ambiguity error %q does not carry evidence %q", msg, evidence)
+		}
+	}
+}
+
+// A halftime side switch can land during freeze time, after RoundStart
+// snapshotted the old sides. A player who disconnects inside that window
+// must not be presented to team resolution on their stale pre-switch side,
+// where they would sit among the other lineup and read as playing for both
+// teams.
+func TestPreSwapFreezeTimeLeaverDoesNotBreakIdentity(t *testing.T) {
+	one := player(1, "one", common.TeamTerrorists)
+	two := player(2, "two", common.TeamTerrorists)
+	eleven := player(11, "eleven", common.TeamCounterTerrorists)
+	twelve := player(12, "twelve", common.TeamCounterTerrorists)
+	a := teamAnalyser("", "", one, two, eleven, twelve)
+	p := a.parser.(*matchParser)
+
+	playRound(a, common.TeamTerrorists)
+
+	// Halftime: RoundStart still sees the old sides.
+	a.onRoundStart(events.RoundStart{})
+	// The switch lands during freeze time, and player 2 leaves before live
+	// play begins.
+	one.Team = common.TeamCounterTerrorists
+	eleven.Team, twelve.Team = common.TeamTerrorists, common.TeamTerrorists
+	p.playing = []*common.Player{one, eleven, twelve}
+	a.onDisconnect(events.PlayerDisconnected{Player: two})
+	a.onRoundFreezetimeEnd(events.RoundFreezetimeEnd{})
+	endScoredRound(a, common.TeamCounterTerrorists)
+
+	if err := a.finalise(); err != nil {
+		t.Fatalf("freeze-time leaver broke team resolution: %v", err)
+	}
+	want := []DemoTeam{
+		{TeamID: 1, Name: "", Aliases: []string{}, Score: 0, Roster: []uint64{11, 12}},
+		{TeamID: 2, Name: "", Aliases: []string{}, Score: 2, Roster: []uint64{1, 2}},
+	}
+	if !reflect.DeepEqual(a.teams, want) {
+		t.Errorf("teams = %+v, want identity kept through the late swap: %+v", a.teams, want)
+	}
+	if got := a.players[2].TeamID; got != 2 {
+		t.Errorf("leaver team_id = %d, want their round-1 team 2", got)
+	}
+}
+
+// A setup round can receive RoundEnd and still be restarted at the same
+// authoritative score. Such a round consumes a scored slot in the player
+// facts, but it must not seed logical teams, add its roster to them, or
+// move a team score.
+func TestDecidedSetupRoundDoesNotSeedOrScoreTeams(t *testing.T) {
+	extra := player(98, "extra-ct", common.TeamCounterTerrorists)
+	tPlayer := player(1, "t", common.TeamTerrorists)
+	ct := player(11, "ct", common.TeamCounterTerrorists)
+	a := teamAnalyser("", "", extra, tPlayer)
+	p := a.parser.(*matchParser)
+
+	a.onRoundStart(events.RoundStart{})
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamCounterTerrorists})
+	a.onRoundEndOfficial(events.RoundEndOfficial{})
+
+	// The match restarts at the same count with the real lineup.
+	p.playing = []*common.Player{ct, tPlayer}
+	playRound(a, common.TeamCounterTerrorists)
+	playRound(a, common.TeamTerrorists)
+
+	if err := a.finalise(); err != nil {
+		t.Fatalf("decided setup round broke team identity: %v", err)
+	}
+	want := []DemoTeam{
+		{TeamID: 1, Name: "", Aliases: []string{}, Score: 1, Roster: []uint64{11}},
+		{TeamID: 2, Name: "", Aliases: []string{}, Score: 1, Roster: []uint64{1}},
+	}
+	if !reflect.DeepEqual(a.teams, want) {
+		t.Errorf("teams = %+v, want seeding and scores from the real rounds only: %+v", a.teams, want)
+	}
+	if got := a.players[98].TeamID; got != 0 {
+		t.Errorf("setup-round participant team_id = %d, want 0", got)
+	}
+}
+
+func TestTeamConflictInFinaliseFlushedRoundIsReported(t *testing.T) {
+	first := player(1, "first", common.TeamTerrorists)
+	second := player(11, "second", common.TeamCounterTerrorists)
+	a := teamAnalyser("", "", first, second)
+	p := a.parser.(*matchParser)
+
+	playRound(a, common.TeamTerrorists)
+	// The final round is played by unknown SteamIDs and its official end
+	// never arrives, so only the finalise flush can apply it.
+	p.playing = []*common.Player{
+		player(3, "unknown-t", common.TeamTerrorists),
+		player(13, "unknown-ct", common.TeamCounterTerrorists),
+	}
+	a.onRoundStart(events.RoundStart{})
+	markRoundScored(a)
+	a.onRoundEnd(events.RoundEnd{Winner: common.TeamTerrorists})
+
+	if err := a.finalise(); err == nil {
+		t.Fatal("team conflict in the finalise-flushed round was swallowed")
+	}
+}
+
+func TestPlayerOnBothTeamsFailsExplicitly(t *testing.T) {
+	switcher := player(1, "switcher", common.TeamTerrorists)
+	teammate := player(2, "teammate", common.TeamTerrorists)
+	opponentA := player(11, "opponent-a", common.TeamCounterTerrorists)
+	opponentB := player(12, "opponent-b", common.TeamCounterTerrorists)
+	a := teamAnalyser("", "", switcher, teammate, opponentA, opponentB)
+
+	playRound(a, common.TeamTerrorists)
+	// Player 1 reappears on the other lineup's side.
+	switcher.Team = common.TeamCounterTerrorists
+	playRound(a, common.TeamTerrorists)
+
+	err := a.finalise()
+	if err == nil {
+		t.Fatal("a player on both lineups did not produce an error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "participate for both logical teams") {
+		t.Errorf("error %q does not name the dual participation", msg)
+	}
+	if !strings.Contains(msg, "[1]") {
+		t.Errorf("error %q does not identify the conflicting SteamID", msg)
+	}
+}

--- a/cmd/demo_parser/testdata/golden_ancient.json
+++ b/cmd/demo_parser/testdata/golden_ancient.json
@@ -4,6 +4,7 @@
       "steam_id": 76561198032044481,
       "name": "bonK",
       "user_id": 4,
+      "team_id": 1,
       "deaths": 3,
       "deaths_traded": {
         "total": 1,
@@ -114,6 +115,7 @@
       "steam_id": 76561198071075349,
       "name": "mattos-v",
       "user_id": 1,
+      "team_id": 1,
       "deaths": 2,
       "deaths_traded": {
         "total": 0,
@@ -225,6 +227,7 @@
       "steam_id": 76561198307159112,
       "name": "CHARRADÃO DE FROZEN",
       "user_id": 9,
+      "team_id": 2,
       "deaths": 6,
       "deaths_traded": {
         "total": 0,
@@ -334,6 +337,7 @@
       "steam_id": 76561198387460920,
       "name": "tandu",
       "user_id": 2,
+      "team_id": 1,
       "deaths": 4,
       "deaths_traded": {
         "total": 2,
@@ -441,6 +445,7 @@
       "steam_id": 76561198826243397,
       "name": "botu360",
       "user_id": 0,
+      "team_id": 1,
       "deaths": 3,
       "deaths_traded": {
         "total": 0,
@@ -551,6 +556,7 @@
       "steam_id": 76561198966281369,
       "name": "cmz-",
       "user_id": 3,
+      "team_id": 1,
       "deaths": 4,
       "deaths_traded": {
         "total": 0,
@@ -664,6 +670,7 @@
       "steam_id": 76561199102419525,
       "name": "seloko-numcompensa",
       "user_id": 6,
+      "team_id": 2,
       "deaths": 6,
       "deaths_traded": {
         "total": 1,
@@ -775,6 +782,7 @@
       "steam_id": 76561199271102802,
       "name": "! Ømegapr1v",
       "user_id": 5,
+      "team_id": 2,
       "deaths": 7,
       "deaths_traded": {
         "total": 0,
@@ -884,6 +892,7 @@
       "steam_id": 76561199311359933,
       "name": "Nagi",
       "user_id": 7,
+      "team_id": 2,
       "deaths": 2,
       "deaths_traded": {
         "total": 0,
@@ -994,6 +1003,7 @@
       "steam_id": 76561199558715190,
       "name": "BushBandit",
       "user_id": 8,
+      "team_id": 2,
       "deaths": 6,
       "deaths_traded": {
         "total": 0,
@@ -1101,6 +1111,34 @@
       }
     }
   },
+  "teams": [
+    {
+      "team_id": 1,
+      "name": "",
+      "aliases": [],
+      "score": 6,
+      "roster": [
+        76561198032044481,
+        76561198071075349,
+        76561198387460920,
+        76561198826243397,
+        76561198966281369
+      ]
+    },
+    {
+      "team_id": 2,
+      "name": "",
+      "aliases": [],
+      "score": 2,
+      "roster": [
+        76561198307159112,
+        76561199102419525,
+        76561199271102802,
+        76561199311359933,
+        76561199558715190
+      ]
+    }
+  ],
   "map_data": {
     "map_name": "de_ancient",
     "total_rounds": 8,

--- a/cmd/demo_parser/testdata/golden_inferno_shotgun.json
+++ b/cmd/demo_parser/testdata/golden_inferno_shotgun.json
@@ -4,6 +4,7 @@
       "steam_id": 76561197995625385,
       "name": "Xiscu",
       "user_id": 0,
+      "team_id": 1,
       "deaths": 12,
       "deaths_traded": {
         "total": 1,
@@ -118,6 +119,7 @@
       "steam_id": 76561198038237426,
       "name": "Calitaz",
       "user_id": 2,
+      "team_id": 1,
       "deaths": 12,
       "deaths_traded": {
         "total": 3,
@@ -231,6 +233,7 @@
       "steam_id": 76561198171714151,
       "name": "Perre",
       "user_id": 1,
+      "team_id": 1,
       "deaths": 14,
       "deaths_traded": {
         "total": 2,
@@ -343,6 +346,7 @@
       "steam_id": 76561198195312910,
       "name": "sem habilidade",
       "user_id": 3,
+      "team_id": 1,
       "deaths": 16,
       "deaths_traded": {
         "total": 1,
@@ -458,6 +462,7 @@
       "steam_id": 76561198283132505,
       "name": "blunt1™",
       "user_id": 4,
+      "team_id": 1,
       "deaths": 18,
       "deaths_traded": {
         "total": 2,
@@ -572,6 +577,7 @@
       "steam_id": 76561199013033607,
       "name": "S1lent",
       "user_id": 7,
+      "team_id": 2,
       "deaths": 15,
       "deaths_traded": {
         "total": 3,
@@ -684,6 +690,7 @@
       "steam_id": 76561199064030155,
       "name": "Biel Mexânico",
       "user_id": 5,
+      "team_id": 2,
       "deaths": 13,
       "deaths_traded": {
         "total": 4,
@@ -796,6 +803,7 @@
       "steam_id": 76561199353626993,
       "name": ":ppp",
       "user_id": 9,
+      "team_id": 2,
       "deaths": 16,
       "deaths_traded": {
         "total": 0,
@@ -909,6 +917,7 @@
       "steam_id": 76561199575273990,
       "name": "S1nner",
       "user_id": 6,
+      "team_id": 2,
       "deaths": 14,
       "deaths_traded": {
         "total": 2,
@@ -1023,6 +1032,7 @@
       "steam_id": 76561199680390775,
       "name": "-wLL",
       "user_id": 8,
+      "team_id": 2,
       "deaths": 17,
       "deaths_traded": {
         "total": 3,
@@ -1135,6 +1145,34 @@
       }
     }
   },
+  "teams": [
+    {
+      "team_id": 1,
+      "name": "",
+      "aliases": [],
+      "score": 7,
+      "roster": [
+        76561197995625385,
+        76561198038237426,
+        76561198171714151,
+        76561198195312910,
+        76561198283132505
+      ]
+    },
+    {
+      "team_id": 2,
+      "name": "",
+      "aliases": [],
+      "score": 13,
+      "roster": [
+        76561199013033607,
+        76561199064030155,
+        76561199353626993,
+        76561199575273990,
+        76561199680390775
+      ]
+    }
+  ],
   "map_data": {
     "map_name": "de_inferno",
     "total_rounds": 20,

--- a/cmd/demo_parser/testdata/golden_mirage.json
+++ b/cmd/demo_parser/testdata/golden_mirage.json
@@ -4,6 +4,7 @@
       "steam_id": 76561197964020430,
       "name": "Подсосник blick'a",
       "user_id": 0,
+      "team_id": 2,
       "deaths": 5,
       "deaths_traded": {
         "total": 2,
@@ -116,6 +117,7 @@
       "steam_id": 76561198073049527,
       "name": "miu miu",
       "user_id": 8,
+      "team_id": 1,
       "deaths": 8,
       "deaths_traded": {
         "total": 1,
@@ -227,6 +229,7 @@
       "steam_id": 76561198118803912,
       "name": "Голова, глаза",
       "user_id": 2,
+      "team_id": 2,
       "deaths": 7,
       "deaths_traded": {
         "total": 1,
@@ -337,6 +340,7 @@
       "steam_id": 76561198194694750,
       "name": "Dog",
       "user_id": 7,
+      "team_id": 1,
       "deaths": 7,
       "deaths_traded": {
         "total": 0,
@@ -450,6 +454,7 @@
       "steam_id": 76561198202353993,
       "name": "IMI Negev",
       "user_id": 4,
+      "team_id": 2,
       "deaths": 2,
       "deaths_traded": {
         "total": 1,
@@ -561,6 +566,7 @@
       "steam_id": 76561198244754626,
       "name": "NIGHTSOUL",
       "user_id": 1,
+      "team_id": 2,
       "deaths": 5,
       "deaths_traded": {
         "total": 0,
@@ -672,6 +678,7 @@
       "steam_id": 76561198258044111,
       "name": "-ExΩtiC-",
       "user_id": 9,
+      "team_id": 1,
       "deaths": 8,
       "deaths_traded": {
         "total": 1,
@@ -783,6 +790,7 @@
       "steam_id": 76561198265366770,
       "name": "123",
       "user_id": 3,
+      "team_id": 2,
       "deaths": 4,
       "deaths_traded": {
         "total": 1,
@@ -893,6 +901,7 @@
       "steam_id": 76561198280975787,
       "name": "povergo",
       "user_id": 6,
+      "team_id": 1,
       "deaths": 9,
       "deaths_traded": {
         "total": 0,
@@ -1004,6 +1013,7 @@
       "steam_id": 76561198324843075,
       "name": "Trahun \u003c3 V",
       "user_id": 5,
+      "team_id": 1,
       "deaths": 9,
       "deaths_traded": {
         "total": 2,
@@ -1111,6 +1121,34 @@
       }
     }
   },
+  "teams": [
+    {
+      "team_id": 1,
+      "name": "",
+      "aliases": [],
+      "score": 2,
+      "roster": [
+        76561198073049527,
+        76561198194694750,
+        76561198258044111,
+        76561198280975787,
+        76561198324843075
+      ]
+    },
+    {
+      "team_id": 2,
+      "name": "",
+      "aliases": [],
+      "score": 8,
+      "roster": [
+        76561197964020430,
+        76561198118803912,
+        76561198202353993,
+        76561198244754626,
+        76561198265366770
+      ]
+    }
+  ],
   "map_data": {
     "map_name": "de_mirage",
     "total_rounds": 10,

--- a/cmd/demo_parser/testdata/hltv-128974/expected.json
+++ b/cmd/demo_parser/testdata/hltv-128974/expected.json
@@ -13,6 +13,10 @@
       "game_mode": "competitive",
       "rounds": 21,
       "score_values": [8, 13],
+      "teams": [
+        {"name": "Spirit", "score": 8, "steam_ids": [76561198081484775, 76561198386265483, 76561198872013168, 76561198995880877, 76561199063238565]},
+        {"name": "MOUZ", "score": 13, "steam_ids": [76561198063336407, 76561198193174134, 76561198310561479, 76561198355739212, 76561198998266210]}
+      ],
       "players": [
         {"steam_id": "76561198386265483", "hltv_name": "donk", "kills": 14, "deaths": 16, "adr": 73.4, "kast_percent": 57.1, "rating": 1.09},
         {"steam_id": "76561199063238565", "hltv_name": "magixx", "kills": 12, "deaths": 17, "adr": 77.3, "kast_percent": 42.9, "rating": 0.91},
@@ -36,6 +40,10 @@
       "game_mode": "competitive",
       "rounds": 17,
       "score_values": [4, 13],
+      "teams": [
+        {"name": "Spirit", "score": 4, "steam_ids": [76561198081484775, 76561198386265483, 76561198872013168, 76561198995880877, 76561199063238565]},
+        {"name": "MOUZ", "score": 13, "steam_ids": [76561198063336407, 76561198193174134, 76561198310561479, 76561198355739212, 76561198998266210]}
+      ],
       "players": [
         {"steam_id": "76561198386265483", "hltv_name": "donk", "kills": 10, "deaths": 15, "adr": 70.5, "kast_percent": 52.9, "rating": 0.89},
         {"steam_id": "76561198995880877", "hltv_name": "zont1x", "kills": 11, "deaths": 15, "adr": 69.8, "kast_percent": 58.8, "rating": 0.89},
@@ -59,6 +67,10 @@
       "game_mode": "competitive",
       "rounds": 22,
       "score_values": [9, 13],
+      "teams": [
+        {"name": "Spirit", "score": 13, "steam_ids": [76561198081484775, 76561198386265483, 76561198872013168, 76561198995880877, 76561199063238565]},
+        {"name": "MOUZ", "score": 9, "steam_ids": [76561198063336407, 76561198193174134, 76561198310561479, 76561198355739212, 76561198998266210]}
+      ],
       "players": [
         {"steam_id": "76561198386265483", "hltv_name": "donk", "kills": 21, "deaths": 16, "adr": 108.9, "kast_percent": 81.8, "rating": 1.37},
         {"steam_id": "76561199063238565", "hltv_name": "magixx", "kills": 13, "deaths": 10, "adr": 65.0, "kast_percent": 68.2, "rating": 1.30},
@@ -82,6 +94,10 @@
       "game_mode": "competitive",
       "rounds": 23,
       "score_values": [10, 13],
+      "teams": [
+        {"name": "Spirit", "score": 10, "steam_ids": [76561198081484775, 76561198386265483, 76561198872013168, 76561198995880877, 76561199063238565]},
+        {"name": "MOUZ", "score": 13, "steam_ids": [76561198063336407, 76561198193174134, 76561198310561479, 76561198355739212, 76561198998266210]}
+      ],
       "players": [
         {"steam_id": "76561198081484775", "hltv_name": "sh1ro", "kills": 20, "deaths": 15, "adr": 80.9, "kast_percent": 82.6, "rating": 1.34},
         {"steam_id": "76561198386265483", "hltv_name": "donk", "kills": 13, "deaths": 18, "adr": 70.5, "kast_percent": 52.2, "rating": 1.00},

--- a/cmd/demo_parser/testdata/hltv-129241/expected.json
+++ b/cmd/demo_parser/testdata/hltv-129241/expected.json
@@ -13,6 +13,10 @@
       "game_mode": "competitive",
       "rounds": 22,
       "score_values": [9, 13],
+      "teams": [
+        {"name": "Rooster", "score": 9, "steam_ids": [76561198050779850, 76561198081702155, 76561198093162249, 76561198127259887, 76561198158971650]},
+        {"name": "Mindfreak", "score": 13, "steam_ids": [76561198044112269, 76561198108660703, 76561198208618504, 76561198226777692, 76561199048086137]}
+      ],
       "players": [
         {"steam_id": "76561198158971650", "hltv_name": "chelleos", "kills": 25, "deaths": 13, "adr": 114.0, "kast_percent": 77.3, "rating": 1.63},
         {"steam_id": "76561198050779850", "hltv_name": "rekonz", "kills": 12, "deaths": 15, "adr": 55.5, "kast_percent": 63.6, "rating": 0.70},
@@ -36,6 +40,10 @@
       "game_mode": "competitive",
       "rounds": 19,
       "score_values": [13, 6],
+      "teams": [
+        {"name": "Rooster", "score": 13, "steam_ids": [76561198050779850, 76561198081702155, 76561198093162249, 76561198127259887, 76561198158971650]},
+        {"name": "Mindfreak", "score": 6, "steam_ids": [76561198044112269, 76561198108660703, 76561198208618504, 76561198226777692, 76561199048086137]}
+      ],
       "players": [
         {"steam_id": "76561198158971650", "hltv_name": "chelleos", "kills": 21, "deaths": 8, "adr": 106.4, "kast_percent": 94.7, "rating": 1.87},
         {"steam_id": "76561198050779850", "hltv_name": "rekonz", "kills": 15, "deaths": 12, "adr": 91.2, "kast_percent": 89.5, "rating": 1.43},
@@ -59,6 +67,10 @@
       "game_mode": "competitive",
       "rounds": 23,
       "score_values": [10, 13],
+      "teams": [
+        {"name": "Rooster", "score": 10, "steam_ids": [76561198050779850, 76561198081702155, 76561198093162249, 76561198127259887, 76561198158971650]},
+        {"name": "Mindfreak", "score": 13, "steam_ids": [76561198044112269, 76561198108660703, 76561198208618504, 76561198226777692, 76561199048086137]}
+      ],
       "players": [
         {"steam_id": "76561198158971650", "hltv_name": "chelleos", "kills": 14, "deaths": 16, "adr": 59.2, "kast_percent": 69.6, "rating": 0.83},
         {"steam_id": "76561198050779850", "hltv_name": "rekonz", "kills": 22, "deaths": 17, "adr": 119.0, "kast_percent": 91.3, "rating": 1.58},

--- a/cmd/demo_parser/testdata/hltv-2396559/expected.json
+++ b/cmd/demo_parser/testdata/hltv-2396559/expected.json
@@ -13,6 +13,10 @@
       "game_mode": "competitive",
       "rounds": 23,
       "score_values": [10, 13],
+      "teams": [
+        {"name": "Team Spirit", "score": 10, "steam_ids": [76561198081484775, 76561198386265483, 76561198872013168, 76561198995880877, 76561199063238565]},
+        {"name": "JiJieHao", "score": 13, "steam_ids": [76561198110839613, 76561198165327895, 76561198263656468, 76561198422389693, 76561199024583803]}
+      ],
       "players": [
         {"steam_id": "76561198386265483", "hltv_name": "donk", "kills": 23, "deaths": 16, "adr": 93.2, "kast_percent": 69.6, "rating": 1.58},
         {"steam_id": "76561199063238565", "hltv_name": "magixx", "kills": 13, "deaths": 15, "adr": 71.5, "kast_percent": 78.3, "rating": 1.18},

--- a/cmd/demo_parser/types.go
+++ b/cmd/demo_parser/types.go
@@ -138,9 +138,13 @@ type RatingStats struct {
 }
 
 type DemoPlayer struct {
-	SteamID          uint64           `json:"steam_id"`
-	Name             string           `json:"name"`
-	UserID           int              `json:"user_id"`
+	SteamID uint64 `json:"steam_id"`
+	Name    string `json:"name"`
+	UserID  int    `json:"user_id"`
+	// TeamID references the logical team in ProcessedDemo.Teams the player
+	// participated for, or 0 for a player who never played an accepted
+	// scored round (and so belongs to no team).
+	TeamID           int              `json:"team_id"`
 	Deaths           int              `json:"deaths"`
 	DeathsTraded     SideCount        `json:"deaths_traded"`
 	KillStats        KillStats        `json:"kill_stats"`
@@ -159,8 +163,37 @@ type MapData struct {
 	RoundsWonT  int    `json:"rounds_won_t"`
 }
 
+// DemoTeam is one of the two logical teams of a map. CT and T are temporary
+// sides that swap at halftime and with every overtime half; a logical team
+// is the lineup that persists across those swaps. Identity comes from
+// eligible nonzero-SteamID64 rosters seeded at the first authoritative
+// scored round — never from sides, clan names, TeamState.ID(), user IDs,
+// entity IDs, filenames or map names. TeamID is map-local: team 1 played CT
+// in the seeding round, team 2 played T, and the IDs claim no organization
+// identity across demos (cross-map matching belongs to issue #34).
+type DemoTeam struct {
+	TeamID int `json:"team_id"`
+	// Name is the display alias: the nonempty clan name observed in the
+	// most accepted rounds, ties broken by first observation. It stays ""
+	// when the demo never showed one; a name is never invented.
+	Name string `json:"name"`
+	// Aliases are the deduplicated nonempty clan names observed while this
+	// team held a side, in first-observation order. Clan names are mutable
+	// labels: they corroborate a team but never define its identity, so
+	// duplicate names across the two teams do not merge them.
+	Aliases []string `json:"aliases"`
+	// Score is the team's accepted round wins. It reconciles with
+	// map_data's final CT/T scores without depending on the side the team
+	// finished the map on.
+	Score int `json:"score"`
+	// Roster is every eligible SteamID64 that played an accepted scored
+	// round for this team, substitutes included, sorted ascending.
+	Roster []uint64 `json:"roster"`
+}
+
 type ProcessedDemo struct {
 	Players  map[uint64]*DemoPlayer `json:"players"`
+	Teams    []DemoTeam             `json:"teams"`
 	Map      MapData                `json:"map_data"`
 	GameMode string                 `json:"game_mode"`
 }


### PR DESCRIPTION
Closes #28.

## What

Adds a `teams` collection to the saved analysis and a `team_id` reference on every player, so consumers can tell which lineup earned which rounds. CT and T are temporary sides that swap at halftime and with every overtime half; a logical team is the roster that persists across those swaps.

- Each team exports a deterministic map-local `team_id` (1 = CT side of the seeding round, 2 = T side), a display `name`, deduplicated clan-name `aliases` in first-observation order, its accepted round wins as `score`, and its sorted eligible SteamID64 `roster`.
- `map_data.rounds_won_ct`/`rounds_won_t` and the player CT/T side splits are unchanged; team scores reconcile with them without ever deriving a score from the side a team finished on.
- Serialization is deterministic: teams ordered by ID, rosters sorted, aliases in observation order.
- CSV stays byte-identical and player-only; CLI tables and single-demo behavior are unchanged.

## Identity rules

- Identity seeds once, from the first authoritative scored round with an eligible participant — the same pending/scored-round gate every round-derived stat uses — so warmup, pregame knife rounds, restarts and unscored setup rounds can never seed teams or scores. Eligible means a real competitor: nonzero SteamID64, not a bot, not a coach, not a spectator.
- Every later round's side rosters map back to the seeded teams through shared SteamIDs, the strongest evidence a demo offers. Clan names are mutable labels: they corroborate but never define identity; empty names stay unknown rather than inventing one, duplicate names do not merge teams, and renames accumulate as aliases with a deterministic display-name rule (most rounds observed, ties to the first observed).
- Substitutes join the uniquely matched team, reconnects cannot duplicate participation, and a fully replaced side still resolves by elimination through the other side.
- An ambiguous roster, or a SteamID that appears to play for both teams, fails the parse with an error carrying the competing evidence instead of guessing.
- Two timing shapes are handled explicitly: round roster evidence is the lineup when live play begins, so a halftime switch landing during freeze time cannot present a leaver on their stale pre-switch side; and team facts are resolved at parse end, so a decided setup round that restarted at the same score cannot seed the teams or consume the last real round's slot.

## Testing

- 20 new unit tests covering seeding, halftime/overtime stability, win attribution across swaps, substitutes, reconnects, warmup/knife/setup/bot/coach exclusion, empty/duplicate/changing clan names, ambiguity and dual-participation errors, and the freeze-time-leaver and decided-setup-restart shapes.
- JSON envelope tests updated for the new top-level `teams` field; CSV tests pin that no team data leaks into the flat export.
- All three golden fixtures regenerated from real parses; the diffs are pure insertions (`team_id` per player plus the `teams` block), with no drift in any other statistic.
- The HLTV external regression now pins logical teams for all eight audited maps: fixture teams are matched to parser output by exact roster (independent of map-local numbering), then display name, aliases, per-team score, and every player's `team_id` are asserted, and team scores are checked to reconcile with the final side scores. Rooster–Mindfreak resolves as Inferno 9–13, Anubis 13–6, Mirage 10–13 with both rosters intact across all side switches; the EWC fixture additionally pins that the same Spirit lineup is labeled `Team Spirit` there but `Spirit` on the BLAST server — labels, not identity.
- `go test ./...`, `go vet ./...`, `go build ./...` all pass; HLTV parity aggregates are unchanged (kills 30/30 + 50/50, deaths 30/30 + 50/50, ADR 30/30 + 43/50, KAST 29/30 + 49/50).

## Docs

`_docs/PLAYER_DATA.MD` gains a full "Logical teams" section (shape, identity evidence, alias semantics, ambiguity errors, ID scope), `_docs/HLTV_REGRESSION.md` documents the extended oracle contract, and the README's saved-file example includes the new field.

## Non-goals

Cross-map/series team matching, series-scoped team IDs, and history storage remain issue #34; `team_id` is meaningful only within one map's output, and series aggregation must match teams by roster, never by ID, name, or side.
