### PR TITLE
feat(series): aggregate completed BO3/BO5 series from repeated --demo with --best-of

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,17 @@ analyse [flags]
 
 #### Flags
 
-- `-d, --demo <path>`: Path to the CS2 demo file.
-- `-p, --players <players>`: A list of players to analyse. This should be provided as a comma-separated list of player names. Names match case-insensitively, and if any requested name is not in the demo the command fails and lists the available players.
+- `-d, --demo <path>`: Path to a CS2 demo file. Repeat the flag in played order to analyse a completed BO3/BO5 series together with `--best-of`.
+- `--best-of <n>`: Series format for multiple demos, `3` or `5`. A completed BO3 takes 2 or 3 demos, a completed BO5 takes 3, 4 or 5. Multiple demos always require this flag — the series format is never inferred from the file count — and one demo with it is invalid.
+- `-p, --players <players>`: A list of players to analyse. This should be provided as a comma-separated list of player names. Names match case-insensitively, and if any requested name is not in the demo the command fails and lists the available players. In a series, names match any alias the player used across the maps, and a name matching more than one SteamID fails with the candidate SteamIDs.
 - `-s, --save`: Flag to save the demo player's data.
 - `--save-type <type>`: Type of file to save the data. Options are `json` and `csv`. The default is `json`.
-- `--details`: Print the extra stat tables that do not fit the main one: the rating breakdown, approximate Rating 3.0 metrics, multi-kill rounds, trades, CT/T side splits, utility effectiveness and grenades thrown.
+- `--details`: Print the extra stat tables that do not fit the main one: the rating breakdown, approximate Rating 3.0 metrics, multi-kill rounds, trades, CT/T side splits, utility effectiveness and grenades thrown. For a series these show the aggregate values.
 
 #### Options
 
-- `d`: If -d not provided, the CLI will pop a window to select the file in our system.
-- `p`: If no players are provided, a multiselect option will show on terminal.
+- `d`: If -d not provided, the CLI will pop a window to select the file in our system. Series analysis never opens the picker: every map must be passed explicitly.
+- `p`: If no players are provided, a multiselect option will show on terminal. Series analysis skips the multiselect and analyses everyone unless `--players` is given.
 
 #### Examples
 
@@ -42,6 +43,16 @@ analyse --demo path/to/demo --players "player1,player2" --save --save-type csv
 ```
 
 This will analyse only "player1" and "player2" from the specified demo and save the data in CSV format.
+
+**Analyzing a Completed BO3/BO5 Series**
+
+```bash
+analyse --best-of 3 --demo map1.dem --demo map2.dem
+analyse --best-of 3 --demo map1.dem --demo map2.dem --demo map3.dem
+analyse --best-of 5 --demo map1.dem --demo map2.dem --demo map3.dem
+```
+
+The demos must be the series' played maps in order. The tool hashes each file (rejecting the same demo supplied twice), parses every map, resolves the two series teams by their rosters, and prints the ordered map results, the overall map and round score, the series winner and an aggregate player table. Only completed competitive 5v5 series are accepted: Wingman-sized maps are rejected, and the final demo must be the map on which a team clinched, so a 1-1 BO3 or a map supplied after the clinch is an error. With `--save` the JSON contains the full series envelope — see [PLAYER_DATA](./_docs/PLAYER_DATA.MD#series-analysis-bo3bo5) — while CSV stays the flat aggregate-player table with the exact single-map columns; full per-map series data requires JSON.
 
 #### Saved files
 

--- a/_docs/HLTV_REGRESSION.md
+++ b/_docs/HLTV_REGRESSION.md
@@ -85,6 +85,39 @@ extra/match-128974/nuke-234256
 extra/match-2396559/mirage-234956
 ```
 
+## Series regression
+
+`TestHLTVSeriesRegression` (issue #34) reuses the original Rooster–Mindfreak
+oracle as a BO3 series fixture: it hashes and parses the three demos in
+oracle order, aggregates them with `BuildSeries(3, …)`, and asserts against
+values derived from the audited per-map rows rather than numbers of its own.
+Production code contains no fixture names, rosters, scores, paths or hashes.
+
+The assertions cover:
+
+- `best_of` 3, three ordered maps whose `sha256` and parsed map names match
+  the oracle rows in order (Inferno, Anubis, Mirage).
+- The two series teams matched by exact roster — never by team numbering —
+  with oracle-derived map wins (Mindfreak 2, Rooster 1), round wins (32
+  each), display names, and the completed-series winner (Mindfreak, who
+  clinches on the final map).
+- Total series rounds (64) equal to the sum of the three maps' rounds.
+- Exactly the ten oracle SteamIDs as aggregate players, each matched across
+  all three maps with `maps_played` 3 and the full 64-round denominator.
+- Additive totals (kills, deaths, damage, headshots, assists) equal to the
+  sums of the three standalone map analyses, series ADR and classic KAST
+  recomputed from those exact numerators over 64 rounds, and a recomputed —
+  never omitted — series rating for every player.
+
+It runs under the same environment convention as the original fixture and
+skips when the demos are unconfigured:
+
+```sh
+HLTV_DEMO_DIR=/path/to/match-129241-demos \
+REQUIRE_HLTV_DEMOS=1 \
+  go test -count=1 -v ./cmd/demo_parser -run '^(TestHLTVRegression|TestHLTVSeriesRegression)$'
+```
+
 ## Comparison contract
 
 Each map requires exactly the ten oracle SteamIDs. Map name, game mode, round

--- a/_docs/PLAYER_DATA.MD
+++ b/_docs/PLAYER_DATA.MD
@@ -354,3 +354,79 @@ A round win is attributed to a logical team only when the authoritative scored-r
 `team_id` is scoped to one map: the numbering says only which lineup started the seeding round on which side of *this* demo. It makes no claim about organization identity across demos — the same organization can be team 1 on one map and team 2 on the next. Matching teams across the maps of a BO3/BO5 series is issue #34's job, deliberately not this field's.
 
 Players keep their existing CT/T side splits (`side_stats`), which remain attributed round by round and are unaffected by logical team identity. A player with `team_id` 0 exists in the demo's raw events but never played an accepted round (for example, someone only present during an unscored setup round).
+
+## Series analysis (BO3/BO5)
+
+`analyse --best-of 3|5` with repeated `--demo` flags aggregates a *completed* series. The format is always explicit: multiple demos without `--best-of` are rejected, a series is never inferred from the file count, and history never infers one either. The demos are the played maps in order, and that order is preserved everywhere — parsing, output, errors and JSON. Before parsing, every file is streamed through SHA-256; two inputs with the same digest are rejected as the same demo regardless of their paths.
+
+### Completed series only
+
+A BO3 accepts exactly 2 or 3 played maps and a BO5 exactly 3, 4 or 5. Each map must be decided: exactly two logical teams, untied per-team scores that add up to the map's rounds, and players referencing only those teams. Only the competitive 5v5 format is supported, enforced three ways: a map reporting any game mode other than `competitive`, `scrimcomp5v5`, `premier` or the unknown `""` is rejected outright (casual, deathmatch and Wingman's `scrimcomp2v2` all fail here, whatever their lobby size); every logical team must have fielded at least five eligible players, rejecting Wingman-sized lineups before identity resolution — substitutions only ever make a roster larger, so a competitive map with stand-ins always passes; and a map whose per-round participation exceeds what a 5v5 lobby can produce (ten players per round, with one spare for a freeze-time swap) is rejected, which catches oversized lobbies whose demos name no mode. The final supplied map must be the first point at which a team reaches the clinch threshold — 2 map wins in a BO3, 3 in a BO5. An unclinched series and a map supplied after the clinch are both errors; live or unfinished series are out of scope.
+
+### Series team identity
+
+`team_id` inside one map is map-local (see [Team ID scope](#team-id-scope)); the series introduces *series-local* team IDs 1 and 2, seeded deterministically from the first map's team order, that are scoped to this one series and claim nothing beyond it. Every map's `team_assignments` records the explicit bridge from its map-local IDs to the series IDs.
+
+The two series teams are resolved through a unique joint roster assignment. Each map after the first can keep the first map's orientation or cross it; all combinations (at most 2^4 for a BO5) are evaluated jointly — never greedily map by map — under one rule: the union rosters of the two series teams must stay disjoint. Exactly one surviving combination is success. Zero is a mixed/conflicting-team error, several is an ambiguity error; both are structured, `errors.As`-testable values carrying the map indexes, map-local team IDs, rosters and competing assignments. The joint evaluation is what lets a middle map played entirely by substitutes resolve through a later map that ties those substitutes back to a lineup.
+
+Substitutions are roster additions to the same series team, never a new team. Sides, map-local IDs, filenames, map names, scores, player names and clan names are never identity; clan names may corroborate a label but never resolve an otherwise ambiguous assignment. Series team `aliases` are the deduplicated map-level aliases in first map-observation order, and `name` is the most-observed nonempty map-level name, ties broken by first observation.
+
+### Series JSON
+
+`--save` writes the series envelope (CSV behaves differently, see below):
+
+```json
+{
+  "best_of": 3,
+  "winner_team_id": 2,
+  "teams": [
+    {
+      "team_id": 1,
+      "name": "Rooster",
+      "aliases": ["Rooster"],
+      "maps_won": 1,
+      "rounds_won": 32,
+      "roster": [76561198000000000]
+    }
+  ],
+  "players": {
+    "<steam-id>": { "...": "aggregate player, see below" }
+  },
+  "maps": [
+    {
+      "sha256": "...",
+      "winner_team_id": 2,
+      "team_assignments": [
+        { "map_team_id": 1, "series_team_id": 2 },
+        { "map_team_id": 2, "series_team_id": 1 }
+      ],
+      "analysis": { "...": "the unchanged standalone map record" }
+    }
+  ]
+}
+```
+
+`maps` keeps the supplied order; each entry carries the demo's SHA-256, the map winner translated into series-team terms, the map-local-to-series-team assignments, and the complete standalone analysis with the exact single-map shape documented above. `winner_team_id` at the top level is the completed-series winner, and each team's `maps_won`/`rounds_won` are its map wins and summed logical round wins.
+
+### Aggregate players
+
+`players` is keyed by SteamID64, the only cross-map player identity — names are labels. Each entry is a series-specific record: it deliberately has no `user_id`, because server user IDs are map-local and meaningless across demos. `aliases` collects the player's deduplicated nonempty per-map display names in map order, and `name` picks the most-observed one, first observation breaking ties — the same rule team names use.
+
+Additive facts (kills, deaths, headshots, assists, flash assists, damage, trades, team kills, weapon kills, MVPs, aces, multi-kill buckets, clutches, opening kills/deaths, CT/T count splits, utility counters, flash duration, unused utility value) are exact sums of the per-map values. Every rate is recomputed from exact summed numerators and denominators preserved by the parser — never by combining or averaging the rounded per-map rates:
+
+- `maps_played` counts the maps where the SteamID participated for a logical team, and `rounds` sums those maps' total rounds. All ten players of a three-map series with 22+19+23 rounds therefore have a 64-round denominator.
+- Match-wide ADR, classic KAST, the approximate eKAST and round-swing percentages divide by `rounds`, mirroring how a single map divides by the whole map's rounds; the per-map late-join dilution inside each map is unchanged.
+- CT/T ADR and KAST divide by the player's own summed CT/T rounds; precision, opening success and average enemy flash duration divide their exact summed numerators by their summed counts.
+- `player_map_stats` is named `player_series_stats` in the aggregate record; its fields have the same meaning over the series denominator.
+
+### Series rating
+
+The series `rating` is not an average of map ratings. The parser preserves each map's exact raw rating facts — eco-adjusted kill points and damage, eco-weighted survival and rating-KAST credits, signed round swing, multi-kill buckets — and the rating model runs once over their sums with the player's series round denominator. If a map was not produced by this parser and carries no raw facts (only possible for programmatically constructed inputs, never for `analyse`), the rating is explicitly `null` rather than reconstructed from rounded output.
+
+### Player selection in a series
+
+`--players` is resolved only after cross-map identity and alias collection: names match any collected alias case-insensitively, duplicates count once, a name with no match fails listing the available players, and a name matching more than one SteamID fails with the candidate SteamIDs. Selection never affects team resolution or the aggregate calculations — a filtered save narrows `players` and each map's `analysis.players`, while teams, rosters, scores, map results and team assignments remain complete.
+
+### Series CSV
+
+CSV stays the flat aggregate-player table with the existing single-map header, column order and formatting — no series, team, hash or map columns. The one series-specific cell rule: a player whose series rating was [omitted](#series-rating) has empty cells in the seven rating columns, never a fabricated `0.00`; the CLI tables render the same omission as `-`. Full per-map series data requires JSON.

--- a/cmd/analyse.go
+++ b/cmd/analyse.go
@@ -14,17 +14,21 @@ import (
 	printstyle "github.com/taua-almeida/cs2-analyser-tool/cmd/ui/print-style"
 )
 
-var players []string // players is the list of players to analyse.
-var demoPath string  // demoPath is the path to the demo file.
-var save bool        // save is the flag to save the demo players data.
-var saveType string  // saveType is the type of storage to use.
-var details bool     // details prints the stats that do not fit the main table.
+var players []string   // players is the list of players to analyse.
+var demoPaths []string // demoPaths are the demo files, in played order for a series.
+var bestOf int         // bestOf is the series format: 0 for a single demo, else 3 or 5.
+var save bool          // save is the flag to save the demo players data.
+var saveType string    // saveType is the type of storage to use.
+var details bool       // details prints the stats that do not fit the main table.
 
 func init() {
 	// Add the analyse command as a subcommand of rootCmd.
 	rootCmd.AddCommand(analyseCmd)
 
-	analyseCmd.Flags().StringVarP(&demoPath, "demo", "d", "", "Demo path.")
+	// StringArray rather than StringSlice: repeated --demo flags keep their
+	// command-line order and a path containing a comma stays one path.
+	analyseCmd.Flags().StringArrayVarP(&demoPaths, "demo", "d", nil, "Demo path. Repeat in played order for a --best-of series.")
+	analyseCmd.Flags().IntVar(&bestOf, "best-of", 0, "Series format for multiple demos: 3 or 5.")
 	analyseCmd.Flags().StringSliceVarP(&players, "players", "p", []string{}, "Players to analyse.")
 	analyseCmd.Flags().BoolVarP(&save, "save", "s", false, "Save the demo players data.")
 	analyseCmd.Flags().StringVar(&saveType, "save-type", "json", "Type of file to save the data [json, csv], default is json.")
@@ -40,7 +44,18 @@ var analyseCmd = &cobra.Command{
 		if saveType != "json" && saveType != "csv" {
 			return fmt.Errorf("invalid --save-type %q, must be json or csv", saveType)
 		}
+		bestOfSet := cmd.Flags().Changed("best-of")
+		if err := validateSeriesFlags(bestOf, bestOfSet, len(demoPaths)); err != nil {
+			return err
+		}
+		if bestOfSet {
+			return runSeriesAnalysis(bestOf, demoPaths)
+		}
 
+		demoPath := ""
+		if len(demoPaths) == 1 {
+			demoPath = demoPaths[0]
+		}
 		if demoPath == "" {
 			selected, err := filepicker.PickDemoFile()
 			if err != nil {
@@ -97,14 +112,11 @@ var analyseCmd = &cobra.Command{
 		}
 
 		if save {
-			lipgloss.Println(printstyle.StyleSuccess.Render("\nWritting data to file..."))
 			analysisToSave := *processedDemoData
 			analysisToSave.Players = playersToAnalyse
-			fileName, err := dataexport.WriteAnalysisToFile(&analysisToSave, saveType)
-			if err != nil {
-				return fmt.Errorf("writing to file: %w", err)
-			}
-			lipgloss.Println(printstyle.StyleSuccess.Render("Data written to file: " + fileName))
+			return saveAndReport(func() (string, error) {
+				return dataexport.WriteAnalysisToFile(&analysisToSave, saveType)
+			})
 		}
 		return nil
 	},

--- a/cmd/analyse_series.go
+++ b/cmd/analyse_series.go
@@ -1,0 +1,146 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"charm.land/lipgloss/v2"
+	dataexport "github.com/taua-almeida/cs2-analyser-tool/cmd/dataexport"
+	demoparser "github.com/taua-almeida/cs2-analyser-tool/cmd/demo_parser"
+	printstyle "github.com/taua-almeida/cs2-analyser-tool/cmd/ui/print-style"
+)
+
+// validateSeriesFlags rejects invalid --best-of/--demo combinations before
+// any file is opened or parsed. bestOfSet is whether the user supplied the
+// flag at all: only an unset flag keeps the existing single-demo flow (one
+// path, or none for the picker), so an explicit --best-of 0 is rejected like
+// any other value outside 3 and 5 instead of silently reading as absent. A
+// series is never inferred from the file count; with the flag set,
+// demoparser owns the format rule and this only rewords it in flag terms.
+func validateSeriesFlags(bestOf int, bestOfSet bool, demoCount int) error {
+	if !bestOfSet {
+		if demoCount > 1 {
+			return fmt.Errorf("%d --demo values need an explicit series format: add --best-of 3 or --best-of 5", demoCount)
+		}
+		return nil
+	}
+	minDemos, maxDemos, err := demoparser.SeriesMapCountRange(bestOf)
+	if err != nil {
+		return fmt.Errorf("invalid --best-of %d, must be 3 or 5", bestOf)
+	}
+	if demoCount < minDemos || demoCount > maxDemos {
+		counts := "2 or 3"
+		if bestOf == 5 {
+			counts = "3, 4 or 5"
+		}
+		return fmt.Errorf("--best-of %d takes %s --demo values in played order, got %d", bestOf, counts, demoCount)
+	}
+	return nil
+}
+
+// hashDemoFiles streams every demo through SHA-256 — never loading a demo
+// into memory — and rejects duplicate content before anything is parsed, so
+// the same map supplied under two paths fails fast.
+func hashDemoFiles(paths []string) ([]string, error) {
+	digests := make([]string, len(paths))
+	seen := make(map[string]int, len(paths))
+	for i, path := range paths {
+		digest, err := hashDemoFile(path)
+		if err != nil {
+			return nil, err
+		}
+		if first, duplicate := seen[digest]; duplicate {
+			return nil, fmt.Errorf("--demo %s repeats the content of %s (SHA-256 %s)", path, paths[first], digest)
+		}
+		seen[digest] = i
+		digests[i] = digest
+	}
+	return digests, nil
+}
+
+func hashDemoFile(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("opening demo file: %w", err)
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", fmt.Errorf("hashing %s: %w", path, err)
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+// runSeriesAnalysis is the multi-demo path: hash, parse in command-line
+// order, build the series, resolve the player selection against cross-map
+// identity, then render and optionally save. It never opens the demo file
+// picker or the interactive player selector; without --players every player
+// is analysed.
+func runSeriesAnalysis(bestOf int, paths []string) error {
+	digests, err := hashDemoFiles(paths)
+	if err != nil {
+		return err
+	}
+
+	lipgloss.Println(printstyle.StyleInfo.Render("Processing CS2 series, hang tight... \n"))
+	startTime := time.Now()
+	inputs := make([]demoparser.SeriesMapInput, len(paths))
+	for i, path := range paths {
+		fmt.Printf("Parsing map %d/%d: %s\n", i+1, len(paths), path)
+		demo, err := demoparser.ProcessDemo(path)
+		if err != nil {
+			return err
+		}
+		inputs[i] = demoparser.SeriesMapInput{Demo: demo, SHA256: digests[i]}
+	}
+
+	series, err := demoparser.BuildSeries(bestOf, inputs)
+	if err != nil {
+		return err
+	}
+	lipgloss.Println(printstyle.StyleSuccess.Render("\n\nProcessing is done! \n"))
+	fmt.Printf("Time taken for the series: %s\n\n", time.Since(startTime))
+
+	// Selection narrows only what is shown and saved; the series teams,
+	// scores and aggregates above were already resolved from everyone.
+	var selected map[uint64]bool
+	if len(players) > 0 {
+		selected, err = demoparser.SelectSeriesPlayers(series, players)
+		if err != nil {
+			return err
+		}
+	}
+
+	dataexport.PrintSeriesCLITables(series, selected)
+	if details {
+		dataexport.PrintSeriesDetailTables(series, selected)
+	}
+
+	if save {
+		seriesToSave := series
+		if selected != nil {
+			seriesToSave = demoparser.FilterSeriesPlayers(series, selected)
+		}
+		return saveAndReport(func() (string, error) {
+			return dataexport.WriteSeriesToFile(seriesToSave, saveType)
+		})
+	}
+	return nil
+}
+
+// saveAndReport wraps a save-file writer with the shared status output the
+// single-demo and series paths both print.
+func saveAndReport(write func() (string, error)) error {
+	lipgloss.Println(printstyle.StyleSuccess.Render("\nWritting data to file..."))
+	fileName, err := write()
+	if err != nil {
+		return fmt.Errorf("writing to file: %w", err)
+	}
+	lipgloss.Println(printstyle.StyleSuccess.Render("Data written to file: " + fileName))
+	return nil
+}

--- a/cmd/analyse_test.go
+++ b/cmd/analyse_test.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// TestValidateSeriesFlags pins the flag contract: the single-demo flows stay
+// valid only while --best-of is genuinely unset, an explicitly supplied
+// value outside 3 and 5 is always rejected (zero included), several demos
+// never infer a series, and --best-of only accepts completed-series map
+// counts. All of this fails before any demo is opened or parsed.
+func TestValidateSeriesFlags(t *testing.T) {
+	tests := []struct {
+		name      string
+		bestOf    int
+		bestOfSet bool
+		demoCount int
+		wantErr   string
+	}{
+		{name: "picker flow", bestOf: 0, demoCount: 0},
+		{name: "single demo", bestOf: 0, demoCount: 1},
+		{name: "multi demo without best-of", bestOf: 0, demoCount: 2, wantErr: "need an explicit series format"},
+		{name: "explicit best-of 0 without demos", bestOf: 0, bestOfSet: true, demoCount: 0, wantErr: "invalid --best-of 0"},
+		{name: "explicit best-of 0 with one demo", bestOf: 0, bestOfSet: true, demoCount: 1, wantErr: "invalid --best-of 0"},
+		{name: "best-of 4", bestOf: 4, bestOfSet: true, demoCount: 3, wantErr: "invalid --best-of 4"},
+		{name: "bo3 no demos", bestOf: 3, bestOfSet: true, demoCount: 0, wantErr: "2 or 3 --demo values"},
+		{name: "bo3 one demo", bestOf: 3, bestOfSet: true, demoCount: 1, wantErr: "2 or 3 --demo values"},
+		{name: "bo3 two demos", bestOf: 3, bestOfSet: true, demoCount: 2},
+		{name: "bo3 three demos", bestOf: 3, bestOfSet: true, demoCount: 3},
+		{name: "bo3 four demos", bestOf: 3, bestOfSet: true, demoCount: 4, wantErr: "2 or 3 --demo values"},
+		{name: "bo5 two demos", bestOf: 5, bestOfSet: true, demoCount: 2, wantErr: "3, 4 or 5 --demo values"},
+		{name: "bo5 three demos", bestOf: 5, bestOfSet: true, demoCount: 3},
+		{name: "bo5 five demos", bestOf: 5, bestOfSet: true, demoCount: 5},
+		{name: "bo5 six demos", bestOf: 5, bestOfSet: true, demoCount: 6, wantErr: "3, 4 or 5 --demo values"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateSeriesFlags(test.bestOf, test.bestOfSet, test.demoCount)
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateSeriesFlags(%d, %t, %d) = %v, want nil", test.bestOf, test.bestOfSet, test.demoCount, err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("validateSeriesFlags(%d, %t, %d) = %v, want it to contain %q",
+					test.bestOf, test.bestOfSet, test.demoCount, err, test.wantErr)
+			}
+		})
+	}
+}
+
+// TestRepeatedDemoFlagPreservesOrder parses the real analyse flag set:
+// repeated --demo values must keep their command-line order, and a path
+// containing a comma must stay one path (a StringSlice would split it).
+func TestRepeatedDemoFlagPreservesOrder(t *testing.T) {
+	t.Cleanup(func() { demoPaths = nil })
+	args := []string{"--demo", "second/map2.dem", "-d", "first/map1.dem", "--demo", "dir,with,commas/map3.dem"}
+	if err := analyseCmd.ParseFlags(args); err != nil {
+		t.Fatalf("parsing flags: %v", err)
+	}
+	want := []string{"second/map2.dem", "first/map1.dem", "dir,with,commas/map3.dem"}
+	if !slices.Equal(demoPaths, want) {
+		t.Fatalf("demoPaths = %q, want the command-line order %q", demoPaths, want)
+	}
+}
+
+func TestHashDemoFilesRejectsDuplicateContent(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "map1.dem")
+	second := filepath.Join(dir, "renamed-copy.dem")
+	for _, path := range []string{first, second} {
+		if err := os.WriteFile(path, []byte("identical demo bytes"), 0o644); err != nil {
+			t.Fatalf("writing fixture: %v", err)
+		}
+	}
+	_, err := hashDemoFiles([]string{first, second})
+	if err == nil || !strings.Contains(err.Error(), "repeats the content") {
+		t.Fatalf("hashDemoFiles error = %v, want duplicate-content rejection", err)
+	}
+	if !strings.Contains(err.Error(), first) || !strings.Contains(err.Error(), second) {
+		t.Errorf("duplicate error %q does not name both paths", err)
+	}
+}
+
+func TestHashDemoFilesStreamsExactDigests(t *testing.T) {
+	dir := t.TempDir()
+	contents := []string{"map one bytes", "map two bytes"}
+	paths := make([]string, len(contents))
+	for i, content := range contents {
+		paths[i] = filepath.Join(dir, strings.ReplaceAll(content, " ", "-"))
+		if err := os.WriteFile(paths[i], []byte(content), 0o644); err != nil {
+			t.Fatalf("writing fixture: %v", err)
+		}
+	}
+	digests, err := hashDemoFiles(paths)
+	if err != nil {
+		t.Fatalf("hashDemoFiles: %v", err)
+	}
+	for i, content := range contents {
+		sum := sha256.Sum256([]byte(content))
+		if want := hex.EncodeToString(sum[:]); digests[i] != want {
+			t.Errorf("digest[%d] = %s, want %s", i, digests[i], want)
+		}
+	}
+}

--- a/cmd/dataexport/analysis_export_test.go
+++ b/cmd/dataexport/analysis_export_test.go
@@ -46,18 +46,27 @@ func selectedAnalysis() *demoparser.ProcessedDemo {
 	return analysis
 }
 
-func writeAndRead(t *testing.T, analysis *demoparser.ProcessedDemo, saveType string) []byte {
+// writeToTempAndRead runs a save-file writer inside a fresh temp working
+// directory and returns the produced file's bytes.
+func writeToTempAndRead(t *testing.T, write func() (string, error)) []byte {
 	t.Helper()
 	t.Chdir(t.TempDir())
-	fileName, err := WriteAnalysisToFile(analysis, saveType)
+	fileName, err := write()
 	if err != nil {
-		t.Fatalf("writing %s: %v", saveType, err)
+		t.Fatalf("writing: %v", err)
 	}
 	data, err := os.ReadFile(fileName)
 	if err != nil {
-		t.Fatalf("reading %s: %v", saveType, err)
+		t.Fatalf("reading %s: %v", fileName, err)
 	}
 	return data
+}
+
+func writeAndRead(t *testing.T, analysis *demoparser.ProcessedDemo, saveType string) []byte {
+	t.Helper()
+	return writeToTempAndRead(t, func() (string, error) {
+		return WriteAnalysisToFile(analysis, saveType)
+	})
 }
 
 // TestJSONEnvelopeTopLevelShape pins the saved document contract: exactly

--- a/cmd/dataexport/player_export.go
+++ b/cmd/dataexport/player_export.go
@@ -22,81 +22,8 @@ func WriteAnalysisToFile(analysis *demoparser.ProcessedDemo, saveType string) (s
 		}
 		defer csvFile.Close()
 
-		// New columns are appended after all existing ones so legacy column
-		// positions stay stable. "Rating KAST" and "Rating Round Swing" keep
-		// their headers for the same reason: they remain the normalized
-		// sub-ratings, while the two appended "Approx." columns carry the
-		// pre-normalization percentages.
-		csvRecords := [][]string{
-			{"Name", "Kills", "Deaths", "K/D", "HS", "Assists", "Flash Assists", "Damage Given", "ADR", "KAST (%)", "Precision (%)", "Trade Kills", "Deaths Traded", "Opening Kills", "Opening Deaths", "Opening Success (%)", "MVPs", "ACEs", "2K", "3K", "4K", "5K", "Clutches Won", "Rounds CT", "Rounds T", "Kills CT", "Kills T", "Deaths CT", "Deaths T", "Deaths Traded CT", "Deaths Traded T", "ADR CT", "ADR T", "KAST CT (%)", "KAST T (%)", "Best Weapon", "Enemies Flashed", "Friends Flashed", "Enemy Flash Time (s)", "Average Enemy Flash Time (s)", "Utility Damage Total", "HE Utility Damage", "Fire Utility Damage", "Grenades Thrown Total", "Flashbangs Thrown", "Smokes Thrown", "HE Grenades Thrown", "Molotovs Thrown", "Incendiaries Thrown", "Decoys Thrown", "Unused Utility Value", "Rating", "Rating Kills", "Rating Damage", "Rating Survival", "Rating KAST", "Rating Multi-kill", "Rating Round Swing", "Approx. eKAST (%)", "Approx. swing (%)"},
-		}
-		for _, player := range sortedByKills(analysis.Players) {
-			csvRecords = append(csvRecords, []string{
-				player.Name,
-				fmt.Sprintf("%d", player.KillStats.Total),
-				fmt.Sprintf("%d", player.Deaths),
-				kdRatio(player.KillStats.Total, player.Deaths),
-				fmt.Sprintf("%d", player.KillStats.HeadShots),
-				fmt.Sprintf("%d", player.AssistStats.Total),
-				fmt.Sprintf("%d", player.AssistStats.FlashedEnemies),
-				fmt.Sprintf("%d", player.AssistStats.DamageGiven),
-				fmt.Sprintf("%.1f", player.AssistStats.ADR),
-				fmt.Sprintf("%.1f", player.PlayerMapStats.KAST),
-				fmt.Sprintf("%.1f", player.KillStats.Precision*100),
-				fmt.Sprintf("%d", player.KillStats.TradeKills),
-				fmt.Sprintf("%d", player.DeathsTraded.Total),
-				fmt.Sprintf("%d", player.OpeningDuelStats.OpeningKills.Total),
-				fmt.Sprintf("%d", player.OpeningDuelStats.OpeningDeaths.Total),
-				fmt.Sprintf("%.1f", player.OpeningDuelStats.OpeningSuccessRate),
-				fmt.Sprintf("%d", player.PlayerMapStats.MVPs),
-				fmt.Sprintf("%d", player.PlayerMapStats.ACEs),
-				fmt.Sprintf("%d", player.PlayerMapStats.MultiKills.K2),
-				fmt.Sprintf("%d", player.PlayerMapStats.MultiKills.K3),
-				fmt.Sprintf("%d", player.PlayerMapStats.MultiKills.K4),
-				fmt.Sprintf("%d", player.PlayerMapStats.MultiKills.K5),
-				fmt.Sprintf("%d", player.PlayerMapStats.ClutchesWon),
-				fmt.Sprintf("%d", player.SideStats.Rounds.CT),
-				fmt.Sprintf("%d", player.SideStats.Rounds.T),
-				fmt.Sprintf("%d", player.SideStats.Kills.CT),
-				fmt.Sprintf("%d", player.SideStats.Kills.T),
-				fmt.Sprintf("%d", player.SideStats.Deaths.CT),
-				fmt.Sprintf("%d", player.SideStats.Deaths.T),
-				fmt.Sprintf("%d", player.DeathsTraded.CT),
-				fmt.Sprintf("%d", player.DeathsTraded.T),
-				fmt.Sprintf("%.1f", player.SideStats.ADR.CT),
-				fmt.Sprintf("%.1f", player.SideStats.ADR.T),
-				fmt.Sprintf("%.1f", player.SideStats.KAST.CT),
-				fmt.Sprintf("%.1f", player.SideStats.KAST.T),
-				demoparser.GetPlayerBestWeapon(player.KillStats.WeaponsKills),
-				fmt.Sprintf("%d", player.UtilityStats.EnemiesFlashed),
-				fmt.Sprintf("%d", player.UtilityStats.FriendsFlashed),
-				fmt.Sprintf("%.1f", player.UtilityStats.EnemyFlashTimeSeconds),
-				fmt.Sprintf("%.1f", player.UtilityStats.AverageEnemyFlashTimeSeconds),
-				fmt.Sprintf("%d", player.UtilityStats.UtilityDamage.Total),
-				fmt.Sprintf("%d", player.UtilityStats.UtilityDamage.HE),
-				fmt.Sprintf("%d", player.UtilityStats.UtilityDamage.Fire),
-				fmt.Sprintf("%d", player.UtilityStats.GrenadesThrown.Total),
-				fmt.Sprintf("%d", player.UtilityStats.GrenadesThrown.Flash),
-				fmt.Sprintf("%d", player.UtilityStats.GrenadesThrown.Smoke),
-				fmt.Sprintf("%d", player.UtilityStats.GrenadesThrown.HE),
-				fmt.Sprintf("%d", player.UtilityStats.GrenadesThrown.Molotov),
-				fmt.Sprintf("%d", player.UtilityStats.GrenadesThrown.Incendiary),
-				fmt.Sprintf("%d", player.UtilityStats.GrenadesThrown.Decoy),
-				fmt.Sprintf("%d", player.UtilityStats.UnusedUtilityValue),
-				fmt.Sprintf("%.2f", player.Rating.Value),
-				fmt.Sprintf("%.2f", player.Rating.Kills),
-				fmt.Sprintf("%.2f", player.Rating.Damage),
-				fmt.Sprintf("%.2f", player.Rating.Survival),
-				fmt.Sprintf("%.2f", player.Rating.KAST),
-				fmt.Sprintf("%.2f", player.Rating.MultiKill),
-				fmt.Sprintf("%.2f", player.Rating.RoundSwing),
-				fmt.Sprintf("%.1f", player.PlayerMapStats.ApproxEKASTPercent),
-				fmt.Sprintf("%.1f", player.PlayerMapStats.ApproxRoundSwingPercent),
-			})
-		}
-
 		w := csv.NewWriter(csvFile)
-		if err := w.WriteAll(csvRecords); err != nil {
+		if err := w.WriteAll(playerCSVRecords(analysis.Players)); err != nil {
 			return "", err
 		}
 		return fileName, nil
@@ -113,4 +40,111 @@ func WriteAnalysisToFile(analysis *demoparser.ProcessedDemo, saveType string) (s
 	}
 
 	return fileName, nil
+}
+
+// playerCSVHeader is the flat CSV's single header row. New columns are
+// appended after all existing ones so legacy column positions stay stable.
+// "Rating KAST" and "Rating Round Swing" keep their headers for the same
+// reason: they remain the normalized sub-ratings, while the two appended
+// "Approx." columns carry the pre-normalization percentages.
+func playerCSVHeader() []string {
+	return []string{"Name", "Kills", "Deaths", "K/D", "HS", "Assists", "Flash Assists", "Damage Given", "ADR", "KAST (%)", "Precision (%)", "Trade Kills", "Deaths Traded", "Opening Kills", "Opening Deaths", "Opening Success (%)", "MVPs", "ACEs", "2K", "3K", "4K", "5K", "Clutches Won", "Rounds CT", "Rounds T", "Kills CT", "Kills T", "Deaths CT", "Deaths T", "Deaths Traded CT", "Deaths Traded T", "ADR CT", "ADR T", "KAST CT (%)", "KAST T (%)", "Best Weapon", "Enemies Flashed", "Friends Flashed", "Enemy Flash Time (s)", "Average Enemy Flash Time (s)", "Utility Damage Total", "HE Utility Damage", "Fire Utility Damage", "Grenades Thrown Total", "Flashbangs Thrown", "Smokes Thrown", "HE Grenades Thrown", "Molotovs Thrown", "Incendiaries Thrown", "Decoys Thrown", "Unused Utility Value", "Rating", "Rating Kills", "Rating Damage", "Rating Survival", "Rating KAST", "Rating Multi-kill", "Rating Round Swing", "Approx. eKAST (%)", "Approx. swing (%)"}
+}
+
+// ratingCSVColumns is how many rating columns the flat CSV carries — the
+// cells ratingCSVCells formats, in the header's order.
+const ratingCSVColumns = 7
+
+// ratingCSVCells formats the seven rating columns.
+func ratingCSVCells(rating demoparser.RatingStats) []string {
+	return []string{
+		fmt.Sprintf("%.2f", rating.Value),
+		fmt.Sprintf("%.2f", rating.Kills),
+		fmt.Sprintf("%.2f", rating.Damage),
+		fmt.Sprintf("%.2f", rating.Survival),
+		fmt.Sprintf("%.2f", rating.KAST),
+		fmt.Sprintf("%.2f", rating.MultiKill),
+		fmt.Sprintf("%.2f", rating.RoundSwing),
+	}
+}
+
+// omittedRatingCSVCells keeps the seven rating columns empty for a player
+// whose rating was not computed, so an absent rating never prints as a real
+// 0.00 one.
+func omittedRatingCSVCells() []string {
+	return make([]string, ratingCSVColumns)
+}
+
+// playerCSVRecords builds the flat player-only CSV: header plus one row per
+// player, most kills first.
+func playerCSVRecords(players map[uint64]*demoparser.DemoPlayer) [][]string {
+	csvRecords := [][]string{playerCSVHeader()}
+	for _, player := range sortedByKills(players) {
+		csvRecords = append(csvRecords, playerCSVRow(player, ratingCSVCells(player.Rating)))
+	}
+	return csvRecords
+}
+
+// playerCSVRow formats one player row. The rating cells are injected so a
+// series save can blank them for an omitted rating; everything else keeps
+// the existing single-map formatting.
+func playerCSVRow(player *demoparser.DemoPlayer, ratingCells []string) []string {
+	row := []string{
+		player.Name,
+		fmt.Sprintf("%d", player.KillStats.Total),
+		fmt.Sprintf("%d", player.Deaths),
+		kdRatio(player.KillStats.Total, player.Deaths),
+		fmt.Sprintf("%d", player.KillStats.HeadShots),
+		fmt.Sprintf("%d", player.AssistStats.Total),
+		fmt.Sprintf("%d", player.AssistStats.FlashedEnemies),
+		fmt.Sprintf("%d", player.AssistStats.DamageGiven),
+		fmt.Sprintf("%.1f", player.AssistStats.ADR),
+		fmt.Sprintf("%.1f", player.PlayerMapStats.KAST),
+		fmt.Sprintf("%.1f", player.KillStats.Precision*100),
+		fmt.Sprintf("%d", player.KillStats.TradeKills),
+		fmt.Sprintf("%d", player.DeathsTraded.Total),
+		fmt.Sprintf("%d", player.OpeningDuelStats.OpeningKills.Total),
+		fmt.Sprintf("%d", player.OpeningDuelStats.OpeningDeaths.Total),
+		fmt.Sprintf("%.1f", player.OpeningDuelStats.OpeningSuccessRate),
+		fmt.Sprintf("%d", player.PlayerMapStats.MVPs),
+		fmt.Sprintf("%d", player.PlayerMapStats.ACEs),
+		fmt.Sprintf("%d", player.PlayerMapStats.MultiKills.K2),
+		fmt.Sprintf("%d", player.PlayerMapStats.MultiKills.K3),
+		fmt.Sprintf("%d", player.PlayerMapStats.MultiKills.K4),
+		fmt.Sprintf("%d", player.PlayerMapStats.MultiKills.K5),
+		fmt.Sprintf("%d", player.PlayerMapStats.ClutchesWon),
+		fmt.Sprintf("%d", player.SideStats.Rounds.CT),
+		fmt.Sprintf("%d", player.SideStats.Rounds.T),
+		fmt.Sprintf("%d", player.SideStats.Kills.CT),
+		fmt.Sprintf("%d", player.SideStats.Kills.T),
+		fmt.Sprintf("%d", player.SideStats.Deaths.CT),
+		fmt.Sprintf("%d", player.SideStats.Deaths.T),
+		fmt.Sprintf("%d", player.DeathsTraded.CT),
+		fmt.Sprintf("%d", player.DeathsTraded.T),
+		fmt.Sprintf("%.1f", player.SideStats.ADR.CT),
+		fmt.Sprintf("%.1f", player.SideStats.ADR.T),
+		fmt.Sprintf("%.1f", player.SideStats.KAST.CT),
+		fmt.Sprintf("%.1f", player.SideStats.KAST.T),
+		demoparser.GetPlayerBestWeapon(player.KillStats.WeaponsKills),
+		fmt.Sprintf("%d", player.UtilityStats.EnemiesFlashed),
+		fmt.Sprintf("%d", player.UtilityStats.FriendsFlashed),
+		fmt.Sprintf("%.1f", player.UtilityStats.EnemyFlashTimeSeconds),
+		fmt.Sprintf("%.1f", player.UtilityStats.AverageEnemyFlashTimeSeconds),
+		fmt.Sprintf("%d", player.UtilityStats.UtilityDamage.Total),
+		fmt.Sprintf("%d", player.UtilityStats.UtilityDamage.HE),
+		fmt.Sprintf("%d", player.UtilityStats.UtilityDamage.Fire),
+		fmt.Sprintf("%d", player.UtilityStats.GrenadesThrown.Total),
+		fmt.Sprintf("%d", player.UtilityStats.GrenadesThrown.Flash),
+		fmt.Sprintf("%d", player.UtilityStats.GrenadesThrown.Smoke),
+		fmt.Sprintf("%d", player.UtilityStats.GrenadesThrown.HE),
+		fmt.Sprintf("%d", player.UtilityStats.GrenadesThrown.Molotov),
+		fmt.Sprintf("%d", player.UtilityStats.GrenadesThrown.Incendiary),
+		fmt.Sprintf("%d", player.UtilityStats.GrenadesThrown.Decoy),
+		fmt.Sprintf("%d", player.UtilityStats.UnusedUtilityValue),
+	}
+	row = append(row, ratingCells...)
+	return append(row,
+		fmt.Sprintf("%.1f", player.PlayerMapStats.ApproxEKASTPercent),
+		fmt.Sprintf("%.1f", player.PlayerMapStats.ApproxRoundSwingPercent),
+	)
 }

--- a/cmd/dataexport/series_export.go
+++ b/cmd/dataexport/series_export.go
@@ -1,0 +1,245 @@
+package dataexport
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"os"
+	"slices"
+	"time"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	demoparser "github.com/taua-almeida/cs2-analyser-tool/cmd/demo_parser"
+)
+
+// seriesTeamLabels labels the two series teams for tables, keyed by series
+// team ID. A team the demos never named falls back to its series-local ID.
+// Collisions are detected on the final label strings, after that fallback:
+// two teams can share a clan name — the parser permits it, names being
+// labels and never identity — and a real clan name can equally collide with
+// the other team's generated "Team N". Either way the ID is appended to
+// both so columns and winners stay distinguishable.
+func seriesTeamLabels(series *demoparser.ProcessedSeries) map[int]string {
+	labels := make(map[int]string, len(series.Teams))
+	counts := make(map[string]int, len(series.Teams))
+	for _, team := range series.Teams {
+		label := team.Name
+		if label == "" {
+			label = fmt.Sprintf("Team %d", team.TeamID)
+		}
+		labels[team.TeamID] = label
+		counts[label]++
+	}
+	for _, team := range series.Teams {
+		if counts[labels[team.TeamID]] > 1 {
+			labels[team.TeamID] = fmt.Sprintf("%s (team %d)", labels[team.TeamID], team.TeamID)
+		}
+	}
+	return labels
+}
+
+// sortedSeriesByKills orders aggregate players the way sortedByKills orders
+// map players.
+func sortedSeriesByKills(players map[uint64]*demoparser.SeriesPlayer) []*demoparser.SeriesPlayer {
+	return slices.SortedFunc(maps.Values(players), func(a, b *demoparser.SeriesPlayer) int {
+		return killsOrder(a.KillStats.Total, b.KillStats.Total, a.Name, b.Name, a.SteamID, b.SteamID)
+	})
+}
+
+// selectedSeriesPlayers narrows the aggregate players to the selection; a
+// nil selection means everyone.
+func selectedSeriesPlayers(series *demoparser.ProcessedSeries, selected map[uint64]bool) map[uint64]*demoparser.SeriesPlayer {
+	if selected == nil {
+		return series.Players
+	}
+	players := make(map[uint64]*demoparser.SeriesPlayer, len(selected))
+	for id, player := range series.Players {
+		if selected[id] {
+			players[id] = player
+		}
+	}
+	return players
+}
+
+// seriesPlayerView reshapes an aggregate player into the per-map player
+// struct the existing rating-free tables and CSV row builder format. It is
+// a rendering adapter only: user_id stays zero and is never printed. The
+// view cannot express an omitted rating, so every rating-consuming output
+// reads the SeriesPlayer itself instead — printSeriesPlayersTable and
+// printSeriesRatingTable render "-", and seriesCSVRecords injects blank
+// rating cells.
+func seriesPlayerView(player *demoparser.SeriesPlayer) *demoparser.DemoPlayer {
+	return &demoparser.DemoPlayer{
+		SteamID:          player.SteamID,
+		Name:             player.Name,
+		TeamID:           player.TeamID,
+		Deaths:           player.Deaths,
+		DeathsTraded:     player.DeathsTraded,
+		KillStats:        player.KillStats,
+		AssistStats:      player.AssistStats,
+		PlayerMapStats:   player.PlayerStats,
+		OpeningDuelStats: player.OpeningDuelStats,
+		SideStats:        player.SideStats,
+		UtilityStats:     player.UtilityStats,
+	}
+}
+
+// PrintSeriesCLITables prints the multi-demo output: the ordered map
+// results with the overall map score, round score and winner, then the
+// aggregate player table for the selected players (everyone when selected
+// is nil).
+func PrintSeriesCLITables(series *demoparser.ProcessedSeries, selected map[uint64]bool) {
+	printSeriesResultTable(series, os.Stdout)
+	printSeriesPlayersTable(series, selected, os.Stdout)
+}
+
+func printSeriesResultTable(series *demoparser.ProcessedSeries, output io.Writer) {
+	labels := seriesTeamLabels(series)
+	// BuildSeries emits the teams in series-team-ID order, 1 then 2.
+	teamOne, teamTwo := series.Teams[0], series.Teams[1]
+	winner, loser := teamOne, teamTwo
+	if series.WinnerTeamID == teamTwo.TeamID {
+		winner, loser = teamTwo, teamOne
+	}
+
+	t := table.NewWriter()
+	t.SetOutputMirror(output)
+	t.SetTitle("Best-of-%d map results", series.BestOf)
+	t.AppendHeader(table.Row{"#", "Map", labels[teamOne.TeamID], labels[teamTwo.TeamID], "Winner"})
+	for i, seriesMap := range series.Maps {
+		seriesOf := make(map[int]int, len(seriesMap.TeamAssignments))
+		for _, assignment := range seriesMap.TeamAssignments {
+			seriesOf[assignment.MapTeamID] = assignment.SeriesTeamID
+		}
+		rounds := make(map[int]int, len(seriesMap.Analysis.Teams))
+		for _, mapTeam := range seriesMap.Analysis.Teams {
+			rounds[seriesOf[mapTeam.TeamID]] += mapTeam.Score
+		}
+		t.AppendRow(table.Row{
+			i + 1,
+			seriesMap.Analysis.Map.MapName,
+			rounds[teamOne.TeamID],
+			rounds[teamTwo.TeamID],
+			labels[seriesMap.WinnerTeamID],
+		})
+	}
+	t.AppendFooter(table.Row{"", "Maps", teamOne.MapsWon, teamTwo.MapsWon, labels[winner.TeamID]})
+	t.AppendFooter(table.Row{"", "Rounds", teamOne.RoundsWon, teamTwo.RoundsWon, ""})
+	t.SetCaption("Series winner: %s (%d:%d maps, %d:%d rounds)\n",
+		labels[winner.TeamID], winner.MapsWon, loser.MapsWon, winner.RoundsWon, loser.RoundsWon)
+	t.Render()
+}
+
+// printSeriesPlayersTable is the aggregate counterpart of the main
+// single-map table, with a Maps column instead of the map footer. Rates are
+// series-wide recomputations; a player whose rating could not be recomputed
+// from raw facts shows "-".
+func printSeriesPlayersTable(series *demoparser.ProcessedSeries, selected map[uint64]bool, output io.Writer) {
+	t := table.NewWriter()
+	t.SetOutputMirror(output)
+	t.SetTitle("Series player aggregates")
+	t.AppendHeader(table.Row{"Name", "Maps", "Kills", "Deaths", "K/D", "HS", "Assists", "ADR", "KAST (%)", "Rating", "Entry", "Precision (%)", "Best Weapon"})
+	for _, player := range sortedSeriesByKills(selectedSeriesPlayers(series, selected)) {
+		rating := "-"
+		if player.Rating != nil {
+			rating = fmt.Sprintf("%.2f", player.Rating.Value)
+		}
+		t.AppendRow(table.Row{
+			player.Name,
+			player.MapsPlayed,
+			player.KillStats.Total,
+			player.Deaths,
+			kdRatio(player.KillStats.Total, player.Deaths),
+			player.KillStats.HeadShots,
+			player.AssistStats.Total,
+			fmt.Sprintf("%.1f", player.AssistStats.ADR),
+			fmt.Sprintf("%.1f", player.PlayerStats.KAST),
+			rating,
+			entryScore(player.OpeningDuelStats),
+			fmt.Sprintf("%.1f", player.KillStats.Precision*100),
+			demoparser.GetPlayerBestWeapon(player.KillStats.WeaponsKills),
+		})
+	}
+	t.Render()
+}
+
+// PrintSeriesDetailTables prints the aggregate versions of the --details
+// tables for the selected players (everyone when selected is nil). The
+// rating breakdown goes through the aggregate players themselves so an
+// omitted rating stays visibly omitted; the per-map detail values remain
+// available through the saved series JSON.
+func PrintSeriesDetailTables(series *demoparser.ProcessedSeries, selected map[uint64]bool) {
+	sorted := sortedSeriesByKills(selectedSeriesPlayers(series, selected))
+	printSeriesRatingTable(sorted, os.Stdout)
+	views := make([]*demoparser.DemoPlayer, len(sorted))
+	for i, player := range sorted {
+		views[i] = seriesPlayerView(player)
+	}
+	printApproxMetricsTable(views, os.Stdout)
+	printMultiKillTable(views, os.Stdout)
+	printTradeTable(views, os.Stdout)
+	printSideSplitTable(views, os.Stdout)
+	printUtilityEffectivenessTable(views, os.Stdout)
+	printGrenadesThrownTable(views, os.Stdout)
+}
+
+// printSeriesRatingTable feeds aggregate players to the shared rating
+// breakdown; a nil rating renders as "-" cells there.
+func printSeriesRatingTable(players []*demoparser.SeriesPlayer, output io.Writer) {
+	rows := make([]ratingRow, len(players))
+	for i, player := range players {
+		rows[i] = ratingRow{name: player.Name, rating: player.Rating}
+	}
+	printRatingRows(rows, output)
+}
+
+// WriteSeriesToFile writes the series as JSON — the complete envelope with
+// the ordered map analyses — or as CSV. The CSV deliberately stays the
+// existing flat aggregate-player table with the exact single-map header,
+// order and formatting: no series, team, hash or map columns leak into it,
+// so full per-map series data requires JSON. The one series-specific cell
+// rule is that an omitted rating leaves its seven columns empty instead of
+// printing as 0.00.
+func WriteSeriesToFile(series *demoparser.ProcessedSeries, saveType string) (string, error) {
+	fileName := fmt.Sprintf("%d_data.%s", time.Now().Unix(), saveType)
+
+	if saveType == "csv" {
+		csvFile, err := os.Create(fileName)
+		if err != nil {
+			return "", err
+		}
+		defer csvFile.Close()
+
+		w := csv.NewWriter(csvFile)
+		if err := w.WriteAll(seriesCSVRecords(series.Players)); err != nil {
+			return "", err
+		}
+		return fileName, nil
+	}
+
+	jsonData, err := json.MarshalIndent(series, "", " ")
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(fileName, jsonData, 0644); err != nil {
+		return "", err
+	}
+	return fileName, nil
+}
+
+// seriesCSVRecords builds the aggregate-player rows under the single-map
+// header contract, blanking the rating columns of players whose series
+// rating was not recomputed.
+func seriesCSVRecords(players map[uint64]*demoparser.SeriesPlayer) [][]string {
+	records := [][]string{playerCSVHeader()}
+	for _, player := range sortedSeriesByKills(players) {
+		ratingCells := omittedRatingCSVCells()
+		if player.Rating != nil {
+			ratingCells = ratingCSVCells(*player.Rating)
+		}
+		records = append(records, playerCSVRow(seriesPlayerView(player), ratingCells))
+	}
+	return records
+}

--- a/cmd/dataexport/series_export_test.go
+++ b/cmd/dataexport/series_export_test.go
@@ -1,0 +1,284 @@
+package dataexport
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	demoparser "github.com/taua-almeida/cs2-analyser-tool/cmd/demo_parser"
+)
+
+// seriesFixture is a hand-built completed BO3 for export tests: two series
+// teams, one aggregate player per team — "sharp" with a recomputed rating,
+// "quiet" with the rating explicitly omitted — and two maps whose analyses
+// carry the standalone envelope.
+func seriesFixture() *demoparser.ProcessedSeries {
+	rating := demoparser.RatingStats{Value: 1.23, Kills: 1.1, Damage: 0.9, Survival: 1, KAST: 1.05, MultiKill: 0.5, RoundSwing: 1.2}
+	sharp := &demoparser.SeriesPlayer{
+		SteamID: 76561198000000001, Name: "sharp", Aliases: []string{"sharp"},
+		TeamID: 1, MapsPlayed: 2, Rounds: 45, Deaths: 25,
+		KillStats:   demoparser.KillStats{Total: 40, HeadShots: 22, Precision: 0.55, WeaponsKills: map[string]int{"AK-47": 30}},
+		AssistStats: demoparser.AssistStats{Total: 9, DamageGiven: 3600, ADR: 80},
+		PlayerStats: demoparser.PlayerMapStats{KAST: 71.1},
+		Rating:      &rating,
+	}
+	quiet := &demoparser.SeriesPlayer{
+		SteamID: 76561198000000002, Name: "quiet", Aliases: []string{"quiet"},
+		TeamID: 2, MapsPlayed: 2, Rounds: 45, Deaths: 30,
+		KillStats:   demoparser.KillStats{Total: 12, HeadShots: 4, WeaponsKills: map[string]int{"M4A1": 8}},
+		AssistStats: demoparser.AssistStats{Total: 14, DamageGiven: 1500, ADR: 33.3},
+	}
+	mapAnalysis := func(name string, scoreOne, scoreTwo int) *demoparser.ProcessedDemo {
+		return &demoparser.ProcessedDemo{
+			Players: map[uint64]*demoparser.DemoPlayer{},
+			Teams: []demoparser.DemoTeam{
+				{TeamID: 1, Name: "RedSquad", Aliases: []string{"RedSquad"}, Score: scoreOne, Roster: []uint64{sharp.SteamID}},
+				{TeamID: 2, Name: "BlueCrew", Aliases: []string{"BlueCrew"}, Score: scoreTwo, Roster: []uint64{quiet.SteamID}},
+			},
+			Map:      demoparser.MapData{MapName: name, TotalRounds: scoreOne + scoreTwo},
+			GameMode: "competitive",
+		}
+	}
+	return &demoparser.ProcessedSeries{
+		BestOf:       3,
+		WinnerTeamID: 1,
+		Teams: []demoparser.SeriesTeam{
+			{TeamID: 1, Name: "RedSquad", Aliases: []string{"RedSquad"}, MapsWon: 2, RoundsWon: 26, Roster: []uint64{sharp.SteamID}},
+			{TeamID: 2, Name: "BlueCrew", Aliases: []string{"BlueCrew"}, MapsWon: 0, RoundsWon: 19, Roster: []uint64{quiet.SteamID}},
+		},
+		Players: map[uint64]*demoparser.SeriesPlayer{sharp.SteamID: sharp, quiet.SteamID: quiet},
+		Maps: []demoparser.SeriesMap{
+			{
+				SHA256:       "digest-one",
+				WinnerTeamID: 1,
+				TeamAssignments: []demoparser.SeriesTeamAssignment{
+					{MapTeamID: 1, SeriesTeamID: 1}, {MapTeamID: 2, SeriesTeamID: 2},
+				},
+				Analysis: mapAnalysis("de_first", 13, 9),
+			},
+			{
+				SHA256:       "digest-two",
+				WinnerTeamID: 1,
+				TeamAssignments: []demoparser.SeriesTeamAssignment{
+					{MapTeamID: 1, SeriesTeamID: 1}, {MapTeamID: 2, SeriesTeamID: 2},
+				},
+				Analysis: mapAnalysis("de_second", 13, 10),
+			},
+		},
+	}
+}
+
+// TestSeriesCSVKeepsFlatPlayerContract pins the series CSV to the existing
+// single-map contract: identical header and per-player formatting, and no
+// series, team, hash or map metadata anywhere in the file.
+func TestSeriesCSVKeepsFlatPlayerContract(t *testing.T) {
+	data := writeToTempAndRead(t, func() (string, error) {
+		return WriteSeriesToFile(seriesFixture(), "csv")
+	})
+	records, err := csv.NewReader(strings.NewReader(string(data))).ReadAll()
+	if err != nil {
+		t.Fatalf("parsing series CSV: %v", err)
+	}
+	if len(records) != 3 {
+		t.Fatalf("CSV records = %d, want header plus the two aggregate players", len(records))
+	}
+
+	wantHeader := slices.Concat(legacyCSVHeader, utilityCSVHeader, ratingCSVHeader, approxCSVHeader)
+	if !reflect.DeepEqual(records[0], wantHeader) {
+		t.Errorf("series CSV header = %q, want the unchanged flat contract %q", records[0], wantHeader)
+	}
+	if records[1][0] != "sharp" || records[2][0] != "quiet" {
+		t.Errorf("series CSV rows = %q/%q, want most kills first", records[1][0], records[2][0])
+	}
+	ratingStart := len(legacyCSVHeader) + len(utilityCSVHeader)
+	wantSharpRating := []string{"1.23", "1.10", "0.90", "1.00", "1.05", "0.50", "1.20"}
+	if got := records[1][ratingStart : ratingStart+len(ratingCSVHeader)]; !reflect.DeepEqual(got, wantSharpRating) {
+		t.Errorf("recomputed rating cells = %q, want %q", got, wantSharpRating)
+	}
+	wantOmittedRating := make([]string, len(ratingCSVHeader))
+	if got := records[2][ratingStart : ratingStart+len(ratingCSVHeader)]; !reflect.DeepEqual(got, wantOmittedRating) {
+		t.Errorf("omitted rating cells = %q, want all empty; an absent rating must not print as 0.00", got)
+	}
+	for _, leaked := range []string{"digest-one", "digest-two", "de_first", "de_second", "RedSquad", "BlueCrew", "best_of", "team_id", "sha256", "maps_won"} {
+		if strings.Contains(string(data), leaked) {
+			t.Errorf("series CSV contains %q; series metadata must stay JSON-only", leaked)
+		}
+	}
+}
+
+// TestSeriesJSONEnvelope pins the saved series document: the five envelope
+// keys, ordered maps with digests and assignments, standalone analyses
+// inside each map, no user_id in aggregate players, and an explicit null
+// rating when it was not recomputed.
+func TestSeriesJSONEnvelope(t *testing.T) {
+	series := seriesFixture()
+	data := writeToTempAndRead(t, func() (string, error) {
+		return WriteSeriesToFile(series, "json")
+	})
+
+	var topLevel map[string]json.RawMessage
+	if err := json.Unmarshal(data, &topLevel); err != nil {
+		t.Fatalf("unmarshalling top level: %v", err)
+	}
+	gotKeys := slices.Sorted(maps.Keys(topLevel))
+	wantKeys := []string{"best_of", "maps", "players", "teams", "winner_team_id"}
+	if !reflect.DeepEqual(gotKeys, wantKeys) {
+		t.Fatalf("top-level keys = %q, want %q", gotKeys, wantKeys)
+	}
+
+	var seriesMaps []map[string]json.RawMessage
+	if err := json.Unmarshal(topLevel["maps"], &seriesMaps); err != nil {
+		t.Fatalf("unmarshalling maps: %v", err)
+	}
+	if len(seriesMaps) != 2 {
+		t.Fatalf("maps = %d entries, want 2", len(seriesMaps))
+	}
+	for i, want := range []string{`"digest-one"`, `"digest-two"`} {
+		if got := string(seriesMaps[i]["sha256"]); got != want {
+			t.Errorf("maps[%d].sha256 = %s, want %s; supplied order must be kept", i, got, want)
+		}
+		var analysis map[string]json.RawMessage
+		if err := json.Unmarshal(seriesMaps[i]["analysis"], &analysis); err != nil {
+			t.Fatalf("unmarshalling maps[%d].analysis: %v", i, err)
+		}
+		gotAnalysisKeys := slices.Sorted(maps.Keys(analysis))
+		wantAnalysisKeys := []string{"game_mode", "map_data", "players", "teams"}
+		if !reflect.DeepEqual(gotAnalysisKeys, wantAnalysisKeys) {
+			t.Errorf("maps[%d].analysis keys = %q, want the standalone envelope %q", i, gotAnalysisKeys, wantAnalysisKeys)
+		}
+		if _, ok := seriesMaps[i]["team_assignments"]; !ok {
+			t.Errorf("maps[%d] has no team_assignments", i)
+		}
+	}
+
+	var playersByID map[string]map[string]json.RawMessage
+	if err := json.Unmarshal(topLevel["players"], &playersByID); err != nil {
+		t.Fatalf("unmarshalling players: %v", err)
+	}
+	quiet := playersByID["76561198000000002"]
+	if quiet == nil {
+		t.Fatal("aggregate player 76561198000000002 missing")
+	}
+	if _, hasUserID := quiet["user_id"]; hasUserID {
+		t.Error("aggregate player carries a map-local user_id; the series player type must not")
+	}
+	if got := string(quiet["rating"]); got != "null" {
+		t.Errorf("omitted rating = %s, want an explicit null", got)
+	}
+	if got := string(quiet["maps_played"]); got != "2" {
+		t.Errorf("maps_played = %s, want 2", got)
+	}
+
+	var roundTrip demoparser.ProcessedSeries
+	if err := json.Unmarshal(data, &roundTrip); err != nil {
+		t.Fatalf("round-tripping series JSON: %v", err)
+	}
+	if !reflect.DeepEqual(&roundTrip, series) {
+		t.Error("series JSON does not round-trip through ProcessedSeries")
+	}
+}
+
+// TestSeriesTables renders the series result and aggregate player tables
+// and pins their load-bearing content: ordered maps, team labels, winner,
+// the Maps column, the recomputed rating, and that a nil rating is not
+// printed as a zero rating.
+func TestSeriesTables(t *testing.T) {
+	series := seriesFixture()
+
+	// Comparisons are case-insensitive because go-pretty upper-cases header
+	// cells when rendering.
+	var result strings.Builder
+	printSeriesResultTable(series, &result)
+	rendered := strings.ToLower(result.String())
+	for _, want := range []string{"Best-of-3", "de_first", "de_second", "RedSquad", "BlueCrew", "Series winner: RedSquad (2:0 maps, 26:19 rounds)"} {
+		if !strings.Contains(rendered, strings.ToLower(want)) {
+			t.Errorf("series result table missing %q:\n%s", want, result.String())
+		}
+	}
+
+	var playersTable strings.Builder
+	printSeriesPlayersTable(series, nil, &playersTable)
+	rendered = strings.ToLower(playersTable.String())
+	for _, want := range []string{"Maps", "sharp", "quiet", "1.23"} {
+		if !strings.Contains(rendered, strings.ToLower(want)) {
+			t.Errorf("series players table missing %q:\n%s", want, playersTable.String())
+		}
+	}
+	if strings.Contains(rendered, "0.00") {
+		t.Errorf("series players table renders an omitted rating as 0.00:\n%s", rendered)
+	}
+
+	var filtered strings.Builder
+	printSeriesPlayersTable(series, map[uint64]bool{76561198000000001: true}, &filtered)
+	if strings.Contains(filtered.String(), "quiet") {
+		t.Errorf("player selection did not narrow the table:\n%s", filtered.String())
+	}
+}
+
+// TestSeriesRatingTablePreservesOmission pins the aggregate rating
+// breakdown: a recomputed rating prints normally while an omitted one shows
+// "-" cells rather than a fabricated 0.00 rating.
+func TestSeriesRatingTablePreservesOmission(t *testing.T) {
+	series := seriesFixture()
+	var breakdown strings.Builder
+	printSeriesRatingTable(sortedSeriesByKills(series.Players), &breakdown)
+	rendered := strings.ToLower(breakdown.String())
+	for _, want := range []string{"Rating breakdown", "eKAST sub-rating", "sharp", "1.23", "quiet"} {
+		if !strings.Contains(rendered, strings.ToLower(want)) {
+			t.Errorf("series rating table missing %q:\n%s", want, breakdown.String())
+		}
+	}
+	if strings.Contains(rendered, "0.00") {
+		t.Errorf("series rating table renders an omitted rating as 0.00:\n%s", breakdown.String())
+	}
+}
+
+// TestSeriesTeamLabelCollisions pins that two series teams sharing one clan
+// name — which identity resolution permits, names being labels — render
+// with their series-team IDs appended, so every column and winner stays
+// attributable.
+func TestSeriesTeamLabelCollisions(t *testing.T) {
+	series := seriesFixture()
+	series.Teams[0].Name = "SameName"
+	series.Teams[1].Name = "SameName"
+	var result strings.Builder
+	printSeriesResultTable(series, &result)
+	rendered := strings.ToLower(result.String())
+	for _, want := range []string{"SameName (team 1)", "SameName (team 2)", "Series winner: SameName (team 1)"} {
+		if !strings.Contains(rendered, strings.ToLower(want)) {
+			t.Errorf("colliding-label result table missing %q:\n%s", want, result.String())
+		}
+	}
+
+	// A real clan name can also collide with the other team's generated
+	// fallback, so collisions must be detected on the final labels.
+	fallback := seriesFixture()
+	fallback.Teams[0].Name = ""
+	fallback.Teams[1].Name = "Team 1"
+	var fallbackResult strings.Builder
+	printSeriesResultTable(fallback, &fallbackResult)
+	rendered = strings.ToLower(fallbackResult.String())
+	for _, want := range []string{"Team 1 (team 1)", "Team 1 (team 2)", "Series winner: Team 1 (team 1)"} {
+		if !strings.Contains(rendered, strings.ToLower(want)) {
+			t.Errorf("fallback-collision result table missing %q:\n%s", want, fallbackResult.String())
+		}
+	}
+}
+
+// TestSortedSeriesByKillsTieBreaksBySteamID pins the final ordering key:
+// two players sharing a kill count and display name must not inherit the
+// map's random iteration order.
+func TestSortedSeriesByKillsTieBreaksBySteamID(t *testing.T) {
+	players := map[uint64]*demoparser.SeriesPlayer{
+		11: {SteamID: 11, Name: "twin", KillStats: demoparser.KillStats{Total: 7}},
+		5:  {SteamID: 5, Name: "twin", KillStats: demoparser.KillStats{Total: 7}},
+	}
+	sorted := sortedSeriesByKills(players)
+	if sorted[0].SteamID != 5 || sorted[1].SteamID != 11 {
+		t.Errorf("tied players sorted as %d, %d; want ascending SteamID 5, 11", sorted[0].SteamID, sorted[1].SteamID)
+	}
+}

--- a/cmd/dataexport/table_print.go
+++ b/cmd/dataexport/table_print.go
@@ -13,15 +13,24 @@ import (
 	demoparser "github.com/taua-almeida/cs2-analyser-tool/cmd/demo_parser"
 )
 
-// sortedByKills orders players the way the main table does, most kills
-// first, so every output lists them in the same order. Ties break by name
-// to keep that order stable across runs.
+// killsOrder is the one player ordering every output uses: most kills
+// first, ties broken by name, then by SteamID — without the final unique
+// key, two players sharing a name and kill count would inherit the map's
+// random iteration order and reorder between runs.
+func killsOrder(aKills, bKills int, aName, bName string, aID, bID uint64) int {
+	if c := cmp.Compare(bKills, aKills); c != 0 {
+		return c
+	}
+	if c := cmp.Compare(aName, bName); c != 0 {
+		return c
+	}
+	return cmp.Compare(aID, bID)
+}
+
+// sortedByKills orders players the way the main table does.
 func sortedByKills(players map[uint64]*demoparser.DemoPlayer) []*demoparser.DemoPlayer {
 	return slices.SortedFunc(maps.Values(players), func(a, b *demoparser.DemoPlayer) int {
-		if c := cmp.Compare(b.KillStats.Total, a.KillStats.Total); c != 0 {
-			return c
-		}
-		return cmp.Compare(a.Name, b.Name)
+		return killsOrder(a.KillStats.Total, b.KillStats.Total, a.Name, b.Name, a.SteamID, b.SteamID)
 	})
 }
 
@@ -82,29 +91,49 @@ func PrintCLIDetailTables(playerToAnalyse map[uint64]*demoparser.DemoPlayer) {
 	printGrenadesThrownTable(players, os.Stdout)
 }
 
-// printRatingTable breaks the rating into its six sub-ratings, each
+// ratingRow is one line of the rating breakdown. A nil rating means it was
+// not computed — a series aggregate without raw facts — and renders as "-"
+// cells rather than a fabricated zero rating.
+type ratingRow struct {
+	name   string
+	rating *demoparser.RatingStats
+}
+
+// printRatingRows breaks the rating into its six sub-ratings, each
 // normalized so 1.00 is an average performance on that axis. The KAST and
 // round-swing columns are headed as sub-ratings to keep them apart from the
-// approximate percentages printed below them.
-func printRatingTable(players []*demoparser.DemoPlayer, output io.Writer) {
+// approximate percentages printed below them. It is the one rating-breakdown
+// shell, shared by the single-map and series detail tables.
+func printRatingRows(rows []ratingRow, output io.Writer) {
 	t := table.NewWriter()
 	t.SetOutputMirror(output)
 	t.SetTitle("Rating breakdown (1.00 = average)")
 	t.AppendHeader(table.Row{"Name", "Rating", "Kills", "Damage", "Survival", "eKAST sub-rating", "Multi-kill", "Round swing sub-rating"})
-	for _, player := range players {
-		rating := player.Rating
-		t.AppendRow(table.Row{
-			player.Name,
-			fmt.Sprintf("%.2f", rating.Value),
-			fmt.Sprintf("%.2f", rating.Kills),
-			fmt.Sprintf("%.2f", rating.Damage),
-			fmt.Sprintf("%.2f", rating.Survival),
-			fmt.Sprintf("%.2f", rating.KAST),
-			fmt.Sprintf("%.2f", rating.MultiKill),
-			fmt.Sprintf("%.2f", rating.RoundSwing),
-		})
+	for _, row := range rows {
+		cells := table.Row{row.name, "-", "-", "-", "-", "-", "-", "-"}
+		if rating := row.rating; rating != nil {
+			cells = table.Row{
+				row.name,
+				fmt.Sprintf("%.2f", rating.Value),
+				fmt.Sprintf("%.2f", rating.Kills),
+				fmt.Sprintf("%.2f", rating.Damage),
+				fmt.Sprintf("%.2f", rating.Survival),
+				fmt.Sprintf("%.2f", rating.KAST),
+				fmt.Sprintf("%.2f", rating.MultiKill),
+				fmt.Sprintf("%.2f", rating.RoundSwing),
+			}
+		}
+		t.AppendRow(cells)
 	}
 	t.Render()
+}
+
+func printRatingTable(players []*demoparser.DemoPlayer, output io.Writer) {
+	rows := make([]ratingRow, len(players))
+	for i, player := range players {
+		rows[i] = ratingRow{name: player.Name, rating: &player.Rating}
+	}
+	printRatingRows(rows, output)
 }
 
 // printApproxMetricsTable shows the interpretable pre-normalization values

--- a/cmd/dataexport/utility_export_test.go
+++ b/cmd/dataexport/utility_export_test.go
@@ -12,6 +12,17 @@ import (
 	demoparser "github.com/taua-almeida/cs2-analyser-tool/cmd/demo_parser"
 )
 
+// The flat CSV header contract, pinned independently of playerCSVHeader so
+// accidental production drift fails these tests. New columns are appended
+// after all existing ones so legacy column positions stay stable; the series
+// CSV test asserts the identical concatenation.
+var (
+	legacyCSVHeader  = []string{"Name", "Kills", "Deaths", "K/D", "HS", "Assists", "Flash Assists", "Damage Given", "ADR", "KAST (%)", "Precision (%)", "Trade Kills", "Deaths Traded", "Opening Kills", "Opening Deaths", "Opening Success (%)", "MVPs", "ACEs", "2K", "3K", "4K", "5K", "Clutches Won", "Rounds CT", "Rounds T", "Kills CT", "Kills T", "Deaths CT", "Deaths T", "Deaths Traded CT", "Deaths Traded T", "ADR CT", "ADR T", "KAST CT (%)", "KAST T (%)", "Best Weapon"}
+	utilityCSVHeader = []string{"Enemies Flashed", "Friends Flashed", "Enemy Flash Time (s)", "Average Enemy Flash Time (s)", "Utility Damage Total", "HE Utility Damage", "Fire Utility Damage", "Grenades Thrown Total", "Flashbangs Thrown", "Smokes Thrown", "HE Grenades Thrown", "Molotovs Thrown", "Incendiaries Thrown", "Decoys Thrown", "Unused Utility Value"}
+	ratingCSVHeader  = []string{"Rating", "Rating Kills", "Rating Damage", "Rating Survival", "Rating KAST", "Rating Multi-kill", "Rating Round Swing"}
+	approxCSVHeader  = []string{"Approx. eKAST (%)", "Approx. swing (%)"}
+)
+
 func utilityPlayer() *demoparser.DemoPlayer {
 	return &demoparser.DemoPlayer{
 		SteamID: 1,
@@ -87,27 +98,22 @@ func TestCSVAppendsStableUtilityAndRatingColumns(t *testing.T) {
 		t.Fatalf("CSV records = %d, want header and one player", len(records))
 	}
 
-	legacyHeader := []string{"Name", "Kills", "Deaths", "K/D", "HS", "Assists", "Flash Assists", "Damage Given", "ADR", "KAST (%)", "Precision (%)", "Trade Kills", "Deaths Traded", "Opening Kills", "Opening Deaths", "Opening Success (%)", "MVPs", "ACEs", "2K", "3K", "4K", "5K", "Clutches Won", "Rounds CT", "Rounds T", "Kills CT", "Kills T", "Deaths CT", "Deaths T", "Deaths Traded CT", "Deaths Traded T", "ADR CT", "ADR T", "KAST CT (%)", "KAST T (%)", "Best Weapon"}
-	utilityHeader := []string{"Enemies Flashed", "Friends Flashed", "Enemy Flash Time (s)", "Average Enemy Flash Time (s)", "Utility Damage Total", "HE Utility Damage", "Fire Utility Damage", "Grenades Thrown Total", "Flashbangs Thrown", "Smokes Thrown", "HE Grenades Thrown", "Molotovs Thrown", "Incendiaries Thrown", "Decoys Thrown", "Unused Utility Value"}
-	ratingHeader := []string{"Rating", "Rating Kills", "Rating Damage", "Rating Survival", "Rating KAST", "Rating Multi-kill", "Rating Round Swing"}
-	// Appended last so every legacy column keeps its position.
-	approxHeader := []string{"Approx. eKAST (%)", "Approx. swing (%)"}
-	wantHeader := slices.Concat(legacyHeader, utilityHeader, ratingHeader, approxHeader)
+	wantHeader := slices.Concat(legacyCSVHeader, utilityCSVHeader, ratingCSVHeader, approxCSVHeader)
 	if !reflect.DeepEqual(records[0], wantHeader) {
 		t.Errorf("CSV header = %q, want %q", records[0], wantHeader)
 	}
 	wantUtilityValues := []string{"3", "4", "5.2", "1.8", "60", "40", "20", "21", "1", "2", "3", "4", "5", "6", "700"}
-	utilityValues := records[1][len(legacyHeader) : len(legacyHeader)+len(utilityHeader)]
+	utilityValues := records[1][len(legacyCSVHeader) : len(legacyCSVHeader)+len(utilityCSVHeader)]
 	if !reflect.DeepEqual(utilityValues, wantUtilityValues) {
 		t.Errorf("CSV utility values = %q, want %q", utilityValues, wantUtilityValues)
 	}
 	wantRatingValues := []string{"1.23", "1.10", "0.90", "1.00", "1.05", "0.50", "1.20"}
-	ratingStart := len(legacyHeader) + len(utilityHeader)
-	if got := records[1][ratingStart : ratingStart+len(ratingHeader)]; !reflect.DeepEqual(got, wantRatingValues) {
+	ratingStart := len(legacyCSVHeader) + len(utilityCSVHeader)
+	if got := records[1][ratingStart : ratingStart+len(ratingCSVHeader)]; !reflect.DeepEqual(got, wantRatingValues) {
 		t.Errorf("CSV rating values = %q, want %q", got, wantRatingValues)
 	}
 	wantApproxValues := []string{"104.3", "-4.5"}
-	if got := records[1][ratingStart+len(ratingHeader):]; !reflect.DeepEqual(got, wantApproxValues) {
+	if got := records[1][ratingStart+len(ratingCSVHeader):]; !reflect.DeepEqual(got, wantApproxValues) {
 		t.Errorf("CSV approx metric values = %q, want %q", got, wantApproxValues)
 	}
 }

--- a/cmd/demo_parser/demo_parser.go
+++ b/cmd/demo_parser/demo_parser.go
@@ -123,7 +123,34 @@ func ProcessDemo(demoPath string) (*ProcessedDemo, error) {
 		Teams:    a.teams,
 		Map:      a.mapData,
 		GameMode: a.gameMode,
+		aggFacts: a.exportAggFacts(),
 	}, nil
+}
+
+// exportAggFacts snapshots the raw accumulators behind each player's derived
+// stats, keyed by SteamID64, so series aggregation can recompute rates and
+// the rating from exact numerators. Bots never reach a.players, so their
+// tracker-only IDs are naturally excluded.
+func (a *analyser) exportAggFacts() map[uint64]playerAggFacts {
+	facts := make(map[uint64]playerAggFacts, len(a.players))
+	for id := range a.players {
+		facts[id] = a.factsFor(id)
+	}
+	return facts
+}
+
+// factsFor collects one player's raw accumulators from the analyser's maps.
+func (a *analyser) factsFor(id uint64) playerAggFacts {
+	return playerAggFacts{
+		kastRounds:  a.kastRounds[id],
+		sideDamage:  a.sideDamage[id],
+		openingWins: a.openingWins[id],
+		ecoKills:    a.ecoKills[id],
+		ecoDamage:   a.ecoDamage[id],
+		ecoSurvival: a.ecoSurvival[id],
+		ecoKast:     a.ecoKast[id],
+		roundSwing:  a.roundSwing[id],
+	}
 }
 
 // resolveGameMode picks the game mode to report. GameSessionConfig's gamemode
@@ -586,6 +613,15 @@ func (s *SideCount) count(side common.Team) {
 	s.add(side, 1)
 }
 
+// addCounts sums another counter into this one field by field. It is not
+// add over both sides: Total is carried through, not rederived, so counters
+// whose Total is more than CT+T keep that property when merged.
+func (s *SideCount) addCounts(other SideCount) {
+	s.Total += other.Total
+	s.CT += other.CT
+	s.T += other.T
+}
+
 // addSide credits n to the counter kept under id, which the maps hold by
 // value so a player that has never been counted reads as an empty one.
 func addSide(counters map[uint64]SideCount, id uint64, side common.Team, n int) {
@@ -880,54 +916,89 @@ func perRound(value, rounds int) float64 {
 // count instead of a demo.
 func (a *analyser) derive(totalRounds int) {
 	for id, p := range a.players {
-		if p.KillStats.Total > 0 {
-			p.KillStats.Precision = float64(p.KillStats.HeadShots) / float64(p.KillStats.Total)
-		}
-		// The match-wide ADR and KAST both use the match's round count,
-		// following the convention of HLTV-style stat sites. The rating's
-		// per-round averages share that denominator, so a late joiner is
-		// diluted here exactly as their ADR is.
-		if totalRounds > 0 {
-			p.AssistStats.ADR = perRound(p.AssistStats.DamageGiven, totalRounds)
-			p.PlayerMapStats.KAST = 100 * perRound(a.kastRounds[id].Total, totalRounds)
-			rounds := float64(totalRounds)
-			// The approximate percentages publish the same per-round
-			// values the rating normalizes, before the KAST baseline
-			// division and before the swing floor can hide a negative.
-			ecoKastPerRound := a.ecoKast[id] / rounds
-			swingPerRound := a.roundSwing[id] / rounds
-			p.PlayerMapStats.ApproxEKASTPercent = 100 * ecoKastPerRound
-			p.PlayerMapStats.ApproxRoundSwingPercent = 100 * swingPerRound
-			p.Rating = blendRating(ratingRound{
-				killPoints: a.ecoKills[id] / rounds,
-				ecoDamage:  a.ecoDamage[id] / rounds,
-				survival:   a.ecoSurvival[id] / rounds,
-				kast:       ecoKastPerRound,
-				multiKill:  multiKillPoints(p.PlayerMapStats.MultiKills) / rounds,
-				swing:      swingPerRound,
-			})
-		}
-		// Their side splits cannot: sides swap at halftime, so there is no
-		// match-wide CT or T round count that holds for every player. Each
-		// side is divided by the rounds that player spent on it, which for
-		// anyone who played the whole match adds back up to the same total.
-		rounds := p.SideStats.Rounds
-		damage, kast := a.sideDamage[id], a.kastRounds[id]
-		p.SideStats.ADR = SideRate{
-			CT: perRound(damage.CT, rounds.CT),
-			T:  perRound(damage.T, rounds.T),
-		}
-		p.SideStats.KAST = SideRate{
-			CT: 100 * perRound(kast.CT, rounds.CT),
-			T:  100 * perRound(kast.T, rounds.T),
-		}
-		if kills := p.OpeningDuelStats.OpeningKills.Total; kills > 0 {
-			p.OpeningDuelStats.OpeningSuccessRate = 100 * float64(a.openingWins[id]) / float64(kills)
-		}
-		if flashes := p.UtilityStats.EnemiesFlashed; flashes > 0 {
-			p.UtilityStats.AverageEnemyFlashTimeSeconds = p.UtilityStats.EnemyFlashTimeSeconds / float64(flashes)
+		rating, rated := deriveStats(p.statRefs(), a.factsFor(id), totalRounds)
+		if rated {
+			p.Rating = rating
 		}
 	}
+}
+
+// statRefs points at the stat blocks a player shares between the per-map and
+// series shapes, so one derivation writes both.
+type statRefs struct {
+	kills   *KillStats
+	assists *AssistStats
+	stats   *PlayerMapStats
+	opening *OpeningDuelStats
+	side    *SideStats
+	utility *UtilityStats
+}
+
+func (p *DemoPlayer) statRefs() statRefs {
+	return statRefs{
+		kills:   &p.KillStats,
+		assists: &p.AssistStats,
+		stats:   &p.PlayerMapStats,
+		opening: &p.OpeningDuelStats,
+		side:    &p.SideStats,
+		utility: &p.UtilityStats,
+	}
+}
+
+// deriveStats recomputes every fact-derived rate in place from the exact raw
+// accumulators, and returns the rating, valid only when there were rounds to
+// divide by. It is the one home of these formulas: a map divides by the
+// map's rounds, a series by the player's summed series rounds, and both get
+// identical arithmetic.
+func deriveStats(refs statRefs, facts playerAggFacts, totalRounds int) (rating RatingStats, rated bool) {
+	if refs.kills.Total > 0 {
+		refs.kills.Precision = float64(refs.kills.HeadShots) / float64(refs.kills.Total)
+	}
+	// The match-wide ADR and KAST both use the match's round count,
+	// following the convention of HLTV-style stat sites. The rating's
+	// per-round averages share that denominator, so a late joiner is
+	// diluted here exactly as their ADR is.
+	if totalRounds > 0 {
+		refs.assists.ADR = perRound(refs.assists.DamageGiven, totalRounds)
+		refs.stats.KAST = 100 * perRound(facts.kastRounds.Total, totalRounds)
+		rounds := float64(totalRounds)
+		// The approximate percentages publish the same per-round
+		// values the rating normalizes, before the KAST baseline
+		// division and before the swing floor can hide a negative.
+		ecoKastPerRound := facts.ecoKast / rounds
+		swingPerRound := facts.roundSwing / rounds
+		refs.stats.ApproxEKASTPercent = 100 * ecoKastPerRound
+		refs.stats.ApproxRoundSwingPercent = 100 * swingPerRound
+		rating = blendRating(ratingRound{
+			killPoints: facts.ecoKills / rounds,
+			ecoDamage:  facts.ecoDamage / rounds,
+			survival:   facts.ecoSurvival / rounds,
+			kast:       ecoKastPerRound,
+			multiKill:  multiKillPoints(refs.stats.MultiKills) / rounds,
+			swing:      swingPerRound,
+		})
+		rated = true
+	}
+	// The side splits cannot share that denominator: sides swap at halftime,
+	// so there is no match-wide CT or T round count that holds for every
+	// player. Each side is divided by the rounds that player spent on it,
+	// which for anyone who played every round adds back up to the same total.
+	sideRounds := refs.side.Rounds
+	refs.side.ADR = SideRate{
+		CT: perRound(facts.sideDamage.CT, sideRounds.CT),
+		T:  perRound(facts.sideDamage.T, sideRounds.T),
+	}
+	refs.side.KAST = SideRate{
+		CT: 100 * perRound(facts.kastRounds.CT, sideRounds.CT),
+		T:  100 * perRound(facts.kastRounds.T, sideRounds.T),
+	}
+	if kills := refs.opening.OpeningKills.Total; kills > 0 {
+		refs.opening.OpeningSuccessRate = 100 * float64(facts.openingWins) / float64(kills)
+	}
+	if flashes := refs.utility.EnemiesFlashed; flashes > 0 {
+		refs.utility.AverageEnemyFlashTimeSeconds = refs.utility.EnemyFlashTimeSeconds / float64(flashes)
+	}
+	return rating, rated
 }
 
 func GetPlayerBestWeapon(weaponsKills map[string]int) string {
@@ -958,16 +1029,7 @@ func GetPlayersName(players map[uint64]*DemoPlayer) []string {
 // no selection and an error listing the unmatched names in first-request order
 // along with every available demo name.
 func GetPlayersToAnalyse(players map[uint64]*DemoPlayer, requestedNames []string) (map[uint64]*DemoPlayer, error) {
-	distinct := make([]string, 0, len(requestedNames))
-	for _, name := range requestedNames {
-		duplicate := slices.ContainsFunc(distinct, func(seen string) bool {
-			return strings.EqualFold(seen, name)
-		})
-		if !duplicate {
-			distinct = append(distinct, name)
-		}
-	}
-
+	distinct := distinctNamesFold(requestedNames)
 	selected := make(map[uint64]*DemoPlayer)
 	var unmatched []string
 	for _, name := range distinct {
@@ -987,4 +1049,19 @@ func GetPlayersToAnalyse(players map[uint64]*DemoPlayer, requestedNames []string
 			strings.Join(unmatched, ", "), strings.Join(GetPlayersName(players), ", "))
 	}
 	return selected, nil
+}
+
+// distinctNamesFold removes case-insensitive duplicate requests, keeping the
+// first spelling of each name in request order.
+func distinctNamesFold(names []string) []string {
+	distinct := make([]string, 0, len(names))
+	for _, name := range names {
+		duplicate := slices.ContainsFunc(distinct, func(seen string) bool {
+			return strings.EqualFold(seen, name)
+		})
+		if !duplicate {
+			distinct = append(distinct, name)
+		}
+	}
+	return distinct
 }

--- a/cmd/demo_parser/hltv_regression_test.go
+++ b/cmd/demo_parser/hltv_regression_test.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -226,14 +227,7 @@ func TestHLTVRegression(t *testing.T) {
 					}
 					t.Fatalf("locating HLTV demo: %v", err)
 				}
-				if err := verifyDemoChecksum(demoPath, expectedMap.DemoSHA256); err != nil {
-					t.Fatalf("verifying HLTV demo: %v", err)
-				}
-
-				result, err := ProcessDemo(demoPath)
-				if err != nil {
-					t.Fatalf("ProcessDemo(%s): %v", expectedMap.DemoFile, err)
-				}
+				result := parseVerifiedHLTVDemo(t, demoPath, expectedMap.DemoSHA256)
 
 				assertHLTVMap(t, oracle.FixtureID, result, expectedMap)
 				assertHLTVRoster(t, oracle.FixtureID, result.Players, expectedMap)
@@ -259,6 +253,243 @@ func TestHLTVRegression(t *testing.T) {
 
 	logHLTVParity(t, "original fixture", originalParity, originalRatings)
 	logHLTVParity(t, "additional fixtures", extraParity, extraRatings)
+}
+
+// TestHLTVSeriesRegression drives the whole BO3 pipeline over the original
+// Rooster–Mindfreak fixture: every map is hashed and parsed in oracle order
+// and aggregated with BuildSeries, and the result is checked against values
+// derived from the same audited oracle — per-team map and round wins, the
+// series winner, exact SteamID matching across all three maps, additive
+// totals equal to the sum of the standalone map analyses, and the 64-round
+// series denominator behind every rate. Like TestHLTVRegression it never
+// downloads anything; unconfigured demos skip unless REQUIRE_HLTV_DEMOS is
+// set.
+func TestHLTVSeriesRegression(t *testing.T) {
+	oracle := loadHLTVOracle(t, hltvOracleFixturePath)
+	dirs := configuredDemoDirs(os.Getenv(hltvDemoDirEnv))
+	required := os.Getenv(requireHLTVDemosEnv) != ""
+	if required && len(dirs) == 0 {
+		t.Fatalf("%s is set but %s is empty; point it at the directory containing the three match 129241 demos",
+			requireHLTVDemosEnv, hltvDemoDirEnv)
+	}
+	if len(dirs) == 0 {
+		t.Skipf("HLTV demos are not configured; set %s to run the series fixture", hltvDemoDirEnv)
+	}
+
+	inputs := make([]SeriesMapInput, 0, len(oracle.Maps))
+	for _, expectedMap := range oracle.Maps {
+		demoPath, err := findDemo(dirs, expectedMap.DemoFile)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) && !required {
+				t.Skipf("HLTV demo %s is absent; set %s to make missing demos fail", expectedMap.DemoFile, requireHLTVDemosEnv)
+			}
+			t.Fatalf("locating HLTV demo: %v", err)
+		}
+		result := parseVerifiedHLTVDemo(t, demoPath, expectedMap.DemoSHA256)
+		inputs = append(inputs, SeriesMapInput{Demo: result, SHA256: expectedMap.DemoSHA256})
+	}
+
+	series, err := BuildSeries(3, inputs)
+	if err != nil {
+		t.Fatalf("BuildSeries: %v", err)
+	}
+	if series.BestOf != 3 {
+		t.Errorf("best_of = %d, want 3", series.BestOf)
+	}
+	assertHLTVSeriesMapsInOrder(t, series, oracle)
+	assertHLTVSeriesTeams(t, series, oracle)
+	assertHLTVSeriesPlayers(t, series, inputs, oracle)
+}
+
+// hltvSeriesTeamExpectation is one fixture team folded across the oracle's
+// maps: its roster and its map and round wins.
+type hltvSeriesTeamExpectation struct {
+	name      string
+	steamIDs  []uint64
+	mapsWon   int
+	roundsWon int
+}
+
+// hltvSeriesExpectations derives each fixture team's expected series result
+// from the audited per-map oracle rows, so the test asserts oracle-derived
+// values rather than numbers of its own.
+func hltvSeriesExpectations(t *testing.T, oracle hltvOracle) []hltvSeriesTeamExpectation {
+	t.Helper()
+	var expectations []hltvSeriesTeamExpectation
+	for _, expectedMap := range oracle.Maps {
+		teams := *expectedMap.Teams
+		for i, team := range teams {
+			ids := sortedIDs(team.SteamIDs)
+			index := slices.IndexFunc(expectations, func(e hltvSeriesTeamExpectation) bool {
+				return e.name == team.Name
+			})
+			if index < 0 {
+				index = len(expectations)
+				expectations = append(expectations, hltvSeriesTeamExpectation{name: team.Name, steamIDs: ids})
+			}
+			expectation := &expectations[index]
+			if !slices.Equal(expectation.steamIDs, ids) {
+				t.Fatalf("oracle team %s changes roster between maps; the series fixture assumes stable lineups", team.Name)
+			}
+			expectation.roundsWon += team.Score
+			if team.Score > teams[1-i].Score {
+				expectation.mapsWon++
+			}
+		}
+	}
+	if len(expectations) != 2 {
+		t.Fatalf("oracle names %d series teams, want 2", len(expectations))
+	}
+	return expectations
+}
+
+func assertHLTVSeriesMapsInOrder(t *testing.T, series *ProcessedSeries, oracle hltvOracle) {
+	t.Helper()
+	if len(series.Maps) != len(oracle.Maps) {
+		t.Fatalf("series has %d maps, want %d", len(series.Maps), len(oracle.Maps))
+	}
+	for i, expectedMap := range oracle.Maps {
+		if got := series.Maps[i].SHA256; got != expectedMap.DemoSHA256 {
+			t.Errorf("maps[%d].sha256 = %s, want %s; supplied order must be kept", i, got, expectedMap.DemoSHA256)
+		}
+		if got := series.Maps[i].Analysis.Map.MapName; got != expectedMap.ParserMapName {
+			t.Errorf("maps[%d] analysis map = %q, want %q", i, got, expectedMap.ParserMapName)
+		}
+	}
+}
+
+func assertHLTVSeriesTeams(t *testing.T, series *ProcessedSeries, oracle hltvOracle) {
+	t.Helper()
+	if len(series.Teams) != 2 {
+		t.Fatalf("series has %d teams, want 2", len(series.Teams))
+	}
+	expectations := hltvSeriesExpectations(t, oracle)
+	totalRounds := 0
+	for _, expected := range expectations {
+		team, found := findSeriesTeamByRoster(series.Teams, expected.steamIDs)
+		if !found {
+			t.Errorf("no series team has %s's roster %v; teams %+v", expected.name, expected.steamIDs, series.Teams)
+			continue
+		}
+		if team.Name != expected.name {
+			t.Errorf("series team with %s's roster is named %q", expected.name, team.Name)
+		}
+		if team.MapsWon != expected.mapsWon || team.RoundsWon != expected.roundsWon {
+			t.Errorf("series team %s = %d maps/%d rounds, oracle says %d/%d",
+				expected.name, team.MapsWon, team.RoundsWon, expected.mapsWon, expected.roundsWon)
+		}
+		wantThreshold := expected.mapsWon >= 2
+		if isWinner := team.TeamID == series.WinnerTeamID; isWinner != wantThreshold {
+			t.Errorf("series team %s winner = %t, oracle map wins say %t", expected.name, isWinner, wantThreshold)
+		}
+		totalRounds += expected.roundsWon
+	}
+	gotRounds := 0
+	for _, seriesMap := range series.Maps {
+		gotRounds += seriesMap.Analysis.Map.TotalRounds
+	}
+	if gotRounds != totalRounds {
+		t.Errorf("series rounds = %d, oracle says %d", gotRounds, totalRounds)
+	}
+}
+
+func findSeriesTeamByRoster(teams []SeriesTeam, steamIDs []uint64) (SeriesTeam, bool) {
+	for _, team := range teams {
+		if slices.Equal(team.Roster, steamIDs) {
+			return team, true
+		}
+	}
+	return SeriesTeam{}, false
+}
+
+// assertHLTVSeriesPlayers checks cross-map identity and the aggregation
+// arithmetic: all ten oracle SteamIDs appear once, played every map with the
+// full series-round denominator, their additive totals equal the sums of
+// the standalone analyses, their rates divide exact numerators by that
+// denominator, and their rating was recomputed rather than omitted.
+func assertHLTVSeriesPlayers(t *testing.T, series *ProcessedSeries, inputs []SeriesMapInput, oracle hltvOracle) {
+	t.Helper()
+	totalRounds := 0
+	for _, input := range inputs {
+		totalRounds += input.Demo.Map.TotalRounds
+	}
+	if len(series.Players) != 10 {
+		t.Errorf("series has %d aggregate players, want the ten oracle SteamIDs", len(series.Players))
+	}
+	for _, expectedPlayer := range oracle.Maps[0].Players {
+		player := series.Players[expectedPlayer.SteamID]
+		if player == nil {
+			t.Errorf("aggregate player %d (%s) missing", expectedPlayer.SteamID, expectedPlayer.HLTVName)
+			continue
+		}
+		if player.MapsPlayed != len(inputs) || player.Rounds != totalRounds {
+			t.Errorf("%s maps/rounds = %d/%d, want %d/%d",
+				expectedPlayer.HLTVName, player.MapsPlayed, player.Rounds, len(inputs), totalRounds)
+		}
+
+		var kills, deaths, damage, headshots, assists, kastRounds int
+		for _, input := range inputs {
+			mapPlayer := input.Demo.Players[expectedPlayer.SteamID]
+			if mapPlayer == nil {
+				t.Errorf("%s is missing from a map analysis; every oracle player plays all three maps", expectedPlayer.HLTVName)
+				continue
+			}
+			kills += mapPlayer.KillStats.Total
+			deaths += mapPlayer.Deaths
+			damage += mapPlayer.AssistStats.DamageGiven
+			headshots += mapPlayer.KillStats.HeadShots
+			assists += mapPlayer.AssistStats.Total
+			kastRounds += input.Demo.aggFacts[expectedPlayer.SteamID].kastRounds.Total
+		}
+		if player.KillStats.Total != kills || player.Deaths != deaths ||
+			player.AssistStats.DamageGiven != damage ||
+			player.KillStats.HeadShots != headshots || player.AssistStats.Total != assists {
+			t.Errorf("%s additive totals %d/%d/%d/%d/%d do not equal the map sums %d/%d/%d/%d/%d",
+				expectedPlayer.HLTVName,
+				player.KillStats.Total, player.Deaths, player.AssistStats.DamageGiven,
+				player.KillStats.HeadShots, player.AssistStats.Total,
+				kills, deaths, damage, headshots, assists)
+		}
+		if got, want := player.AssistStats.ADR, perRound(damage, totalRounds); got != want {
+			t.Errorf("%s series ADR = %v, want damage over the %d series rounds (%v)",
+				expectedPlayer.HLTVName, got, totalRounds, want)
+		}
+		if got, want := player.PlayerStats.KAST, 100*perRound(kastRounds, totalRounds); got != want {
+			t.Errorf("%s series KAST = %v, want the exact %d/%d recomputation (%v)",
+				expectedPlayer.HLTVName, got, kastRounds, totalRounds, want)
+		}
+		if player.Rating == nil {
+			t.Errorf("%s series rating omitted; parsed maps carry raw facts, so it must be recomputed", expectedPlayer.HLTVName)
+		}
+	}
+}
+
+// hltvParsedDemos caches checksum-verified parses per demo path for the
+// test binary's lifetime, so the map and series regressions share one parse
+// of each multi-hundred-MB demo instead of repeating seconds of work. Both
+// only read the result: the assertions never write, and BuildSeries
+// documents that it does not mutate its inputs.
+var hltvParsedDemos = struct {
+	sync.Mutex
+	byPath map[string]*ProcessedDemo
+}{byPath: map[string]*ProcessedDemo{}}
+
+func parseVerifiedHLTVDemo(t *testing.T, path, wantSHA256 string) *ProcessedDemo {
+	t.Helper()
+	hltvParsedDemos.Lock()
+	defer hltvParsedDemos.Unlock()
+	if demo, ok := hltvParsedDemos.byPath[path]; ok {
+		return demo
+	}
+	if err := verifyDemoChecksum(path, wantSHA256); err != nil {
+		t.Fatalf("verifying HLTV demo: %v", err)
+	}
+	demo, err := ProcessDemo(path)
+	if err != nil {
+		t.Fatalf("ProcessDemo(%s): %v", path, err)
+	}
+	hltvParsedDemos.byPath[path] = demo
+	return demo
 }
 
 func configuredDemoDirs(value string) []string {

--- a/cmd/demo_parser/series.go
+++ b/cmd/demo_parser/series.go
@@ -1,0 +1,798 @@
+// Series analysis (issue #34) aggregates an explicit, completed BO3 or BO5
+// from maps that were each parsed with ProcessDemo. Everything in this file
+// is pure — no flag handling, rendering or filesystem access — so the
+// aggregation can later move into the planned public Go library unchanged.
+// The series is never inferred: the caller states the format, and the maps
+// arrive in supplied order.
+package demoparser
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// SeriesMapInput is one played map of a series. Position in the BuildSeries
+// slice is the map's supplied order — the CLI takes it from the repeated
+// --demo flags — and it is preserved everywhere downstream.
+type SeriesMapInput struct {
+	// Demo is the parsed map. BuildSeries never mutates it.
+	Demo *ProcessedDemo
+	// SHA256 is the lowercase hex digest of the demo file's bytes. It
+	// identifies the map's content, so two inputs with equal digests are
+	// rejected as the same demo regardless of their file paths.
+	SHA256 string
+}
+
+// SeriesTeamAssignment records which series team one map-local team resolved
+// to. It is the explicit bridge between the two ID scopes: map_team_id is
+// only meaningful inside its own map, series_team_id only inside this series.
+type SeriesTeamAssignment struct {
+	MapTeamID    int `json:"map_team_id"`
+	SeriesTeamID int `json:"series_team_id"`
+}
+
+// SeriesMap is one map of the series, in supplied order: its content digest,
+// its winner in series-team terms, the local-to-series team translation, and
+// the unchanged standalone analysis.
+type SeriesMap struct {
+	SHA256          string                 `json:"sha256"`
+	WinnerTeamID    int                    `json:"winner_team_id"`
+	TeamAssignments []SeriesTeamAssignment `json:"team_assignments"`
+	Analysis        *ProcessedDemo         `json:"analysis"`
+}
+
+// SeriesTeam is one of the two series-scoped teams. TeamID is series-local —
+// team 1 is the first map's first logical team — and claims no identity
+// beyond this one series. Name and Aliases follow the map-level label rules:
+// aliases are the deduplicated map-level aliases in first map-observation
+// order, and the display name is the most-observed nonempty map-level name,
+// ties broken by first observation.
+type SeriesTeam struct {
+	TeamID    int      `json:"team_id"`
+	Name      string   `json:"name"`
+	Aliases   []string `json:"aliases"`
+	MapsWon   int      `json:"maps_won"`
+	RoundsWon int      `json:"rounds_won"`
+	Roster    []uint64 `json:"roster"`
+}
+
+// SeriesPlayer is one player aggregated across the maps they appear in,
+// matched exclusively by nonzero SteamID64. It deliberately has no user_id:
+// server user IDs are map-local and meaningless across demos. Additive
+// fields are exact sums of the per-map values; every rate inside the reused
+// stat structs is recomputed from exact summed numerators over the player's
+// series round count, never from the per-map rates.
+type SeriesPlayer struct {
+	SteamID uint64 `json:"steam_id"`
+	// Name is the most-observed nonempty per-map display name, ties broken
+	// by first observation — the same rule series team names use.
+	Name string `json:"name"`
+	// Aliases are the deduplicated nonempty per-map display names in map
+	// order.
+	Aliases []string `json:"aliases"`
+	// TeamID is the series team whose roster contains this SteamID, or 0
+	// for a player who never played an accepted round for a logical team.
+	TeamID int `json:"team_id"`
+	// MapsPlayed counts the maps where this SteamID participated for a
+	// logical team. Rounds sums those maps' total rounds and is the
+	// denominator of every match-wide rate, mirroring how a single map
+	// divides by the whole map's rounds.
+	MapsPlayed       int              `json:"maps_played"`
+	Rounds           int              `json:"rounds"`
+	Deaths           int              `json:"deaths"`
+	DeathsTraded     SideCount        `json:"deaths_traded"`
+	KillStats        KillStats        `json:"kill_stats"`
+	AssistStats      AssistStats      `json:"assist_stats"`
+	PlayerStats      PlayerMapStats   `json:"player_series_stats"`
+	OpeningDuelStats OpeningDuelStats `json:"opening_duel_stats"`
+	SideStats        SideStats        `json:"side_stats"`
+	UtilityStats     UtilityStats     `json:"utility_stats"`
+	// Rating is recomputed by running the rating model once over the exact
+	// summed raw facts (eco-adjusted kills and damage, eco-weighted survival
+	// and rating-KAST, signed swing, multi-kill buckets) with the series
+	// round denominator. It is null — never approximated from map ratings —
+	// when a map was not produced by ProcessDemo and so carries no raw
+	// facts, or when the player has no series rounds.
+	Rating *RatingStats `json:"rating"`
+}
+
+// ProcessedSeries is a completed BO3/BO5: the winner, the two series-scoped
+// teams, the aggregate players keyed by SteamID, and the ordered per-map
+// results with their unchanged standalone analyses.
+type ProcessedSeries struct {
+	BestOf       int                      `json:"best_of"`
+	WinnerTeamID int                      `json:"winner_team_id"`
+	Teams        []SeriesTeam             `json:"teams"`
+	Players      map[uint64]*SeriesPlayer `json:"players"`
+	Maps         []SeriesMap              `json:"maps"`
+}
+
+// SeriesMapTeams records one map's two local teams for identity errors: the
+// 0-based supplied map index, the map-local team IDs in the map's own team
+// order, and their rosters.
+type SeriesMapTeams struct {
+	MapIndex int
+	TeamIDs  [2]int
+	Rosters  [2][]uint64
+}
+
+// SeriesAssignmentCandidate is one enumerated way of assigning every map's
+// two local teams onto the two series teams.
+type SeriesAssignmentCandidate struct {
+	// Assignments[i] holds map i's two local-to-series pairs, in the map's
+	// team order.
+	Assignments [][2]SeriesTeamAssignment
+	// Conflicts lists the SteamIDs this candidate would place on both
+	// series teams, sorted ascending; it is empty for a valid candidate.
+	Conflicts []uint64
+}
+
+func (c SeriesAssignmentCandidate) describe() string {
+	parts := make([]string, len(c.Assignments))
+	for i, pair := range c.Assignments {
+		parts[i] = fmt.Sprintf("map %d: %d→%d, %d→%d", i+1,
+			pair[0].MapTeamID, pair[0].SeriesTeamID, pair[1].MapTeamID, pair[1].SeriesTeamID)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func describeSeriesMapTeams(maps []SeriesMapTeams) string {
+	parts := make([]string, len(maps))
+	for i, m := range maps {
+		parts[i] = fmt.Sprintf("map %d: team %d %v, team %d %v",
+			m.MapIndex+1, m.TeamIDs[0], m.Rosters[0], m.TeamIDs[1], m.Rosters[1])
+	}
+	return strings.Join(parts, "; ")
+}
+
+// SeriesTeamConflictError reports that no joint roster assignment keeps
+// every SteamID on one series team: the supplied maps mix players across
+// lineups rather than replaying the same two teams.
+type SeriesTeamConflictError struct {
+	Maps []SeriesMapTeams
+	// Candidates holds every enumerated assignment with the SteamIDs it
+	// would place on both teams.
+	Candidates []SeriesAssignmentCandidate
+}
+
+func (e *SeriesTeamConflictError) Error() string {
+	var b strings.Builder
+	b.WriteString("cannot resolve series teams: no joint roster assignment keeps every SteamID on one team")
+	for _, candidate := range e.Candidates {
+		fmt.Fprintf(&b, "; [%s] places %v on both teams", candidate.describe(), candidate.Conflicts)
+	}
+	fmt.Fprintf(&b, "; rosters: %s", describeSeriesMapTeams(e.Maps))
+	return b.String()
+}
+
+// SeriesTeamAmbiguityError reports that more than one joint roster
+// assignment is consistent with the supplied maps, so the series teams
+// cannot be resolved without guessing. Clan names never break the tie: they
+// are labels, not identity.
+type SeriesTeamAmbiguityError struct {
+	Maps []SeriesMapTeams
+	// Candidates holds the competing valid assignments.
+	Candidates []SeriesAssignmentCandidate
+}
+
+func (e *SeriesTeamAmbiguityError) Error() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "series team assignment is ambiguous: %d joint roster assignments are consistent", len(e.Candidates))
+	for _, candidate := range e.Candidates {
+		fmt.Fprintf(&b, "; [%s]", candidate.describe())
+	}
+	fmt.Fprintf(&b, "; rosters: %s", describeSeriesMapTeams(e.Maps))
+	return b.String()
+}
+
+// PlayerAliasAmbiguityError reports a requested player alias that matches
+// more than one SteamID across the series.
+type PlayerAliasAmbiguityError struct {
+	Alias    string
+	SteamIDs []uint64 // sorted candidates
+}
+
+func (e *PlayerAliasAmbiguityError) Error() string {
+	return fmt.Sprintf("player %q matches more than one SteamID in this series: %v; request a unique alias",
+		e.Alias, e.SteamIDs)
+}
+
+// BuildSeries aggregates a completed best-of-3 or best-of-5 from maps in
+// supplied order. It validates each map's logical-team shape, rejects
+// duplicate demo content by digest, resolves the two series teams through a
+// unique joint roster assignment, and requires the series to be clinched
+// exactly on the final supplied map. The inputs are never mutated.
+func BuildSeries(bestOf int, maps []SeriesMapInput) (*ProcessedSeries, error) {
+	// The minimum played-map count doubles as the clinch threshold: a series
+	// is complete exactly when one team has won that many maps.
+	threshold, maxMaps, err := SeriesMapCountRange(bestOf)
+	if err != nil {
+		return nil, err
+	}
+	if len(maps) < threshold || len(maps) > maxMaps {
+		return nil, fmt.Errorf("a completed best-of-%d has %s maps, got %d",
+			bestOf, seriesMapCountChoices(bestOf), len(maps))
+	}
+	if err := validateSeriesMaps(maps); err != nil {
+		return nil, err
+	}
+
+	orientation, err := resolveSeriesTeams(maps)
+	if err != nil {
+		return nil, err
+	}
+	tally, err := seriesResults(maps, orientation, bestOf, threshold)
+	if err != nil {
+		return nil, err
+	}
+
+	teams := buildSeriesTeams(maps, orientation, tally)
+	return &ProcessedSeries{
+		BestOf:       bestOf,
+		WinnerTeamID: tally.winner,
+		Teams:        teams,
+		Players:      buildSeriesPlayers(maps, teams),
+		Maps:         buildSeriesMaps(maps, orientation, tally.mapWinners),
+	}, nil
+}
+
+// SeriesMapCountRange validates a series format and returns the played-map
+// counts a completed series can have: a best-of-n is decided somewhere
+// between its clinch threshold, n/2+1, and its full length. It is the one
+// home of the format rule, shared with the CLI's fail-before-parse flag
+// validation.
+func SeriesMapCountRange(bestOf int) (minMaps, maxMaps int, err error) {
+	if bestOf != 3 && bestOf != 5 {
+		return 0, 0, fmt.Errorf("invalid best-of %d, must be 3 or 5", bestOf)
+	}
+	return bestOf/2 + 1, bestOf, nil
+}
+
+// seriesMapCountChoices spells out the accepted played-map counts of a
+// validated format.
+func seriesMapCountChoices(bestOf int) string {
+	if bestOf == 5 {
+		return "3, 4 or 5"
+	}
+	return "2 or 3"
+}
+
+// seriesMapLabel names a map in errors by its 1-based supplied position and,
+// when known, its map name.
+func seriesMapLabel(index int, demo *ProcessedDemo) string {
+	if demo != nil && demo.Map.MapName != "" {
+		return fmt.Sprintf("map %d (%s)", index+1, demo.Map.MapName)
+	}
+	return fmt.Sprintf("map %d", index+1)
+}
+
+func validateSeriesMaps(inputs []SeriesMapInput) error {
+	digests := make(map[string]int, len(inputs))
+	for i, input := range inputs {
+		if input.Demo == nil {
+			return fmt.Errorf("map %d has no parsed demo", i+1)
+		}
+		if input.SHA256 == "" {
+			return fmt.Errorf("%s has no SHA-256 digest", seriesMapLabel(i, input.Demo))
+		}
+		if first, duplicate := digests[input.SHA256]; duplicate {
+			return fmt.Errorf("maps %d and %d are the same demo: both have SHA-256 %s",
+				first+1, i+1, input.SHA256)
+		}
+		digests[input.SHA256] = i
+		if err := validateSeriesMap(i, input.Demo); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// seriesTeamSize is the lineup size of the competitive 5v5 format, the only
+// format series aggregation supports. A map whose logical team fielded fewer
+// eligible players — a completed Wingman 2v2 would otherwise pass every
+// other check — is rejected before identity resolution. Substitutions only
+// ever make a roster larger, so the bound never rejects a competitive map
+// with stand-ins.
+const seriesTeamSize = 5
+
+// seriesGameModes are the reported game modes accepted for a series map:
+// the spellings of the classic competitive 5v5 ruleset, plus "" because a
+// demo that names no mode and matches no known ruleset is unknown rather
+// than known-unsupported. Any other mode — casual, deathmatch, wingman's
+// scrimcomp2v2 — is rejected outright: the rating's win-probability model
+// and denominators assume 5v5 rounds, so aggregating a larger or respawn
+// format would produce numbers that look valid and mean nothing.
+var seriesGameModes = map[string]bool{
+	"":             true,
+	"competitive":  true,
+	"scrimcomp5v5": true,
+	"premier":      true,
+}
+
+// validateSeriesMap checks one map holds a decided, internally consistent
+// two-team competitive 5v5 match: a supported game mode, exactly two logical
+// teams with distinct IDs and at least 5v5 rosters, untied scores that add
+// up to the map's rounds, players that reference only those teams (or team
+// 0, the no-team marker), and no more per-round participants than a 5v5
+// lobby can produce.
+func validateSeriesMap(index int, demo *ProcessedDemo) error {
+	label := seriesMapLabel(index, demo)
+	if !seriesGameModes[demo.GameMode] {
+		return fmt.Errorf("%s reports game mode %q; series aggregation supports only the competitive 5v5 format", label, demo.GameMode)
+	}
+	if len(demo.Teams) != 2 {
+		return fmt.Errorf("%s has %d logical teams, want exactly 2", label, len(demo.Teams))
+	}
+	first, second := demo.Teams[0], demo.Teams[1]
+	if first.TeamID == second.TeamID {
+		return fmt.Errorf("%s repeats map-local team ID %d", label, first.TeamID)
+	}
+	for _, team := range demo.Teams {
+		if len(team.Roster) < seriesTeamSize {
+			return fmt.Errorf("%s team %d fielded %d players; series aggregation supports only the competitive 5v5 format, so a roster needs at least %d (substitutes only add more)",
+				label, team.TeamID, len(team.Roster), seriesTeamSize)
+		}
+	}
+	if first.Score == second.Score {
+		return fmt.Errorf("%s ended tied %d:%d; a series map needs a winner", label, first.Score, second.Score)
+	}
+	if first.Score+second.Score != demo.Map.TotalRounds {
+		return fmt.Errorf("%s team scores %d+%d do not add up to its %d rounds",
+			label, first.Score, second.Score, demo.Map.TotalRounds)
+	}
+	for _, id := range slices.Sorted(maps.Keys(demo.Players)) {
+		if teamID := demo.Players[id].TeamID; teamID != 0 && teamID != first.TeamID && teamID != second.TeamID {
+			return fmt.Errorf("%s player %d references unknown map team ID %d", label, id, teamID)
+		}
+	}
+	// The mode gate above cannot catch an oversized lobby whose demo names
+	// no mode, so hold the per-round participation to what a 5v5 can
+	// produce. A round involves the two lineups' ten players; the one
+	// legitimate overage is a freeze-time swap counting both the leaver and
+	// the joiner, so the ceiling allows one extra participant per round —
+	// well below the ~20 of a 10v10 lobby.
+	participantRounds := 0
+	for _, player := range demo.Players {
+		participantRounds += player.SideStats.Rounds.Total
+	}
+	if participantRounds > (2*seriesTeamSize+1)*demo.Map.TotalRounds {
+		return fmt.Errorf("%s counts %d participant-rounds over %d rounds, more than a 5v5 lobby can produce; series aggregation supports only the competitive 5v5 format",
+			label, participantRounds, demo.Map.TotalRounds)
+	}
+	return nil
+}
+
+// resolveSeriesTeams finds the unique joint assignment of every map's two
+// local teams onto the two series teams. Series team 1 and 2 are seeded
+// deterministically from the first map's team order; each later map either
+// keeps that orientation or crosses it, and all combinations — at most 2^4
+// for a BO5, so exhaustive evaluation is simpler and safer than a greedy
+// matcher — are judged jointly against one rule: the union rosters of the
+// two series teams must stay disjoint. Exactly one surviving combination is
+// success, zero is a mixed-team conflict, several is an ambiguity; both
+// failures carry the competing evidence. Map-local IDs, sides, filenames,
+// map names, scores, player names and clan names are never identity.
+func resolveSeriesTeams(inputs []SeriesMapInput) ([][2]int, error) {
+	type orientationCandidate struct {
+		orientation [][2]int
+		conflicts   []uint64
+	}
+	candidates := make([]orientationCandidate, 0, 1<<(len(inputs)-1))
+	var valid []orientationCandidate
+	for mask := 0; mask < 1<<(len(inputs)-1); mask++ {
+		orientation := make([][2]int, len(inputs))
+		orientation[0] = [2]int{1, 2}
+		for i := 1; i < len(inputs); i++ {
+			if mask&(1<<(i-1)) == 0 {
+				orientation[i] = [2]int{1, 2}
+			} else {
+				orientation[i] = [2]int{2, 1}
+			}
+		}
+		candidate := orientationCandidate{
+			orientation: orientation,
+			conflicts:   assignmentConflicts(inputs, orientation),
+		}
+		candidates = append(candidates, candidate)
+		if len(candidate.conflicts) == 0 {
+			valid = append(valid, candidate)
+		}
+	}
+	// The full evidence — every candidate's explicit local-to-series pairs —
+	// is only assembled for the two failure verdicts.
+	exportCandidates := func(list []orientationCandidate) []SeriesAssignmentCandidate {
+		out := make([]SeriesAssignmentCandidate, len(list))
+		for i, candidate := range list {
+			out[i] = SeriesAssignmentCandidate{
+				Assignments: assignmentPairs(inputs, candidate.orientation),
+				Conflicts:   candidate.conflicts,
+			}
+		}
+		return out
+	}
+	switch len(valid) {
+	case 1:
+		return valid[0].orientation, nil
+	case 0:
+		return nil, &SeriesTeamConflictError{Maps: seriesMapTeams(inputs), Candidates: exportCandidates(candidates)}
+	default:
+		return nil, &SeriesTeamAmbiguityError{Maps: seriesMapTeams(inputs), Candidates: exportCandidates(valid)}
+	}
+}
+
+// assignmentConflicts returns the SteamIDs the orientation would place on
+// both series teams, sorted ascending. Unioning every map — the first
+// included — means a roster overlap inside a single map also surfaces here.
+func assignmentConflicts(inputs []SeriesMapInput, orientation [][2]int) []uint64 {
+	rosters := [3]map[uint64]bool{{}, {}, {}}
+	for i, input := range inputs {
+		for t, team := range input.Demo.Teams {
+			for _, id := range team.Roster {
+				rosters[orientation[i][t]][id] = true
+			}
+		}
+	}
+	var conflicts []uint64
+	for id := range rosters[1] {
+		if rosters[2][id] {
+			conflicts = append(conflicts, id)
+		}
+	}
+	slices.Sort(conflicts)
+	return conflicts
+}
+
+func assignmentPairs(inputs []SeriesMapInput, orientation [][2]int) [][2]SeriesTeamAssignment {
+	pairs := make([][2]SeriesTeamAssignment, len(inputs))
+	for i, input := range inputs {
+		for t, team := range input.Demo.Teams {
+			pairs[i][t] = SeriesTeamAssignment{MapTeamID: team.TeamID, SeriesTeamID: orientation[i][t]}
+		}
+	}
+	return pairs
+}
+
+func seriesMapTeams(inputs []SeriesMapInput) []SeriesMapTeams {
+	out := make([]SeriesMapTeams, len(inputs))
+	for i, input := range inputs {
+		out[i] = SeriesMapTeams{
+			MapIndex: i,
+			TeamIDs:  [2]int{input.Demo.Teams[0].TeamID, input.Demo.Teams[1].TeamID},
+			Rosters: [2][]uint64{
+				slices.Clone(input.Demo.Teams[0].Roster),
+				slices.Clone(input.Demo.Teams[1].Roster),
+			},
+		}
+	}
+	return out
+}
+
+// seriesTally is what walking the maps in order produces: per-series-team
+// map and round wins (indexed by series team ID, slot 0 unused), each map's
+// winner in series terms, and the series winner.
+type seriesTally struct {
+	mapWins    [3]int
+	roundsWon  [3]int
+	mapWinners []int
+	winner     int
+}
+
+// seriesResults walks the maps in supplied order, translating each map's
+// winning local team into series terms and enforcing the completed-series
+// rule: the final supplied map must be the first point at which a team
+// reaches the clinch threshold, so a map after the clinch and a series
+// nobody clinched are both rejected.
+func seriesResults(inputs []SeriesMapInput, orientation [][2]int, bestOf, threshold int) (seriesTally, error) {
+	tally := seriesTally{mapWinners: make([]int, len(inputs))}
+	for i, input := range inputs {
+		teams := input.Demo.Teams
+		winnerIndex := 0
+		if teams[1].Score > teams[0].Score {
+			winnerIndex = 1
+		}
+		for t, team := range teams {
+			tally.roundsWon[orientation[i][t]] += team.Score
+		}
+		seriesWinner := orientation[i][winnerIndex]
+		tally.mapWins[seriesWinner]++
+		tally.mapWinners[i] = seriesWinner
+		if tally.mapWins[seriesWinner] >= threshold {
+			if i != len(inputs)-1 {
+				return seriesTally{}, fmt.Errorf(
+					"series team %d already clinched the best-of-%d %d:%d after %s; %s was supplied after the clinch",
+					seriesWinner, bestOf, tally.mapWins[seriesWinner], tally.mapWins[3-seriesWinner],
+					seriesMapLabel(i, input.Demo), seriesMapLabel(i+1, inputs[i+1].Demo))
+			}
+			tally.winner = seriesWinner
+		}
+	}
+	if tally.winner == 0 {
+		return seriesTally{}, fmt.Errorf(
+			"series is not complete: no team reached %d map wins in the best-of-%d (map score %d:%d)",
+			threshold, bestOf, tally.mapWins[1], tally.mapWins[2])
+	}
+	return tally, nil
+}
+
+// seriesTeamAcc accumulates one series team while the maps are walked once:
+// the union roster, the map-level display-name observations, and the union
+// of map-level aliases (a second tally reused purely for its ordered dedup).
+type seriesTeamAcc struct {
+	roster  map[uint64]bool
+	names   nameTally
+	aliases nameTally
+}
+
+func buildSeriesTeams(inputs []SeriesMapInput, orientation [][2]int, tally seriesTally) []SeriesTeam {
+	acc := [2]seriesTeamAcc{{roster: map[uint64]bool{}}, {roster: map[uint64]bool{}}}
+	for i, input := range inputs {
+		for t, team := range input.Demo.Teams {
+			teamAcc := &acc[orientation[i][t]-1]
+			for _, id := range team.Roster {
+				teamAcc.roster[id] = true
+			}
+			teamAcc.names.observe(team.Name)
+			for _, alias := range team.Aliases {
+				teamAcc.aliases.observe(alias)
+			}
+		}
+	}
+	teams := make([]SeriesTeam, len(acc))
+	for i, teamAcc := range acc {
+		teams[i] = SeriesTeam{
+			TeamID:    i + 1,
+			Name:      teamAcc.names.mostObserved(),
+			Aliases:   teamAcc.aliases.names(),
+			MapsWon:   tally.mapWins[i+1],
+			RoundsWon: tally.roundsWon[i+1],
+			Roster:    slices.Sorted(maps.Keys(teamAcc.roster)),
+		}
+	}
+	return teams
+}
+
+func buildSeriesMaps(inputs []SeriesMapInput, orientation [][2]int, mapWinners []int) []SeriesMap {
+	pairs := assignmentPairs(inputs, orientation)
+	out := make([]SeriesMap, len(inputs))
+	for i, input := range inputs {
+		out[i] = SeriesMap{
+			SHA256:          input.SHA256,
+			WinnerTeamID:    mapWinners[i],
+			TeamAssignments: pairs[i][:],
+			Analysis:        input.Demo,
+		}
+	}
+	return out
+}
+
+// seriesPlayerAgg accumulates one player across maps before the derived
+// stats are computed.
+type seriesPlayerAgg struct {
+	player *SeriesPlayer
+	names  nameTally
+	facts  playerAggFacts
+	// factsKnown stays true only while every map the player appears in
+	// carries raw aggregation facts, i.e. was produced by ProcessDemo.
+	factsKnown bool
+}
+
+func buildSeriesPlayers(inputs []SeriesMapInput, teams []SeriesTeam) map[uint64]*SeriesPlayer {
+	teamOf := make(map[uint64]int)
+	for _, team := range teams {
+		for _, id := range team.Roster {
+			teamOf[id] = team.TeamID
+		}
+	}
+
+	aggregates := make(map[uint64]*seriesPlayerAgg)
+	for _, input := range inputs {
+		demo := input.Demo
+		participants := make(map[uint64]bool)
+		for _, team := range demo.Teams {
+			for _, id := range team.Roster {
+				participants[id] = true
+			}
+		}
+		for id, mapPlayer := range demo.Players {
+			agg := aggregates[id]
+			if agg == nil {
+				agg = &seriesPlayerAgg{
+					player: &SeriesPlayer{
+						SteamID:   id,
+						KillStats: KillStats{WeaponsKills: make(map[string]int)},
+					},
+					factsKnown: true,
+				}
+				aggregates[id] = agg
+			}
+			agg.names.observe(mapPlayer.Name)
+			if participants[id] {
+				agg.player.MapsPlayed++
+				agg.player.Rounds += demo.Map.TotalRounds
+			}
+			agg.player.addMapStats(mapPlayer)
+			if demo.aggFacts == nil {
+				agg.factsKnown = false
+			} else {
+				agg.facts.add(demo.aggFacts[id])
+			}
+		}
+	}
+
+	players := make(map[uint64]*SeriesPlayer, len(aggregates))
+	for id, agg := range aggregates {
+		agg.player.Name = agg.names.mostObserved()
+		agg.player.Aliases = agg.names.names()
+		agg.player.TeamID = teamOf[id]
+		agg.player.deriveSeriesStats(agg.facts, agg.factsKnown)
+		players[id] = agg.player
+	}
+	return players
+}
+
+func (f *playerAggFacts) add(other playerAggFacts) {
+	f.kastRounds.addCounts(other.kastRounds)
+	f.sideDamage.addCounts(other.sideDamage)
+	f.openingWins += other.openingWins
+	f.ecoKills += other.ecoKills
+	f.ecoDamage += other.ecoDamage
+	f.ecoSurvival += other.ecoSurvival
+	f.ecoKast += other.ecoKast
+	f.roundSwing += other.roundSwing
+}
+
+// addMapStats folds one map's additive facts into the aggregate. Derived
+// rates are left alone here: they are recomputed afterwards from exact
+// summed numerators.
+func (sp *SeriesPlayer) addMapStats(mp *DemoPlayer) {
+	sp.Deaths += mp.Deaths
+	sp.DeathsTraded.addCounts(mp.DeathsTraded)
+
+	sp.KillStats.Total += mp.KillStats.Total
+	sp.KillStats.HeadShots += mp.KillStats.HeadShots
+	sp.KillStats.TradeKills += mp.KillStats.TradeKills
+	sp.KillStats.TeamKills += mp.KillStats.TeamKills
+	for weapon, kills := range mp.KillStats.WeaponsKills {
+		sp.KillStats.WeaponsKills[weapon] += kills
+	}
+
+	sp.AssistStats.Total += mp.AssistStats.Total
+	sp.AssistStats.FlashedEnemies += mp.AssistStats.FlashedEnemies
+	sp.AssistStats.DamageGiven += mp.AssistStats.DamageGiven
+
+	sp.PlayerStats.MVPs += mp.PlayerMapStats.MVPs
+	sp.PlayerStats.ACEs += mp.PlayerMapStats.ACEs
+	sp.PlayerStats.MultiKills.K2 += mp.PlayerMapStats.MultiKills.K2
+	sp.PlayerStats.MultiKills.K3 += mp.PlayerMapStats.MultiKills.K3
+	sp.PlayerStats.MultiKills.K4 += mp.PlayerMapStats.MultiKills.K4
+	sp.PlayerStats.MultiKills.K5 += mp.PlayerMapStats.MultiKills.K5
+	sp.PlayerStats.ClutchesWon += mp.PlayerMapStats.ClutchesWon
+
+	sp.OpeningDuelStats.OpeningKills.addCounts(mp.OpeningDuelStats.OpeningKills)
+	sp.OpeningDuelStats.OpeningDeaths.addCounts(mp.OpeningDuelStats.OpeningDeaths)
+
+	sp.SideStats.Rounds.addCounts(mp.SideStats.Rounds)
+	sp.SideStats.Kills.addCounts(mp.SideStats.Kills)
+	sp.SideStats.Deaths.addCounts(mp.SideStats.Deaths)
+
+	sp.UtilityStats.EnemiesFlashed += mp.UtilityStats.EnemiesFlashed
+	sp.UtilityStats.FriendsFlashed += mp.UtilityStats.FriendsFlashed
+	sp.UtilityStats.EnemyFlashTimeSeconds += mp.UtilityStats.EnemyFlashTimeSeconds
+	sp.UtilityStats.UtilityDamage.Total += mp.UtilityStats.UtilityDamage.Total
+	sp.UtilityStats.UtilityDamage.HE += mp.UtilityStats.UtilityDamage.HE
+	sp.UtilityStats.UtilityDamage.Fire += mp.UtilityStats.UtilityDamage.Fire
+	sp.UtilityStats.GrenadesThrown.Total += mp.UtilityStats.GrenadesThrown.Total
+	sp.UtilityStats.GrenadesThrown.Flash += mp.UtilityStats.GrenadesThrown.Flash
+	sp.UtilityStats.GrenadesThrown.Smoke += mp.UtilityStats.GrenadesThrown.Smoke
+	sp.UtilityStats.GrenadesThrown.HE += mp.UtilityStats.GrenadesThrown.HE
+	sp.UtilityStats.GrenadesThrown.Molotov += mp.UtilityStats.GrenadesThrown.Molotov
+	sp.UtilityStats.GrenadesThrown.Incendiary += mp.UtilityStats.GrenadesThrown.Incendiary
+	sp.UtilityStats.GrenadesThrown.Decoy += mp.UtilityStats.GrenadesThrown.Decoy
+	sp.UtilityStats.UnusedUtilityValue += mp.UtilityStats.UnusedUtilityValue
+}
+
+func (sp *SeriesPlayer) statRefs() statRefs {
+	return statRefs{
+		kills:   &sp.KillStats,
+		assists: &sp.AssistStats,
+		stats:   &sp.PlayerStats,
+		opening: &sp.OpeningDuelStats,
+		side:    &sp.SideStats,
+		utility: &sp.UtilityStats,
+	}
+}
+
+// deriveSeriesStats runs the same deriveStats formulas a single map's derive
+// uses, with the player's series round count as the match-wide denominator.
+// When raw facts are unavailable (a map not produced by ProcessDemo), the
+// fact-based values read 0 and the rating stays nil rather than being
+// reconstructed from rounded per-map output.
+func (sp *SeriesPlayer) deriveSeriesStats(facts playerAggFacts, factsKnown bool) {
+	rating, rated := deriveStats(sp.statRefs(), facts, sp.Rounds)
+	if rated && factsKnown {
+		sp.Rating = &rating
+	}
+}
+
+// SelectSeriesPlayers resolves requested names against the aggregate
+// players' collected aliases, case-insensitively, once cross-map identity
+// and alias collection are done. Duplicate requests count once. Selection is
+// all-or-nothing: a name matching no player fails listing every available
+// player, and a name matching more than one SteamID fails with a
+// PlayerAliasAmbiguityError carrying the sorted candidates. The returned set
+// only narrows rendering and saving; it never feeds back into team
+// resolution or aggregation.
+func SelectSeriesPlayers(series *ProcessedSeries, requestedNames []string) (map[uint64]bool, error) {
+	selected := make(map[uint64]bool)
+	var unmatched []string
+	for _, name := range distinctNamesFold(requestedNames) {
+		var matches []uint64
+		for id, player := range series.Players {
+			hasAlias := slices.ContainsFunc(player.Aliases, func(alias string) bool {
+				return strings.EqualFold(alias, name)
+			})
+			if hasAlias {
+				matches = append(matches, id)
+			}
+		}
+		slices.Sort(matches)
+		switch len(matches) {
+		case 0:
+			unmatched = append(unmatched, name)
+		case 1:
+			selected[matches[0]] = true
+		default:
+			return nil, &PlayerAliasAmbiguityError{Alias: name, SteamIDs: matches}
+		}
+	}
+	if len(unmatched) > 0 {
+		return nil, fmt.Errorf("players not found in series: %s; available players: %s",
+			strings.Join(unmatched, ", "), strings.Join(seriesPlayerNames(series), ", "))
+	}
+	return selected, nil
+}
+
+// seriesPlayerNames lists every aggregate player for selection errors,
+// sorted; a player the demos never named is listed by SteamID.
+func seriesPlayerNames(series *ProcessedSeries) []string {
+	names := make([]string, 0, len(series.Players))
+	for id, player := range series.Players {
+		if player.Name != "" {
+			names = append(names, player.Name)
+		} else {
+			names = append(names, strconv.FormatUint(id, 10))
+		}
+	}
+	slices.Sort(names)
+	return names
+}
+
+// FilterSeriesPlayers returns a copy of the series narrowed to the selected
+// SteamIDs: the aggregate players and each map's standalone players are
+// filtered, while teams, rosters, scores, map results and team assignments
+// stay complete. The input series and its maps are not mutated.
+func FilterSeriesPlayers(series *ProcessedSeries, selected map[uint64]bool) *ProcessedSeries {
+	filtered := *series
+	filtered.Players = make(map[uint64]*SeriesPlayer, len(selected))
+	for id, player := range series.Players {
+		if selected[id] {
+			filtered.Players[id] = player
+		}
+	}
+	filtered.Maps = make([]SeriesMap, len(series.Maps))
+	for i, seriesMap := range series.Maps {
+		analysis := *seriesMap.Analysis
+		analysis.Players = make(map[uint64]*DemoPlayer, len(selected))
+		for id, player := range seriesMap.Analysis.Players {
+			if selected[id] {
+				analysis.Players[id] = player
+			}
+		}
+		seriesMap.Analysis = &analysis
+		filtered.Maps[i] = seriesMap
+	}
+	return &filtered
+}

--- a/cmd/demo_parser/series_test.go
+++ b/cmd/demo_parser/series_test.go
@@ -1,0 +1,805 @@
+package demoparser
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// testTeam describes one logical team of a synthetic series map.
+type testTeam struct {
+	id     int
+	name   string
+	roster []uint64
+	score  int
+}
+
+// rosterA and rosterB are the two default lineups of the synthetic series.
+var (
+	rosterA = []uint64{1, 2, 3, 4, 5}
+	rosterB = []uint64{6, 7, 8, 9, 10}
+)
+
+// testMapDemo builds a minimal parsed map: the given logical teams, one
+// player per rostered SteamID named "player-<id>", and a round total equal
+// to the score sum. It deliberately has no aggFacts, like any ProcessedDemo
+// a test constructs by hand.
+func testMapDemo(mapName string, teams ...testTeam) *ProcessedDemo {
+	demo := &ProcessedDemo{
+		Players: map[uint64]*DemoPlayer{},
+		Map:     MapData{MapName: mapName},
+	}
+	for _, team := range teams {
+		aliases := []string{}
+		if team.name != "" {
+			aliases = []string{team.name}
+		}
+		demo.Teams = append(demo.Teams, DemoTeam{
+			TeamID:  team.id,
+			Name:    team.name,
+			Aliases: aliases,
+			Score:   team.score,
+			Roster:  sortedIDs(team.roster),
+		})
+		demo.Map.TotalRounds += team.score
+		for _, id := range team.roster {
+			demo.Players[id] = &DemoPlayer{
+				SteamID:   id,
+				Name:      fmt.Sprintf("player-%d", id),
+				TeamID:    team.id,
+				KillStats: KillStats{WeaponsKills: map[string]int{}},
+			}
+		}
+	}
+	return demo
+}
+
+// abMap is a standard map between the two default lineups: team 1 is A,
+// team 2 is B, named after their lineup.
+func abMap(mapName string, scoreA, scoreB int) *ProcessedDemo {
+	return testMapDemo(mapName,
+		testTeam{id: 1, name: "Alpha", roster: rosterA, score: scoreA},
+		testTeam{id: 2, name: "Bravo", roster: rosterB, score: scoreB})
+}
+
+func seriesInputs(demos ...*ProcessedDemo) []SeriesMapInput {
+	inputs := make([]SeriesMapInput, len(demos))
+	for i, demo := range demos {
+		inputs[i] = SeriesMapInput{Demo: demo, SHA256: fmt.Sprintf("digest-%d", i+1)}
+	}
+	return inputs
+}
+
+func TestBuildSeriesCompletedPaths(t *testing.T) {
+	tests := []struct {
+		name       string
+		bestOf     int
+		scores     [][2]int // per map: rounds of lineup A and lineup B
+		wantWinner int      // series team ID: 1 is lineup A, 2 is lineup B
+		wantMaps   [2]int
+		wantRounds [2]int
+	}{
+		{name: "bo3 2-0", bestOf: 3, scores: [][2]int{{13, 9}, {13, 11}}, wantWinner: 1, wantMaps: [2]int{2, 0}, wantRounds: [2]int{26, 20}},
+		{name: "bo3 2-1", bestOf: 3, scores: [][2]int{{13, 9}, {7, 13}, {10, 13}}, wantWinner: 2, wantMaps: [2]int{1, 2}, wantRounds: [2]int{30, 35}},
+		{name: "bo5 3-0", bestOf: 5, scores: [][2]int{{13, 9}, {13, 10}, {13, 11}}, wantWinner: 1, wantMaps: [2]int{3, 0}, wantRounds: [2]int{39, 30}},
+		{name: "bo5 3-1", bestOf: 5, scores: [][2]int{{13, 9}, {9, 13}, {13, 10}, {13, 11}}, wantWinner: 1, wantMaps: [2]int{3, 1}, wantRounds: [2]int{48, 43}},
+		{name: "bo5 3-2", bestOf: 5, scores: [][2]int{{13, 9}, {9, 13}, {13, 10}, {11, 13}, {16, 13}}, wantWinner: 1, wantMaps: [2]int{3, 2}, wantRounds: [2]int{62, 58}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			demos := make([]*ProcessedDemo, len(test.scores))
+			for i, score := range test.scores {
+				demos[i] = abMap(fmt.Sprintf("de_map%d", i+1), score[0], score[1])
+			}
+			series, err := BuildSeries(test.bestOf, seriesInputs(demos...))
+			if err != nil {
+				t.Fatalf("BuildSeries: %v", err)
+			}
+			if series.BestOf != test.bestOf {
+				t.Errorf("best_of = %d, want %d", series.BestOf, test.bestOf)
+			}
+			if series.WinnerTeamID != test.wantWinner {
+				t.Errorf("winner = %d, want %d", series.WinnerTeamID, test.wantWinner)
+			}
+			for i, team := range series.Teams {
+				if team.TeamID != i+1 {
+					t.Errorf("teams[%d].TeamID = %d, want %d", i, team.TeamID, i+1)
+				}
+				if team.MapsWon != test.wantMaps[i] {
+					t.Errorf("team %d maps won = %d, want %d", team.TeamID, team.MapsWon, test.wantMaps[i])
+				}
+				if team.RoundsWon != test.wantRounds[i] {
+					t.Errorf("team %d rounds won = %d, want %d", team.TeamID, team.RoundsWon, test.wantRounds[i])
+				}
+			}
+			if got := series.Teams[0].Roster; !slices.Equal(got, rosterA) {
+				t.Errorf("team 1 roster = %v, want %v", got, rosterA)
+			}
+			if got := series.Teams[1].Roster; !slices.Equal(got, rosterB) {
+				t.Errorf("team 2 roster = %v, want %v", got, rosterB)
+			}
+			for i, seriesMap := range series.Maps {
+				if seriesMap.SHA256 != fmt.Sprintf("digest-%d", i+1) {
+					t.Errorf("maps[%d].sha256 = %q, want digest-%d", i, seriesMap.SHA256, i+1)
+				}
+				if got, want := seriesMap.Analysis.Map.MapName, fmt.Sprintf("de_map%d", i+1); got != want {
+					t.Errorf("maps[%d] analysis = %q, want %q; map order must be preserved", i, got, want)
+				}
+				wantMapWinner := 1
+				if test.scores[i][1] > test.scores[i][0] {
+					wantMapWinner = 2
+				}
+				if seriesMap.WinnerTeamID != wantMapWinner {
+					t.Errorf("maps[%d].winner_team_id = %d, want %d", i, seriesMap.WinnerTeamID, wantMapWinner)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildSeriesRejectsInvalidFormats(t *testing.T) {
+	m1, m2 := abMap("de_one", 13, 9), abMap("de_two", 13, 10)
+	tests := []struct {
+		name    string
+		bestOf  int
+		inputs  []SeriesMapInput
+		wantErr string
+	}{
+		{name: "best-of 4", bestOf: 4, inputs: seriesInputs(m1, m2), wantErr: "invalid best-of 4"},
+		{name: "bo3 one map", bestOf: 3, inputs: seriesInputs(m1), wantErr: "2 or 3 maps, got 1"},
+		{name: "bo3 four maps", bestOf: 3, inputs: seriesInputs(m1, m2, abMap("de_three", 13, 9), abMap("de_four", 13, 9)), wantErr: "2 or 3 maps, got 4"},
+		{name: "bo5 two maps", bestOf: 5, inputs: seriesInputs(m1, m2), wantErr: "3, 4 or 5 maps, got 2"},
+		{name: "no maps", bestOf: 3, inputs: nil, wantErr: "2 or 3 maps, got 0"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := BuildSeries(test.bestOf, test.inputs)
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("BuildSeries error = %v, want it to contain %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuildSeriesRejectsIncompleteSeries(t *testing.T) {
+	_, err := BuildSeries(3, seriesInputs(abMap("de_one", 13, 9), abMap("de_two", 9, 13)))
+	if err == nil || !strings.Contains(err.Error(), "not complete") {
+		t.Fatalf("BuildSeries error = %v, want incomplete-series rejection", err)
+	}
+	_, err = BuildSeries(5, seriesInputs(abMap("de_one", 13, 9), abMap("de_two", 9, 13), abMap("de_three", 13, 9)))
+	if err == nil || !strings.Contains(err.Error(), "not complete") {
+		t.Fatalf("BuildSeries error = %v, want incomplete-series rejection", err)
+	}
+}
+
+func TestBuildSeriesRejectsMapsAfterClinch(t *testing.T) {
+	_, err := BuildSeries(3, seriesInputs(abMap("de_one", 13, 9), abMap("de_two", 13, 10), abMap("de_three", 9, 13)))
+	if err == nil || !strings.Contains(err.Error(), "after the clinch") {
+		t.Fatalf("BuildSeries error = %v, want after-clinch rejection", err)
+	}
+	_, err = BuildSeries(5, seriesInputs(
+		abMap("de_one", 13, 9), abMap("de_two", 13, 10), abMap("de_three", 13, 11), abMap("de_four", 9, 13)))
+	if err == nil || !strings.Contains(err.Error(), "after the clinch") {
+		t.Fatalf("BuildSeries error = %v, want after-clinch rejection", err)
+	}
+}
+
+func TestBuildSeriesRejectsDuplicateContent(t *testing.T) {
+	inputs := seriesInputs(abMap("de_one", 13, 9), abMap("de_two", 13, 10))
+	inputs[1].SHA256 = inputs[0].SHA256
+	_, err := BuildSeries(3, inputs)
+	if err == nil || !strings.Contains(err.Error(), "same demo") {
+		t.Fatalf("BuildSeries error = %v, want duplicate-content rejection", err)
+	}
+}
+
+func TestBuildSeriesRejectsInvalidMaps(t *testing.T) {
+	oneTeam := testMapDemo("de_solo", testTeam{id: 1, name: "Alpha", roster: rosterA, score: 13})
+	tied := abMap("de_tied", 12, 12)
+	badRounds := abMap("de_short", 13, 9)
+	badRounds.Map.TotalRounds = 30
+	emptyRoster := abMap("de_empty", 13, 9)
+	emptyRoster.Teams[1].Roster = nil
+	// A completed Wingman map passes every consistency check — nonempty
+	// rosters, untied scores summing to the rounds — and is rejected only
+	// by the 5v5 shape rule.
+	wingman := testMapDemo("de_wingman",
+		testTeam{id: 1, name: "Duo", roster: []uint64{1, 2}, score: 9},
+		testTeam{id: 2, name: "Pair", roster: []uint64{6, 7}, score: 5})
+	unknownTeamRef := abMap("de_unknown", 13, 9)
+	unknownTeamRef.Players[1].TeamID = 7
+	noDigest := seriesInputs(abMap("de_one", 13, 9), abMap("de_two", 13, 10))
+	noDigest[1].SHA256 = ""
+	// A casual demo can field two stable 5v5-sized lineups, so the named
+	// mode alone must reject it.
+	casual := abMap("de_casual", 13, 9)
+	casual.GameMode = "casual"
+	// An unknown-mode 10v10 passes the mode gate and the roster lower
+	// bound; only the per-round participation ceiling catches it.
+	crowdedA, crowdedB := make([]uint64, 10), make([]uint64, 10)
+	for i := range crowdedA {
+		crowdedA[i], crowdedB[i] = uint64(31+i), uint64(41+i)
+	}
+	crowded := testMapDemo("de_crowded",
+		testTeam{id: 1, name: "Herd", roster: crowdedA, score: 13},
+		testTeam{id: 2, name: "Flock", roster: crowdedB, score: 9})
+	for _, player := range crowded.Players {
+		player.SideStats.Rounds.Total = crowded.Map.TotalRounds
+	}
+
+	closer := abMap("de_two", 13, 10)
+	tests := []struct {
+		name    string
+		inputs  []SeriesMapInput
+		wantErr string
+	}{
+		{name: "one logical team", inputs: seriesInputs(oneTeam, closer), wantErr: "1 logical teams"},
+		{name: "tied map", inputs: seriesInputs(tied, closer), wantErr: "tied 12:12"},
+		{name: "scores disagree with rounds", inputs: seriesInputs(badRounds, closer), wantErr: "do not add up"},
+		{name: "empty roster", inputs: seriesInputs(emptyRoster, closer), wantErr: "only the competitive 5v5 format"},
+		{name: "wingman map", inputs: seriesInputs(wingman, closer), wantErr: "only the competitive 5v5 format"},
+		{name: "casual mode", inputs: seriesInputs(casual, closer), wantErr: `game mode "casual"`},
+		{name: "oversized unknown-mode lobby", inputs: seriesInputs(crowded, closer), wantErr: "more than a 5v5 lobby"},
+		{name: "unknown player team id", inputs: seriesInputs(unknownTeamRef, closer), wantErr: "unknown map team ID 7"},
+		{name: "missing demo", inputs: []SeriesMapInput{{SHA256: "d1"}, {Demo: closer, SHA256: "d2"}}, wantErr: "no parsed demo"},
+		{name: "missing digest", inputs: noDigest, wantErr: "no SHA-256 digest"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := BuildSeries(3, test.inputs)
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("BuildSeries error = %v, want it to contain %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+// TestBuildSeriesResolvesSwappedLocalIDs pins that map-local team numbering
+// and side order carry no identity: map 2 lists lineup B first under team ID
+// 1, and the assignment still crosses back through the rosters.
+func TestBuildSeriesResolvesSwappedLocalIDs(t *testing.T) {
+	m1 := abMap("de_one", 13, 9)
+	m2 := testMapDemo("de_two",
+		testTeam{id: 1, name: "Bravo", roster: rosterB, score: 11},
+		testTeam{id: 2, name: "Alpha", roster: rosterA, score: 13})
+	series, err := BuildSeries(3, seriesInputs(m1, m2))
+	if err != nil {
+		t.Fatalf("BuildSeries: %v", err)
+	}
+	if series.WinnerTeamID != 1 {
+		t.Errorf("winner = %d, want lineup A as series team 1", series.WinnerTeamID)
+	}
+	wantAssignments := []SeriesTeamAssignment{
+		{MapTeamID: 1, SeriesTeamID: 2},
+		{MapTeamID: 2, SeriesTeamID: 1},
+	}
+	if got := series.Maps[1].TeamAssignments; !reflect.DeepEqual(got, wantAssignments) {
+		t.Errorf("map 2 assignments = %+v, want %+v", got, wantAssignments)
+	}
+	if got := series.Teams[0].Roster; !slices.Equal(got, rosterA) {
+		t.Errorf("team 1 roster = %v, want lineup A %v", got, rosterA)
+	}
+}
+
+// TestBuildSeriesSubstitutionJoinsExistingTeam pins that a roster addition
+// is a substitute on the same series team, not a new team.
+func TestBuildSeriesSubstitutionJoinsExistingTeam(t *testing.T) {
+	m1 := abMap("de_one", 13, 9)
+	m2 := testMapDemo("de_two",
+		testTeam{id: 1, name: "Alpha", roster: []uint64{1, 2, 3, 4, 11}, score: 13},
+		testTeam{id: 2, name: "Bravo", roster: rosterB, score: 10})
+	series, err := BuildSeries(3, seriesInputs(m1, m2))
+	if err != nil {
+		t.Fatalf("BuildSeries: %v", err)
+	}
+	wantRoster := []uint64{1, 2, 3, 4, 5, 11}
+	if got := series.Teams[0].Roster; !slices.Equal(got, wantRoster) {
+		t.Errorf("team 1 roster = %v, want the substitute unioned in: %v", got, wantRoster)
+	}
+	substitute := series.Players[11]
+	if substitute == nil {
+		t.Fatal("substitute missing from aggregate players")
+	}
+	if substitute.TeamID != 1 {
+		t.Errorf("substitute team = %d, want 1", substitute.TeamID)
+	}
+	if substitute.MapsPlayed != 1 || substitute.Rounds != 23 {
+		t.Errorf("substitute maps/rounds = %d/%d, want 1/23", substitute.MapsPlayed, substitute.Rounds)
+	}
+}
+
+// TestBuildSeriesJointAssignmentBeatsGreedyMatching pins the joint
+// evaluation requirement: map 2 is played entirely by two full squads of
+// substitutes and shares no SteamID with map 1, so alone it is ambiguous;
+// map 3 ties one substitute of each squad back to a lineup, which makes
+// exactly one global assignment valid. A greedy map-by-map matcher would
+// have failed on map 2.
+func TestBuildSeriesJointAssignmentBeatsGreedyMatching(t *testing.T) {
+	subsA := []uint64{21, 22, 23, 24, 25}
+	subsB := []uint64{26, 27, 28, 29, 30}
+	m1 := abMap("de_one", 13, 9)
+	m2 := testMapDemo("de_two",
+		testTeam{id: 1, name: "", roster: subsB, score: 13},
+		testTeam{id: 2, name: "", roster: subsA, score: 11})
+	m3 := testMapDemo("de_three",
+		testTeam{id: 1, name: "Alpha", roster: []uint64{1, 2, 3, 4, 21}, score: 10},
+		testTeam{id: 2, name: "Bravo", roster: []uint64{6, 7, 8, 9, 26}, score: 13})
+	series, err := BuildSeries(3, seriesInputs(m1, m2, m3))
+	if err != nil {
+		t.Fatalf("BuildSeries: %v", err)
+	}
+	if series.WinnerTeamID != 2 {
+		t.Errorf("winner = %d, want 2", series.WinnerTeamID)
+	}
+	if got, want := series.Teams[0].Roster, []uint64{1, 2, 3, 4, 5, 21, 22, 23, 24, 25}; !slices.Equal(got, want) {
+		t.Errorf("team 1 roster = %v, want %v", got, want)
+	}
+	if got, want := series.Teams[1].Roster, []uint64{6, 7, 8, 9, 10, 26, 27, 28, 29, 30}; !slices.Equal(got, want) {
+		t.Errorf("team 2 roster = %v, want %v", got, want)
+	}
+	wantAssignments := []SeriesTeamAssignment{
+		{MapTeamID: 1, SeriesTeamID: 2},
+		{MapTeamID: 2, SeriesTeamID: 1},
+	}
+	if got := series.Maps[1].TeamAssignments; !reflect.DeepEqual(got, wantAssignments) {
+		t.Errorf("map 2 assignments = %+v, want %+v", got, wantAssignments)
+	}
+}
+
+func TestBuildSeriesConflictIsStructuredError(t *testing.T) {
+	m1 := abMap("de_one", 13, 9)
+	// Map 2 mixes the lineups: each roster holds players from both of map
+	// 1's teams, so every orientation places someone on both series teams.
+	m2 := testMapDemo("de_two",
+		testTeam{id: 1, name: "Mixed", roster: []uint64{1, 2, 3, 4, 6}, score: 13},
+		testTeam{id: 2, name: "Rest", roster: []uint64{5, 7, 8, 9, 10}, score: 10})
+	_, err := BuildSeries(3, seriesInputs(m1, m2))
+	var conflict *SeriesTeamConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("BuildSeries error = %v, want a *SeriesTeamConflictError", err)
+	}
+	if len(conflict.Maps) != 2 || len(conflict.Candidates) != 2 {
+		t.Fatalf("conflict carries %d maps and %d candidates, want 2 and 2", len(conflict.Maps), len(conflict.Candidates))
+	}
+	if conflict.Maps[1].MapIndex != 1 || conflict.Maps[1].TeamIDs != [2]int{1, 2} {
+		t.Errorf("conflict map evidence = %+v, want map index 1 with team IDs [1 2]", conflict.Maps[1])
+	}
+	for i, candidate := range conflict.Candidates {
+		if len(candidate.Conflicts) == 0 {
+			t.Errorf("candidate %d has no conflicting SteamIDs; a conflict error requires all candidates to fail", i)
+		}
+		if len(candidate.Assignments) != 2 {
+			t.Errorf("candidate %d covers %d maps, want 2", i, len(candidate.Assignments))
+		}
+	}
+}
+
+// TestBuildSeriesAmbiguityIsStructuredError pins two rules at once: fully
+// disjoint rosters leave both orientations valid, and identical clan names
+// on map 2 must not break the tie, because names are labels, not identity.
+func TestBuildSeriesAmbiguityIsStructuredError(t *testing.T) {
+	m1 := abMap("de_one", 13, 9)
+	m2 := testMapDemo("de_two",
+		testTeam{id: 1, name: "Alpha", roster: []uint64{11, 12, 13, 14, 15}, score: 13},
+		testTeam{id: 2, name: "Bravo", roster: []uint64{16, 17, 18, 19, 20}, score: 10})
+	_, err := BuildSeries(3, seriesInputs(m1, m2))
+	var ambiguity *SeriesTeamAmbiguityError
+	if !errors.As(err, &ambiguity) {
+		t.Fatalf("BuildSeries error = %v, want a *SeriesTeamAmbiguityError", err)
+	}
+	if len(ambiguity.Candidates) != 2 {
+		t.Fatalf("ambiguity carries %d candidates, want the 2 competing assignments", len(ambiguity.Candidates))
+	}
+	for i, candidate := range ambiguity.Candidates {
+		if len(candidate.Conflicts) != 0 {
+			t.Errorf("candidate %d has conflicts %v, want none for a valid candidate", i, candidate.Conflicts)
+		}
+	}
+	if len(ambiguity.Maps) != 2 || !slices.Equal(ambiguity.Maps[1].Rosters[0], []uint64{11, 12, 13, 14, 15}) {
+		t.Errorf("ambiguity map evidence = %+v, want map 2 rosters", ambiguity.Maps)
+	}
+}
+
+// TestBuildSeriesClanNamesAreLabels pins alias behavior when a lineup is
+// relabeled mid-series: identity still follows rosters, every observed name
+// is kept in first-observation order, and the display name is the
+// most-observed one with the first observation breaking ties.
+func TestBuildSeriesClanNamesAreLabels(t *testing.T) {
+	m1 := abMap("de_one", 13, 9)
+	m2 := testMapDemo("de_two",
+		testTeam{id: 1, name: "Alpha GG", roster: rosterA, score: 9},
+		testTeam{id: 2, name: "Bravo", roster: rosterB, score: 13})
+	m3 := testMapDemo("de_three",
+		testTeam{id: 1, name: "Alpha GG", roster: rosterA, score: 7},
+		testTeam{id: 2, name: "Bravo", roster: rosterB, score: 13})
+	series, err := BuildSeries(3, seriesInputs(m1, m2, m3))
+	if err != nil {
+		t.Fatalf("BuildSeries: %v", err)
+	}
+	teamOne := series.Teams[0]
+	if !slices.Equal(teamOne.Aliases, []string{"Alpha", "Alpha GG"}) {
+		t.Errorf("team 1 aliases = %v, want first-observation order [Alpha, Alpha GG]", teamOne.Aliases)
+	}
+	if teamOne.Name != "Alpha GG" {
+		t.Errorf("team 1 name = %q, want the most-observed %q", teamOne.Name, "Alpha GG")
+	}
+	if series.Teams[1].Name != "Bravo" {
+		t.Errorf("team 2 name = %q, want %q", series.Teams[1].Name, "Bravo")
+	}
+}
+
+func TestBuildSeriesAggregatesAdditiveStatsExactly(t *testing.T) {
+	m1 := abMap("de_one", 13, 9)
+	m2 := abMap("de_two", 13, 10)
+	statsOne := &DemoPlayer{
+		SteamID: 1, Name: "player-1", UserID: 3, TeamID: 1,
+		Deaths:       12,
+		DeathsTraded: SideCount{Total: 3, CT: 2, T: 1},
+		KillStats: KillStats{
+			Total: 20, HeadShots: 9, WeaponsKills: map[string]int{"AK-47": 12, "AWP": 8},
+			TradeKills: 4, TeamKills: 1,
+		},
+		AssistStats: AssistStats{Total: 5, FlashedEnemies: 2, DamageGiven: 1800},
+		PlayerMapStats: PlayerMapStats{
+			MVPs: 3, ACEs: 1, MultiKills: MultiKillRounds{K2: 3, K3: 1, K5: 1}, ClutchesWon: 2,
+		},
+		OpeningDuelStats: OpeningDuelStats{
+			OpeningKills:  SideCount{Total: 4, CT: 3, T: 1},
+			OpeningDeaths: SideCount{Total: 2, CT: 1, T: 1},
+		},
+		SideStats: SideStats{
+			Rounds: SideCount{Total: 22, CT: 12, T: 10},
+			Kills:  SideCount{Total: 20, CT: 11, T: 9},
+			Deaths: SideCount{Total: 12, CT: 5, T: 7},
+		},
+		UtilityStats: UtilityStats{
+			EnemiesFlashed: 6, FriendsFlashed: 2, EnemyFlashTimeSeconds: 10.5,
+			UtilityDamage:      UtilityDamageStats{Total: 90, HE: 60, Fire: 30},
+			GrenadesThrown:     GrenadesThrownStats{Total: 15, Flash: 5, Smoke: 4, HE: 3, Molotov: 2, Incendiary: 1},
+			UnusedUtilityValue: 900,
+		},
+	}
+	statsTwo := &DemoPlayer{
+		SteamID: 1, Name: "player-1-alt", UserID: 8, TeamID: 1,
+		Deaths:       10,
+		DeathsTraded: SideCount{Total: 2, CT: 1, T: 1},
+		KillStats: KillStats{
+			Total: 15, HeadShots: 6, WeaponsKills: map[string]int{"AK-47": 10, "Desert Eagle": 5},
+			TradeKills: 2, TeamKills: 0,
+		},
+		AssistStats: AssistStats{Total: 7, FlashedEnemies: 1, DamageGiven: 1500},
+		PlayerMapStats: PlayerMapStats{
+			MVPs: 2, ACEs: 0, MultiKills: MultiKillRounds{K2: 2, K4: 1}, ClutchesWon: 1,
+		},
+		OpeningDuelStats: OpeningDuelStats{
+			OpeningKills:  SideCount{Total: 3, CT: 1, T: 2},
+			OpeningDeaths: SideCount{Total: 4, CT: 2, T: 2},
+		},
+		SideStats: SideStats{
+			Rounds: SideCount{Total: 23, CT: 11, T: 12},
+			Kills:  SideCount{Total: 15, CT: 7, T: 8},
+			Deaths: SideCount{Total: 10, CT: 6, T: 4},
+		},
+		UtilityStats: UtilityStats{
+			EnemiesFlashed: 4, FriendsFlashed: 1, EnemyFlashTimeSeconds: 5.25,
+			UtilityDamage:      UtilityDamageStats{Total: 40, HE: 10, Fire: 30},
+			GrenadesThrown:     GrenadesThrownStats{Total: 11, Flash: 4, Smoke: 3, HE: 2, Molotov: 1, Incendiary: 0, Decoy: 1},
+			UnusedUtilityValue: 400,
+		},
+	}
+	m1.Players[1] = statsOne
+	m2.Players[1] = statsTwo
+
+	series, err := BuildSeries(3, seriesInputs(m1, m2))
+	if err != nil {
+		t.Fatalf("BuildSeries: %v", err)
+	}
+	player := series.Players[1]
+	if player.MapsPlayed != 2 || player.Rounds != 45 {
+		t.Errorf("maps/rounds = %d/%d, want 2/45", player.MapsPlayed, player.Rounds)
+	}
+	if player.Deaths != 22 {
+		t.Errorf("deaths = %d, want 22", player.Deaths)
+	}
+	if player.KillStats.Total != 35 || player.KillStats.HeadShots != 15 ||
+		player.KillStats.TradeKills != 6 || player.KillStats.TeamKills != 1 {
+		t.Errorf("kill stats = %+v, want exact sums", player.KillStats)
+	}
+	wantWeapons := map[string]int{"AK-47": 22, "AWP": 8, "Desert Eagle": 5}
+	if !reflect.DeepEqual(player.KillStats.WeaponsKills, wantWeapons) {
+		t.Errorf("weapon kills = %v, want %v", player.KillStats.WeaponsKills, wantWeapons)
+	}
+	if player.AssistStats.Total != 12 || player.AssistStats.FlashedEnemies != 3 || player.AssistStats.DamageGiven != 3300 {
+		t.Errorf("assist stats = %+v, want exact sums", player.AssistStats)
+	}
+	if player.PlayerStats.MVPs != 5 || player.PlayerStats.ACEs != 1 || player.PlayerStats.ClutchesWon != 3 {
+		t.Errorf("map stats = %+v, want exact sums", player.PlayerStats)
+	}
+	if want := (MultiKillRounds{K2: 5, K3: 1, K4: 1, K5: 1}); player.PlayerStats.MultiKills != want {
+		t.Errorf("multi-kills = %+v, want %+v", player.PlayerStats.MultiKills, want)
+	}
+	if want := (SideCount{Total: 5, CT: 3, T: 2}); player.DeathsTraded != want {
+		t.Errorf("deaths traded = %+v, want %+v", player.DeathsTraded, want)
+	}
+	if want := (SideCount{Total: 7, CT: 4, T: 3}); player.OpeningDuelStats.OpeningKills != want {
+		t.Errorf("opening kills = %+v, want %+v", player.OpeningDuelStats.OpeningKills, want)
+	}
+	if want := (SideCount{Total: 45, CT: 23, T: 22}); player.SideStats.Rounds != want {
+		t.Errorf("side rounds = %+v, want %+v", player.SideStats.Rounds, want)
+	}
+	utility := player.UtilityStats
+	if utility.EnemiesFlashed != 10 || utility.FriendsFlashed != 3 || utility.EnemyFlashTimeSeconds != 15.75 ||
+		utility.UnusedUtilityValue != 1300 {
+		t.Errorf("utility stats = %+v, want exact sums", utility)
+	}
+	if utility.UtilityDamage != (UtilityDamageStats{Total: 130, HE: 70, Fire: 60}) {
+		t.Errorf("utility damage = %+v, want exact sums", utility.UtilityDamage)
+	}
+	if utility.GrenadesThrown != (GrenadesThrownStats{Total: 26, Flash: 9, Smoke: 7, HE: 5, Molotov: 3, Incendiary: 1, Decoy: 1}) {
+		t.Errorf("grenades thrown = %+v, want exact sums", utility.GrenadesThrown)
+	}
+	if utility.AverageEnemyFlashTimeSeconds != 1.575 {
+		t.Errorf("average enemy flash time = %v, want 15.75/10", utility.AverageEnemyFlashTimeSeconds)
+	}
+	if got, want := player.KillStats.Precision, 15.0/35.0; got != want {
+		t.Errorf("precision = %v, want %v", got, want)
+	}
+	if got, want := player.AssistStats.ADR, 3300.0/45.0; got != want {
+		t.Errorf("ADR = %v, want damage over the 45 series rounds", got)
+	}
+	if !slices.Equal(player.Aliases, []string{"player-1", "player-1-alt"}) {
+		t.Errorf("aliases = %v, want map-order dedup", player.Aliases)
+	}
+	if player.Name != "player-1" {
+		t.Errorf("name = %q, want the first-observed of the tied names", player.Name)
+	}
+}
+
+// TestBuildSeriesRecomputesRatesFromExactFacts drives the fact-based rates:
+// KAST and its side splits, side ADR, opening success, the approximate
+// percentages and the recomputed rating must all come from summed raw
+// accumulators over the series denominator.
+func TestBuildSeriesRecomputesRatesFromExactFacts(t *testing.T) {
+	m1 := abMap("de_one", 13, 9)  // 22 rounds
+	m2 := abMap("de_two", 13, 10) // 23 rounds
+	m1.Players[1].SideStats.Rounds = SideCount{Total: 22, CT: 12, T: 10}
+	m2.Players[1].SideStats.Rounds = SideCount{Total: 23, CT: 11, T: 12}
+	m1.Players[1].OpeningDuelStats.OpeningKills = SideCount{Total: 4, CT: 2, T: 2}
+	m2.Players[1].OpeningDuelStats.OpeningKills = SideCount{Total: 2, CT: 1, T: 1}
+	m1.Players[1].PlayerMapStats.MultiKills = MultiKillRounds{K2: 2}
+	m2.Players[1].PlayerMapStats.MultiKills = MultiKillRounds{K3: 1}
+	m1.aggFacts = map[uint64]playerAggFacts{1: {
+		kastRounds:  SideCount{Total: 16, CT: 9, T: 7},
+		sideDamage:  SideCount{Total: 1800, CT: 1000, T: 800},
+		openingWins: 3,
+		ecoKills:    14.3,
+		ecoDamage:   1650.5,
+		ecoSurvival: 8.2,
+		ecoKast:     17.1,
+		roundSwing:  0.62,
+	}}
+	m2.aggFacts = map[uint64]playerAggFacts{1: {
+		kastRounds:  SideCount{Total: 15, CT: 8, T: 7},
+		sideDamage:  SideCount{Total: 1500, CT: 700, T: 800},
+		openingWins: 1,
+		ecoKills:    10.1,
+		ecoDamage:   1400.25,
+		ecoSurvival: 7.4,
+		ecoKast:     15.9,
+		roundSwing:  -0.12,
+	}}
+
+	series, err := BuildSeries(3, seriesInputs(m1, m2))
+	if err != nil {
+		t.Fatalf("BuildSeries: %v", err)
+	}
+	player := series.Players[1]
+	if got, want := player.PlayerStats.KAST, 100*perRound(31, 45); got != want {
+		t.Errorf("KAST = %v, want 100*31/45", got)
+	}
+	if got, want := player.SideStats.KAST, (SideRate{CT: 100 * perRound(17, 23), T: 100 * perRound(14, 22)}); got != want {
+		t.Errorf("side KAST = %+v, want %+v", got, want)
+	}
+	if got, want := player.SideStats.ADR, (SideRate{CT: perRound(1700, 23), T: perRound(1600, 22)}); got != want {
+		t.Errorf("side ADR = %+v, want %+v", got, want)
+	}
+	if got, want := player.OpeningDuelStats.OpeningSuccessRate, 100*4.0/6.0; got != want {
+		t.Errorf("opening success = %v, want 100*4/6", got)
+	}
+	// The expected fact sums repeat the builder's own runtime arithmetic —
+	// typed float64 sums divided by the 45 series rounds — so every
+	// comparison is exact rather than tolerance-based. Untyped constant
+	// expressions would be folded exactly at compile time and disagree in
+	// the last bit.
+	summed := m1.aggFacts[1]
+	summed.add(m2.aggFacts[1])
+	rounds := float64(45)
+	if got, want := player.PlayerStats.ApproxEKASTPercent, 100*(summed.ecoKast/rounds); got != want {
+		t.Errorf("approx eKAST = %v, want 100*33/45", got)
+	}
+	if got, want := player.PlayerStats.ApproxRoundSwingPercent, 100*(summed.roundSwing/rounds); got != want {
+		t.Errorf("approx swing = %v, want 100*0.5/45", got)
+	}
+	if player.Rating == nil {
+		t.Fatal("rating omitted despite both maps carrying raw facts")
+	}
+	want := blendRating(ratingRound{
+		killPoints: summed.ecoKills / rounds,
+		ecoDamage:  summed.ecoDamage / rounds,
+		survival:   summed.ecoSurvival / rounds,
+		kast:       summed.ecoKast / rounds,
+		multiKill:  multiKillPoints(MultiKillRounds{K2: 2, K3: 1}) / rounds,
+		swing:      summed.roundSwing / rounds,
+	})
+	if *player.Rating != want {
+		t.Errorf("rating = %+v, want the model run once over summed facts %+v", *player.Rating, want)
+	}
+}
+
+// TestBuildSeriesOmitsRatingWithoutRawFacts pins the documented fallback: a
+// map that was not produced by ProcessDemo carries no raw rating facts, so
+// the series rating is explicitly null instead of being reconstructed from
+// rounded per-map ratings.
+func TestBuildSeriesOmitsRatingWithoutRawFacts(t *testing.T) {
+	series, err := BuildSeries(3, seriesInputs(abMap("de_one", 13, 9), abMap("de_two", 13, 10)))
+	if err != nil {
+		t.Fatalf("BuildSeries: %v", err)
+	}
+	for id, player := range series.Players {
+		if player.Rating != nil {
+			t.Errorf("player %d rating = %+v, want nil without raw facts", id, player.Rating)
+		}
+	}
+}
+
+func TestBuildSeriesDoesNotMutateInputs(t *testing.T) {
+	m1 := abMap("de_one", 13, 9)
+	m2 := abMap("de_two", 9, 13)
+	m3 := abMap("de_three", 10, 13)
+	m1.aggFacts = map[uint64]playerAggFacts{1: {ecoKills: 1.5, kastRounds: SideCount{Total: 3, CT: 2, T: 1}}}
+	inputs := seriesInputs(m1, m2, m3)
+	snapshots := []ProcessedDemo{deepCopyDemo(t, m1), deepCopyDemo(t, m2), deepCopyDemo(t, m3)}
+
+	if _, err := BuildSeries(3, inputs); err != nil {
+		t.Fatalf("BuildSeries: %v", err)
+	}
+	for i, input := range inputs {
+		if !reflect.DeepEqual(*input.Demo, snapshots[i]) {
+			t.Errorf("map %d was mutated by aggregation", i+1)
+		}
+	}
+}
+
+// deepCopyDemo clones a ProcessedDemo including its unexported facts, which
+// json round-tripping would drop.
+func deepCopyDemo(t *testing.T, demo *ProcessedDemo) ProcessedDemo {
+	t.Helper()
+	data, err := json.Marshal(demo)
+	if err != nil {
+		t.Fatalf("marshalling demo: %v", err)
+	}
+	var clone ProcessedDemo
+	if err := json.Unmarshal(data, &clone); err != nil {
+		t.Fatalf("unmarshalling demo: %v", err)
+	}
+	clone.aggFacts = maps.Clone(demo.aggFacts)
+	return clone
+}
+
+func TestBuildSeriesIsDeterministic(t *testing.T) {
+	build := func() *ProcessedSeries {
+		m1 := abMap("de_one", 13, 9)
+		m2 := testMapDemo("de_two",
+			testTeam{id: 1, name: "Bravo", roster: rosterB, score: 9},
+			testTeam{id: 2, name: "Alpha", roster: rosterA, score: 13})
+		series, err := BuildSeries(3, seriesInputs(m1, m2))
+		if err != nil {
+			t.Fatalf("BuildSeries: %v", err)
+		}
+		return series
+	}
+	if first, second := build(), build(); !reflect.DeepEqual(first, second) {
+		t.Error("BuildSeries output differs between identical runs")
+	}
+}
+
+// TestBuildSeriesKeepsUnrosteredPlayers pins how a player that appears in a
+// map's raw events without ever playing an accepted round aggregates: no
+// team, no maps played, and a zero denominator rather than an invented one.
+func TestBuildSeriesKeepsUnrosteredPlayers(t *testing.T) {
+	m1 := abMap("de_one", 13, 9)
+	m1.Players[99] = &DemoPlayer{SteamID: 99, Name: "spectating-sub", KillStats: KillStats{WeaponsKills: map[string]int{}}}
+	series, err := BuildSeries(3, seriesInputs(m1, abMap("de_two", 13, 10)))
+	if err != nil {
+		t.Fatalf("BuildSeries: %v", err)
+	}
+	bystander := series.Players[99]
+	if bystander == nil {
+		t.Fatal("unrostered player missing from aggregate players")
+	}
+	if bystander.TeamID != 0 || bystander.MapsPlayed != 0 || bystander.Rounds != 0 {
+		t.Errorf("unrostered player = team %d, maps %d, rounds %d; want 0/0/0",
+			bystander.TeamID, bystander.MapsPlayed, bystander.Rounds)
+	}
+}
+
+func TestSelectSeriesPlayersResolvesAliasesAcrossMaps(t *testing.T) {
+	m1 := abMap("de_one", 13, 9)
+	m2 := abMap("de_two", 13, 10)
+	m2.Players[1].Name = "renamed-one"
+	series, err := BuildSeries(3, seriesInputs(m1, m2))
+	if err != nil {
+		t.Fatalf("BuildSeries: %v", err)
+	}
+
+	selected, err := SelectSeriesPlayers(series, []string{"RENAMED-ONE", "Player-6", "player-6"})
+	if err != nil {
+		t.Fatalf("SelectSeriesPlayers: %v", err)
+	}
+	want := map[uint64]bool{1: true, 6: true}
+	if !reflect.DeepEqual(selected, want) {
+		t.Errorf("selection = %v, want %v", selected, want)
+	}
+
+	_, err = SelectSeriesPlayers(series, []string{"nobody"})
+	if err == nil || !strings.Contains(err.Error(), "available players") {
+		t.Fatalf("SelectSeriesPlayers error = %v, want the available players listed", err)
+	}
+}
+
+func TestSelectSeriesPlayersAmbiguousAliasFails(t *testing.T) {
+	m1 := abMap("de_one", 13, 9)
+	m2 := abMap("de_two", 13, 10)
+	m1.Players[2].Name = "smurf"
+	m2.Players[7].Name = "Smurf"
+	series, err := BuildSeries(3, seriesInputs(m1, m2))
+	if err != nil {
+		t.Fatalf("BuildSeries: %v", err)
+	}
+	_, err = SelectSeriesPlayers(series, []string{"SMURF"})
+	var ambiguity *PlayerAliasAmbiguityError
+	if !errors.As(err, &ambiguity) {
+		t.Fatalf("SelectSeriesPlayers error = %v, want a *PlayerAliasAmbiguityError", err)
+	}
+	if !slices.Equal(ambiguity.SteamIDs, []uint64{2, 7}) {
+		t.Errorf("ambiguous candidates = %v, want [2 7]", ambiguity.SteamIDs)
+	}
+}
+
+func TestFilterSeriesPlayersNarrowsWithoutTouchingTeams(t *testing.T) {
+	series, err := BuildSeries(3, seriesInputs(abMap("de_one", 13, 9), abMap("de_two", 13, 10)))
+	if err != nil {
+		t.Fatalf("BuildSeries: %v", err)
+	}
+	filtered := FilterSeriesPlayers(series, map[uint64]bool{1: true})
+	if len(filtered.Players) != 1 || filtered.Players[1] == nil {
+		t.Errorf("filtered aggregate players = %d, want only SteamID 1", len(filtered.Players))
+	}
+	for i, seriesMap := range filtered.Maps {
+		if len(seriesMap.Analysis.Players) != 1 || seriesMap.Analysis.Players[1] == nil {
+			t.Errorf("filtered map %d players = %d, want only SteamID 1", i+1, len(seriesMap.Analysis.Players))
+		}
+		if !reflect.DeepEqual(seriesMap.Analysis.Teams, series.Maps[i].Analysis.Teams) {
+			t.Errorf("filtered map %d teams changed", i+1)
+		}
+		if !reflect.DeepEqual(seriesMap.TeamAssignments, series.Maps[i].TeamAssignments) {
+			t.Errorf("filtered map %d assignments changed", i+1)
+		}
+	}
+	if !reflect.DeepEqual(filtered.Teams, series.Teams) {
+		t.Error("filtering changed the series teams")
+	}
+	if len(series.Players) != 10 {
+		t.Errorf("original series was narrowed to %d players; filtering must copy", len(series.Players))
+	}
+	for i, seriesMap := range series.Maps {
+		if len(seriesMap.Analysis.Players) != 10 {
+			t.Errorf("original map %d was narrowed to %d players; filtering must copy", i+1, len(seriesMap.Analysis.Players))
+		}
+	}
+}

--- a/cmd/demo_parser/team_tracker.go
+++ b/cmd/demo_parser/team_tracker.go
@@ -18,11 +18,55 @@ type teamRoundFacts struct {
 	winner            common.Team
 }
 
-// aliasFact is one observed clan-name spelling and the number of accepted
-// rounds it was on the scoreboard for.
-type aliasFact struct {
-	name   string
-	rounds int
+// nameCount is one observed label spelling and how often it was seen.
+type nameCount struct {
+	name  string
+	count int
+}
+
+// nameTally is the one implementation of the label rule shared by map teams,
+// series teams and series players: nonempty labels are collected
+// deduplicated in first-observation order, and the display name is the most
+// observed one with ties broken by first observation. For a map team an
+// observation is an accepted round, so a mid-match rename only takes over
+// once it has been on the scoreboard longer than the old name; series teams
+// and players observe once per map. Something never named has no display
+// name — one is never invented.
+type nameTally struct {
+	counts []nameCount
+}
+
+func (nt *nameTally) observe(name string) {
+	if name == "" {
+		return
+	}
+	for i := range nt.counts {
+		if nt.counts[i].name == name {
+			nt.counts[i].count++
+			return
+		}
+	}
+	nt.counts = append(nt.counts, nameCount{name: name, count: 1})
+}
+
+func (nt *nameTally) mostObserved() string {
+	name, best := "", 0
+	for _, count := range nt.counts {
+		if count.count > best {
+			name, best = count.name, count.count
+		}
+	}
+	return name
+}
+
+// names returns the observed labels in first-observation order, non-nil even
+// when empty so they serialize as [] rather than null.
+func (nt *nameTally) names() []string {
+	names := make([]string, len(nt.counts))
+	for i, count := range nt.counts {
+		names[i] = count.name
+	}
+	return names
 }
 
 // logicalTeam accumulates one map-local team: the members that have played
@@ -31,7 +75,7 @@ type aliasFact struct {
 type logicalTeam struct {
 	id      int
 	members map[uint64]bool
-	aliases []aliasFact // deduplicated, in first-observation order
+	aliases nameTally
 	score   int
 }
 
@@ -47,47 +91,17 @@ func (lt *logicalTeam) recordRound(roster []uint64, clan string, won bool) {
 	for _, id := range roster {
 		lt.members[id] = true
 	}
-	if clan != "" {
-		lt.recordAlias(clan)
-	}
+	lt.aliases.observe(clan)
 	if won {
 		lt.score++
 	}
 }
 
-func (lt *logicalTeam) recordAlias(clan string) {
-	for i := range lt.aliases {
-		if lt.aliases[i].name == clan {
-			lt.aliases[i].rounds++
-			return
-		}
-	}
-	lt.aliases = append(lt.aliases, aliasFact{name: clan, rounds: 1})
-}
-
-// displayName is the alias observed in the most accepted rounds, ties broken
-// by first observation. A mid-match rename therefore only takes over the
-// display name once it has been on the scoreboard longer than the old name,
-// and a team that never showed a nonempty clan name has no display name.
-func (lt *logicalTeam) displayName() string {
-	name, best := "", 0
-	for _, alias := range lt.aliases {
-		if alias.rounds > best {
-			name, best = alias.name, alias.rounds
-		}
-	}
-	return name
-}
-
 func (lt *logicalTeam) export() DemoTeam {
-	aliases := make([]string, len(lt.aliases))
-	for i, alias := range lt.aliases {
-		aliases[i] = alias.name
-	}
 	return DemoTeam{
 		TeamID:  lt.id,
-		Name:    lt.displayName(),
-		Aliases: aliases,
+		Name:    lt.aliases.mostObserved(),
+		Aliases: lt.aliases.names(),
 		Score:   lt.score,
 		Roster:  lt.memberIDs(),
 	}

--- a/cmd/demo_parser/types.go
+++ b/cmd/demo_parser/types.go
@@ -191,9 +191,29 @@ type DemoTeam struct {
 	Roster []uint64 `json:"roster"`
 }
 
+// playerAggFacts preserves the exact accumulators behind one player's
+// derived rates and rating, so series aggregation (issue #34) can recompute
+// every percentage and the rating from raw numerators instead of combining
+// rounded map-level values. The fields mirror the analyser's own maps and
+// are unexported so the standalone JSON output does not change.
+type playerAggFacts struct {
+	kastRounds  SideCount // rounds with classic KAST credit, total and per side
+	sideDamage  SideCount // damage given, total and per side
+	openingWins int       // rounds won after taking the opening kill
+	ecoKills    float64   // eco-adjusted kill points
+	ecoDamage   float64   // eco-adjusted damage given
+	ecoSurvival float64   // eco-weighted rounds survived
+	ecoKast     float64   // eco-weighted rounds with rating KAST credit
+	roundSwing  float64   // summed round-win-probability swing
+}
+
 type ProcessedDemo struct {
 	Players  map[uint64]*DemoPlayer `json:"players"`
 	Teams    []DemoTeam             `json:"teams"`
 	Map      MapData                `json:"map_data"`
 	GameMode string                 `json:"game_mode"`
+	// aggFacts carries every player's raw aggregation facts, keyed by
+	// SteamID64. It is nil on values not produced by ProcessDemo, which
+	// BuildSeries treats as facts being unavailable rather than zero.
+	aggFacts map[uint64]playerAggFacts
 }


### PR DESCRIPTION
Closes #34.

## What this adds

Explicit, completed BO3/BO5 series analysis while keeping the single-demo workflow byte-identical:

```
cs2-analyser analyse --best-of 3 --demo map1.dem --demo map2.dem [--demo map3.dem]
cs2-analyser analyse --best-of 5 --demo map1.dem --demo map2.dem --demo map3.dem [...]
```

`--demo` is now repeatable (`StringArray`, so order is preserved and comma-containing paths stay intact). Multiple demos always require `--best-of 3|5` — the format is never inferred from file count — and one demo without the flag keeps the existing behavior exactly, picker and player multiselect included. Series runs never open either picker.

## How it works

- **Pure builder**: `demoparser.BuildSeries(bestOf, []SeriesMapInput)` is independent of Cobra, rendering and the filesystem, ready for the planned library extraction. The CLI streams each file through SHA-256 (rejecting duplicate content before parsing), parses in played order, and hands the parsed maps to the builder.
- **Completed series only**: BO3 takes 2–3 maps, BO5 takes 3–5; the final supplied map must be the first point at which a team reaches the clinch threshold. Unclinched series and maps supplied after the clinch are rejected. Only competitive 5v5 is accepted, enforced by a game-mode gate (`competitive`/`scrimcomp5v5`/`premier`/unknown), a per-team roster minimum, and a per-round participation ceiling that catches oversized lobbies whose demos name no mode.
- **Team identity**: the two series teams are resolved through a unique joint roster assignment. Series IDs seed from map 1's team order; each later map's two orientations are evaluated jointly (max 2^4 combinations) under one rule — the union rosters must stay disjoint. Zero valid assignments is a structured `SeriesTeamConflictError`, several is a `SeriesTeamAmbiguityError`, both `errors.As`-testable and carrying map indexes, local team IDs, rosters and the competing assignments. Clan names never drive identity; substitutions union into the same team; a middle map played entirely by substitutes resolves through later maps (a greedy matcher could not).
- **Aggregation**: players match by SteamID64 only. Additive stats are exact sums; every rate is recomputed from exact accumulators the parser now preserves as unexported facts on `ProcessedDemo` (standalone JSON is unchanged — goldens prove it). The match-wide denominator is the sum of total rounds of the maps a player was rostered on; side splits divide by the player's own side rounds. One shared `deriveStats` implements the formulas for both the per-map and series paths.
- **Rating**: never averaged. The rating model runs once over the summed raw eco facts with the series denominator; for inputs without preserved facts the rating is an explicit `null`, rendered as `-` in tables and empty cells in CSV, never a fabricated 0.00.
- **Output**: ordered map results with per-map series-team scores, overall map/round score and winner (duplicate or colliding team labels are disambiguated with series IDs), an aggregate player table with deterministic ordering, and aggregate `--details` tables. JSON saves the full series envelope — `best_of`, winner, series teams with rosters/aliases/map+round wins, aggregate players, and ordered maps with SHA-256, series-terms winner and explicit map-local→series team assignments around the unchanged standalone analyses. CSV stays the existing flat player table with the exact single-map header; series metadata is JSON-only. `--players` resolves against cross-map aliases case-insensitively after identity, with ambiguity errors listing candidate SteamIDs, and filtering narrows only player collections.

## Tests

- Unit coverage for all valid BO3/BO5 paths, incomplete/after-clinch/duplicate-hash/format rejections, swapped local IDs, substitutions, joint-vs-greedy resolution, structured conflict/ambiguity errors, label rules, exact additive sums, fact-based rate recomputation, rating recompute/omission, input immutability, determinism, selection and filtered saves, CLI flag combinations (explicit `--best-of 0` rejected), flag order preservation, and the CSV/JSON contracts.
- `TestHLTVSeriesRegression`: opt-in oracle test over the Rooster–Mindfreak BO3 (`HLTV_DEMO_DIR` convention). Verified locally: winner Mindfreak, 2:1 maps, 32:32 rounds, 64 total rounds, all ten players matched across all three maps with 64-round denominators and additive totals equal to the per-map sums. The regression harness now caches verified parses so the map and series tests share one parse per demo.
- Existing single-map goldens pass unchanged; `go test ./...`, `go vet ./...`, `gofmt` all clean.

## Docs

README (flags + series examples), `_docs/PLAYER_DATA.MD` (series JSON contract, identity, denominators, rating rule, 5v5 gates, CSV behavior), `_docs/HLTV_REGRESSION.md` (series oracle and invocation).