### PR TITLE
Automate prebuilt CLI releases with GoReleaser

### DIFF
--- a/.github/actions/goreleaser/action.yml
+++ b/.github/actions/goreleaser/action.yml
@@ -1,0 +1,16 @@
+name: Pinned GoReleaser
+description: Run the repository's pinned GoReleaser release tool.
+
+inputs:
+  args:
+    description: Arguments passed to GoReleaser.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+      with:
+        distribution: goreleaser
+        version: v2.17.1
+        args: ${{ inputs.args }}

--- a/.github/scripts/verify-release-artifacts.sh
+++ b/.github/scripts/verify-release-artifacts.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Keep archive-content comparisons stable across runner and maintainer locales.
+export LC_ALL=C
+
+dist_dir=${1:-dist}
+
+if [[ ! -d "$dist_dir" ]]; then
+  echo "::error::release artifact directory does not exist: $dist_dir"
+  exit 1
+fi
+
+expected_archives=(
+  cs2-analyser-tool-darwin-amd64.tar.gz
+  cs2-analyser-tool-darwin-arm64.tar.gz
+  cs2-analyser-tool-linux-amd64.tar.gz
+  cs2-analyser-tool-windows-amd64.zip
+)
+if ! diff -u \
+  <(printf '%s\n' "${expected_archives[@]}") \
+  <(for archive in "$dist_dir"/*.tar.gz "$dist_dir"/*.zip; do
+      [[ -f "$archive" ]] || continue
+      printf '%s\n' "${archive##*/}"
+    done | sort); then
+  echo "::error::archive set does not match the release contract"
+  exit 1
+fi
+
+if [[ ! -f "$dist_dir/checksums.txt" ]]; then
+  echo "::error::release artifacts do not include checksums.txt"
+  exit 1
+fi
+if ! diff -u \
+  <(printf '%s\n' "${expected_archives[@]}") \
+  <(awk '{print $2}' "$dist_dir/checksums.txt" | sort); then
+  echo "::error::checksums.txt does not cover the release archive set"
+  exit 1
+fi
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd "$dist_dir" && sha256sum --check checksums.txt)
+elif command -v shasum >/dev/null 2>&1; then
+  (cd "$dist_dir" && shasum -a 256 --check checksums.txt)
+else
+  echo "::error::sha256sum or shasum is required to verify checksums.txt"
+  exit 1
+fi
+
+expected_unix_contents=(LICENSE README.md cs2-analyser-tool)
+for archive in "$dist_dir"/*.tar.gz; do
+  if ! diff -u \
+    <(printf '%s\n' "${expected_unix_contents[@]}") \
+    <(tar -tzf "$archive" | sort); then
+    echo "::error::$archive does not contain the expected release files"
+    exit 1
+  fi
+done
+if ! diff -u \
+  <(printf '%s\n' LICENSE README.md cs2-analyser-tool.exe) \
+  <(unzip -Z1 "$dist_dir/cs2-analyser-tool-windows-amd64.zip" | sort); then
+  echo "::error::Windows archive does not contain the expected release files"
+  exit 1
+fi
+
+if ! command -v file >/dev/null 2>&1; then
+  echo "::error::file is required to inspect release binaries"
+  exit 1
+fi
+
+assert_binary_format() {
+  local platform=$1
+  local binary=$2
+  local pattern=$3
+  local description
+
+  description=$(file -b "$binary")
+  if [[ ! "$description" =~ $pattern ]]; then
+    echo "::error::$platform binary has unexpected format: $description"
+    exit 1
+  fi
+  printf '%s: %s\n' "$platform" "$description"
+}
+
+inspect_dir=$(mktemp -d)
+trap 'rm -rf -- "$inspect_dir"' EXIT
+mkdir -p \
+  "$inspect_dir/linux-amd64" \
+  "$inspect_dir/windows-amd64" \
+  "$inspect_dir/darwin-amd64" \
+  "$inspect_dir/darwin-arm64"
+tar -xzf "$dist_dir/cs2-analyser-tool-linux-amd64.tar.gz" -C "$inspect_dir/linux-amd64"
+unzip -q "$dist_dir/cs2-analyser-tool-windows-amd64.zip" -d "$inspect_dir/windows-amd64"
+tar -xzf "$dist_dir/cs2-analyser-tool-darwin-amd64.tar.gz" -C "$inspect_dir/darwin-amd64"
+tar -xzf "$dist_dir/cs2-analyser-tool-darwin-arm64.tar.gz" -C "$inspect_dir/darwin-arm64"
+
+assert_binary_format "Linux AMD64" "$inspect_dir/linux-amd64/cs2-analyser-tool" 'ELF 64-bit.*x86-64'
+assert_binary_format "Windows AMD64" "$inspect_dir/windows-amd64/cs2-analyser-tool.exe" 'PE32\+.*x86-64'
+assert_binary_format "macOS AMD64" "$inspect_dir/darwin-amd64/cs2-analyser-tool" 'Mach-O 64-bit x86_64'
+assert_binary_format "macOS ARM64" "$inspect_dir/darwin-arm64/cs2-analyser-tool" 'Mach-O 64-bit arm64'
+
+version_output=$("$inspect_dir/linux-amd64/cs2-analyser-tool" version)
+if [[ -n "${EXPECTED_RELEASE_VERSION:-}" ]]; then
+  expected_version_output="CS2 Analyser Tool version $EXPECTED_RELEASE_VERSION"
+  if [[ "$version_output" != "$expected_version_output" ]]; then
+    echo "::error::release binary reported $version_output, expected $expected_version_output"
+    exit 1
+  fi
+elif [[ ! "$version_output" =~ ^CS2\ Analyser\ Tool\ version\ v.+$ ]]; then
+  echo "::error::snapshot binary reported an invalid version: $version_output"
+  exit 1
+fi
+
+printf '%s\n' "$version_output"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_call:
+    inputs:
+      release_mode:
+        description: Optional release validation mode (snapshot or tag)
+        required: false
+        default: none
+        type: string
 
 permissions:
   contents: read
@@ -13,11 +20,47 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: ${{ (inputs.release_mode == 'snapshot' || inputs.release_mode == 'tag') && '0' || '1' }}
+      - name: Validate release tag and default-branch ancestry
+        if: inputs.release_mode == 'tag'
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          semver_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$'
+          if [[ ! "$TAG_NAME" =~ $semver_pattern ]]; then
+            echo "::error::tag $TAG_NAME is not a valid v-prefixed semantic version"
+            exit 1
+          fi
+
+          if ! git check-ref-format "refs/heads/$DEFAULT_BRANCH" >/dev/null; then
+            echo "::error::repository default branch is not a valid Git ref"
+            exit 1
+          fi
+
+          event_commit=$(git rev-parse --verify "${GITHUB_SHA}^{commit}")
+          tag_commit=$(git rev-parse --verify "refs/tags/${TAG_NAME}^{commit}")
+          checkout_commit=$(git rev-parse HEAD)
+          if [[ "$tag_commit" != "$event_commit" || "$checkout_commit" != "$event_commit" ]]; then
+            echo "::error::tag, event, and checked-out commits do not match"
+            exit 1
+          fi
+
+          git fetch --no-tags origin "+refs/heads/$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH"
+          if ! git merge-base --is-ancestor "$event_commit" "refs/remotes/origin/$DEFAULT_BRANCH"; then
+            echo "::error::tag $TAG_NAME does not point to a commit contained in $DEFAULT_BRANCH"
+            exit 1
+          fi
+
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - name: Restore test demo fixtures
-        id: demo-cache
+        if: inputs.release_mode != 'snapshot'
         uses: actions/cache@v6
         with:
           path: |
@@ -26,18 +69,22 @@ jobs:
           # Keyed on all fixture checksums, so changing any demo rolls
           # the cache instead of restoring a stale one.
           key: test-demos-84a1a4191302bdd2a3bbb5a727842093744b1fb1a228aeec630369e44b622cb2-b29a9cb537a181deef97b15cfed10ee722a37999644a27bb2226fdd77a1337fc
-      - name: Download test demo fixtures
-        if: steps.demo-cache.outputs.cache-hit != 'true'
+      - name: Verify or download test demo fixtures
+        if: inputs.release_mode != 'snapshot'
         run: make download-test-demos
       - name: Vet
+        if: inputs.release_mode != 'snapshot'
         run: go vet ./...
       - name: Build
+        if: inputs.release_mode != 'snapshot'
         run: go build ./...
       - name: Test with explicit skip policy
+        if: inputs.release_mode != 'snapshot'
         shell: bash
         env:
           # Fail rather than skip if a public fixture never made it into place.
           REQUIRE_TEST_DEMO: "1"
+          CI_TEST_PROFILE: ${{ inputs.release_mode == 'tag' && 'release' || 'pull-request' }}
         run: |
           results="$RUNNER_TEMP/go-test.json"
 
@@ -45,10 +92,25 @@ jobs:
           set -o pipefail
           go test -count=1 -json ./... | tee "$results" >/dev/null
           pipeline_status=("${PIPESTATUS[@]}")
-          go run ./internal/citest -profile pull-request < "$results"
+          go run ./internal/citest -profile "$CI_TEST_PROFILE" < "$results"
           report_status=$?
           set -e
 
           if (( pipeline_status[0] != 0 || pipeline_status[1] != 0 || report_status != 0 )); then
             exit 1
           fi
+      - name: Check GoReleaser configuration
+        if: inputs.release_mode == 'snapshot' || inputs.release_mode == 'tag'
+        uses: ./.github/actions/goreleaser
+        with:
+          args: check
+      - name: Build release candidate
+        if: inputs.release_mode == 'snapshot' || inputs.release_mode == 'tag'
+        uses: ./.github/actions/goreleaser
+        with:
+          args: ${{ inputs.release_mode == 'tag' && 'release --skip=publish --clean' || 'release --snapshot --clean' }}
+      - name: Verify release candidate
+        if: inputs.release_mode == 'snapshot' || inputs.release_mode == 'tag'
+        env:
+          EXPECTED_RELEASE_VERSION: ${{ inputs.release_mode == 'tag' && github.ref_name || '' }}
+        run: bash .github/scripts/verify-release-artifacts.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release
+
+on:
+  pull_request:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  snapshot:
+    name: Snapshot
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/ci.yml
+    with:
+      release_mode: snapshot
+
+  verify-tag:
+    name: Verify tag and test
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
+    uses: ./.github/workflows/ci.yml
+    with:
+      release_mode: tag
+
+  publish:
+    name: Publish
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: verify-tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: release-${{ github.ref_name }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+      - name: Publish GitHub release
+        uses: ./.github/actions/goreleaser
+        with:
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download published release artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/published-release"
+          gh release download "$GITHUB_REF_NAME" --dir "$RUNNER_TEMP/published-release"
+      - name: Verify downloaded release artifacts
+        env:
+          EXPECTED_RELEASE_VERSION: ${{ github.ref_name }}
+        run: bash .github/scripts/verify-release-artifacts.sh "$RUNNER_TEMP/published-release"

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ go.work.sum
 # Build output (see Makefile BUILD_DIR)
 build/
 
+# GoReleaser output
+dist/
+
 # Ignore downloaded and locally supplied demo fixtures.
 # See cmd/demo_parser/testdata/README.md.
 *.dem

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,63 @@
+version: 2
+
+project_name: cs2-analyser-tool
+
+builds:
+  - id: cs2-analyser-tool
+    main: .
+    binary: cs2-analyser-tool
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: linux
+        goarch: arm64
+      - goos: windows
+        goarch: arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X github.com/taua-almeida/cs2-analyser-tool/cmd.CS2AnalyserVersion=v{{ .Version }}
+
+archives:
+  - ids:
+      - cs2-analyser-tool
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+    files:
+      - README.md
+      - LICENSE
+
+checksum:
+  name_template: checksums.txt
+  algorithm: sha256
+
+release:
+  prerelease: auto
+
+changelog:
+  use: git
+  sort: asc
+  groups:
+    - title: Features
+      regexp: '^feat(\([^)]*\))?!?:.+$'
+      order: 0
+    - title: Fixes
+      regexp: '^fix(\([^)]*\))?!?:.+$'
+      order: 1
+    - title: Maintenance
+      regexp: '^chore(\([^)]*\))?!?:.+$'
+      order: 2
+    - title: Other
+      order: 999

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,11 @@ GOCLEAN := $(GOCMD) clean
 GOTIDY := $(GOCMD) mod tidy
 GOTEST := $(GOCMD) test
 
-# Platforms
-PLATFORMS := windows linux darwin
-os = $(word 1, $@)
+# Build targets. A target without an explicit architecture defaults to amd64.
+BUILD_TARGETS := windows linux darwin darwin-arm64
+target_parts = $(subst -, ,$@)
+os = $(word 1,$(target_parts))
+arch = $(if $(word 2,$(target_parts)),$(word 2,$(target_parts)),amd64)
 
 # Public integration test fixtures. Both are real CS2 demos pinned by SHA-256.
 # Sources, licenses and attribution are in analysis/testdata/README.md.
@@ -53,12 +55,12 @@ endef
 # Ensure GOBIN is not set, which can conflict with cross compilation
 unexport GOBIN
 
-.PHONY: build-all clean tidy test download-test-demos $(PLATFORMS)
+.PHONY: build-all clean tidy test download-test-demos $(BUILD_TARGETS)
 
-build-all: windows linux darwin
+build-all: $(BUILD_TARGETS)
 
-$(PLATFORMS):
-	GOOS=$(os) GOARCH=amd64 $(GOBUILD) -o '$(BUILD_DIR)/$(PROJECT_NAME)-$(os)-amd64' .
+$(BUILD_TARGETS):
+	GOOS=$(os) GOARCH=$(arch) $(GOBUILD) -o '$(BUILD_DIR)/$(PROJECT_NAME)-$(os)-$(arch)' .
 
 test:
 	$(GOTEST) ./...
@@ -74,3 +76,4 @@ tidy:
 clean:
 	$(GOCLEAN)
 	rm -f $(BUILD_DIR)/*
+	rm -rf ./dist

--- a/README.md
+++ b/README.md
@@ -1,5 +1,67 @@
 # cs2-analyser-tool
+
 Designed specifically for players and coaches, this command-line interface tool provides a simple display and easy data ready to analyse, compare and start your journey towards improving your team and your personal CS2 skills.
+
+## Installation
+
+### Prebuilt archives
+
+Prebuilt archives are published for each release from `v0.1.0` onward at [GitHub Releases](https://github.com/taua-almeida/cs2-analyser-tool/releases). Download `checksums.txt` and the archive for your system from the same release:
+
+| System | Archive |
+| --- | --- |
+| Linux, 64-bit Intel/AMD | `cs2-analyser-tool-linux-amd64.tar.gz` |
+| Windows, 64-bit Intel/AMD | `cs2-analyser-tool-windows-amd64.zip` |
+| macOS, Intel | `cs2-analyser-tool-darwin-amd64.tar.gz` |
+| macOS, Apple silicon | `cs2-analyser-tool-darwin-arm64.tar.gz` |
+
+Verify the downloaded archive before extracting it. On Linux, replace the archive name if needed:
+
+```sh
+grep 'cs2-analyser-tool-linux-amd64.tar.gz$' checksums.txt | sha256sum --check -
+```
+
+On macOS:
+
+```sh
+grep 'cs2-analyser-tool-darwin-arm64.tar.gz$' checksums.txt | shasum -a 256 --check -
+```
+
+On Windows PowerShell:
+
+```powershell
+$archive = "cs2-analyser-tool-windows-amd64.zip"
+$expected = ((Get-Content checksums.txt | Where-Object { $_ -match ([regex]::Escape($archive) + '$') }) -split '\s+')[0]
+$actual = (Get-FileHash $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($actual -ne $expected) { throw "checksum mismatch" }
+```
+
+Extract a Linux or macOS archive into its own directory and run the binary:
+
+```sh
+mkdir cs2-analyser-tool-release
+tar -xzf cs2-analyser-tool-linux-amd64.tar.gz -C cs2-analyser-tool-release
+./cs2-analyser-tool-release/cs2-analyser-tool version
+```
+
+For Windows:
+
+```powershell
+Expand-Archive cs2-analyser-tool-windows-amd64.zip -DestinationPath cs2-analyser-tool-release
+.\cs2-analyser-tool-release\cs2-analyser-tool.exe version
+```
+
+Each archive also contains `README.md` and `LICENSE`.
+
+### Install with Go
+
+Install the latest available CLI version with a supported Go toolchain:
+
+```sh
+go install github.com/taua-almeida/cs2-analyser-tool@latest
+```
+
+`@latest` resolves a pseudo-version of `main` until the first tag is published; after that it selects the latest tagged release.
 
 ## Usage
 
@@ -131,7 +193,7 @@ series, err := analysis.BuildSeries(3, []analysis.SeriesMapInput{
 
 It is pure aggregation — no I/O, inputs never mutated — and enforces the completed-series rule: the final supplied map must be the clinching one. When the two series teams cannot be resolved from rosters alone, the structured `SeriesTeamConflictError` and `SeriesTeamAmbiguityError` carry the competing evidence and match through `errors.As`.
 
-### JSON and stability
+### JSON contract and v0.x API stability
 
 Every result type marshals with `encoding/json` into the same envelopes the CLI's `--save` writes, documented in [PLAYER_DATA](./_docs/PLAYER_DATA.MD): `MapAnalysis` is the standalone map document, `SeriesAnalysis` the series document embedding each map's unchanged analysis. A series player whose rating cannot be recomputed from raw per-map facts marshals it as `null` rather than a fabricated value.
 
@@ -165,6 +227,18 @@ For a local run of the ordinary suite:
 make download-test-demos
 REQUIRE_TEST_DEMO=1 go test -count=1 ./...
 ```
+
+### Publishing a release
+
+Releases are maintainer-triggered and remain a human-approved operation:
+
+1. Confirm the normal CI workflow passed on the commit to release.
+2. Confirm the latest external-regression workflow run passed.
+3. Create an annotated, v-prefixed semantic-version tag, for example `git tag -a v0.1.0 -m "v0.1.0"`.
+4. Push only that tag, for example `git push origin v0.1.0`.
+5. Watch the release workflow until its verification and publishing jobs finish.
+6. In the GitHub release, verify all four platform archives, `checksums.txt`, each archive's contents, and the binary's `version` output.
+7. Never move a published tag. Publish a new patch release to correct a release.
 
 ### Clone the repo
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 )
@@ -15,6 +16,21 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Display application version information.",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("CS2 Analyser Tool version %v\n", CS2AnalyserVersion)
+		fmt.Fprintf(cmd.OutOrStdout(), "CS2 Analyser Tool version %s\n", currentVersion())
 	},
+}
+
+func currentVersion() string {
+	buildInfo, _ := debug.ReadBuildInfo()
+	return resolveVersion(CS2AnalyserVersion, buildInfo)
+}
+
+func resolveVersion(linkerVersion string, buildInfo *debug.BuildInfo) string {
+	if linkerVersion != "" {
+		return linkerVersion
+	}
+	if buildInfo != nil && buildInfo.Main.Version != "" && buildInfo.Main.Version != "(devel)" {
+		return buildInfo.Main.Version
+	}
+	return "dev"
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"bytes"
+	"runtime/debug"
+	"testing"
+)
+
+func TestResolveVersion(t *testing.T) {
+	tests := []struct {
+		name          string
+		linkerVersion string
+		moduleVersion string
+		buildInfo     bool
+		want          string
+	}{
+		{name: "linker version wins", linkerVersion: "v0.1.0", moduleVersion: "v9.9.9", buildInfo: true, want: "v0.1.0"},
+		{name: "installed module version", moduleVersion: "v0.2.0", buildInfo: true, want: "v0.2.0"},
+		{name: "development module", moduleVersion: "(devel)", buildInfo: true, want: "dev"},
+		{name: "empty module version", buildInfo: true, want: "dev"},
+		{name: "missing build info", want: "dev"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var buildInfo *debug.BuildInfo
+			if test.buildInfo {
+				buildInfo = &debug.BuildInfo{Main: debug.Module{Version: test.moduleVersion}}
+			}
+			if got := resolveVersion(test.linkerVersion, buildInfo); got != test.want {
+				t.Fatalf("resolveVersion(%q, module %q) = %q, want %q", test.linkerVersion, test.moduleVersion, got, test.want)
+			}
+		})
+	}
+}
+
+func TestVersionCommandOutput(t *testing.T) {
+	oldVersion := CS2AnalyserVersion
+	CS2AnalyserVersion = "v0.1.0"
+	t.Cleanup(func() {
+		CS2AnalyserVersion = oldVersion
+		// rootCmd has no parent or configured writer, so nil restores its default.
+		rootCmd.SetOut(nil)
+		// A nil override restores Cobra's default of reading os.Args[1:].
+		rootCmd.SetArgs(nil)
+	})
+
+	var output bytes.Buffer
+	rootCmd.SetOut(&output)
+	rootCmd.SetArgs([]string{"version"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("executing version command: %v", err)
+	}
+
+	const want = "CS2 Analyser Tool version v0.1.0\n"
+	if got := output.String(); got != want {
+		t.Fatalf("version output = %q, want %q", got, want)
+	}
+}

--- a/internal/citest/main.go
+++ b/internal/citest/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	profileName := flag.String("profile", string(profilePullRequest), "summary and skip policy: pull-request, nightly, or external")
+	profileName := flag.String("profile", string(profilePullRequest), "summary and skip policy: pull-request, nightly, release, or external")
 	fixturesVerified := flag.Bool("fixtures-verified", false, "report that the external provisioning step verified every fixture checksum")
 	flag.Parse()
 

--- a/internal/citest/report.go
+++ b/internal/citest/report.go
@@ -16,10 +16,21 @@ type profile string
 const (
 	profilePullRequest profile = "pull-request"
 	profileNightly     profile = "nightly"
+	profileRelease     profile = "release"
 	profileExternal    profile = "external"
 )
 
 var pullRequestSkipEntries = []string{
+	"analysis/TestAnalyseGolden/inferno_shotgun_halftime_and_freeze_join",
+	"analysis/TestHLTVRegression/*",
+	"analysis/TestHLTVSeriesRegression",
+	"analysis/TestEvaluateHLTVTradeModels",
+	"analysis/TestTraceHLTVRoundEvidence",
+}
+
+// Release skips are kept separate so widening pull-request policy cannot
+// silently weaken the tag gate.
+var releaseSkipEntries = []string{
 	"analysis/TestAnalyseGolden/inferno_shotgun_halftime_and_freeze_join",
 	"analysis/TestHLTVRegression/*",
 	"analysis/TestHLTVSeriesRegression",
@@ -234,8 +245,12 @@ func evaluate(profile profile, run testRun, parseErr error, fixturesVerified boo
 	}
 
 	switch profile {
-	case profilePullRequest, profileNightly:
-		rules, err := compileSkipRules(pullRequestSkipEntries)
+	case profilePullRequest, profileNightly, profileRelease:
+		skipEntries := pullRequestSkipEntries
+		if profile == profileRelease {
+			skipEntries = releaseSkipEntries
+		}
+		rules, err := compileSkipRules(skipEntries)
 		if err != nil {
 			report.problems = append(report.problems, err.Error())
 			break
@@ -310,19 +325,27 @@ func renderMarkdown(profile profile, run testRun, report policyReport) string {
 	counts := run.counts()
 	var markdown strings.Builder
 	title := "Go test coverage"
-	if profile == profileNightly {
+	switch profile {
+	case profileNightly:
 		title += " (nightly)"
+	case profileRelease:
+		title += " (release)"
 	}
 	fmt.Fprintf(&markdown, "## %s\n\n", title)
 	fmt.Fprintf(&markdown, "- Passed: %d\n", counts.passed)
 	fmt.Fprintf(&markdown, "- Failed: %d\n", counts.failed)
 	fmt.Fprintf(&markdown, "- Skipped: %d\n", counts.skipped)
 	fmt.Fprintf(&markdown, "- Public golden fixtures: %s\n", publicGoldenStatus(run))
-	if profile == profilePullRequest {
-		fmt.Fprintf(&markdown, "- Private Inferno golden: %s\n", pullRequestPrivateGoldenStatus(run))
+	switch profile {
+	case profilePullRequest:
+		fmt.Fprintf(&markdown, "- Private Inferno golden: %s\n", unprovisionedPrivateGoldenStatus(run))
 		markdown.WriteString("- HLTV map regression: external workflow\n")
 		markdown.WriteString("- HLTV series regression: external workflow\n")
-	} else {
+	case profileRelease:
+		fmt.Fprintf(&markdown, "- Private Inferno golden: %s\n", unprovisionedPrivateGoldenStatus(run))
+		markdown.WriteString("- HLTV map regression: latest external workflow required before tagging\n")
+		markdown.WriteString("- HLTV series regression: latest external workflow required before tagging\n")
+	default:
 		fmt.Fprintf(&markdown, "- Private Inferno golden: %s\n", nightlyPrivateGoldenStatus(run))
 		markdown.WriteString("- HLTV map regression: separate required step\n")
 		markdown.WriteString("- HLTV series regression: separate required step\n")
@@ -375,7 +398,7 @@ func publicGoldenStatus(run testRun) string {
 	return "ran"
 }
 
-func pullRequestPrivateGoldenStatus(run testRun) string {
+func unprovisionedPrivateGoldenStatus(run testRun) string {
 	switch run.actions[privateGoldenTest] {
 	case "skip":
 		return "intentionally unavailable"
@@ -424,7 +447,7 @@ func testActionStatus(action string) string {
 
 func parseProfile(value string) (profile, error) {
 	switch profile(value) {
-	case profilePullRequest, profileNightly, profileExternal:
+	case profilePullRequest, profileNightly, profileRelease, profileExternal:
 		return profile(value), nil
 	default:
 		return "", fmt.Errorf("unknown CI test profile %q", value)

--- a/internal/citest/report_test.go
+++ b/internal/citest/report_test.go
@@ -201,6 +201,46 @@ func TestPullRequestMarkdownIsDeterministic(t *testing.T) {
 	}
 }
 
+func TestReleasePolicyUsesItsOwnSkipRulesAndSummary(t *testing.T) {
+	run := passingPublicGoldenRun()
+	run.actions[privateGoldenTest] = "skip"
+	run.actions["analysis/TestTraceHLTVRoundEvidence"] = "skip"
+
+	report := evaluate(profileRelease, run, nil, false)
+	if len(report.problems) != 0 {
+		t.Fatalf("release policy problems = %#v, want none", report.problems)
+	}
+	markdown := renderMarkdown(profileRelease, run, report)
+	for _, want := range []string{
+		"## Go test coverage (release)",
+		"- Private Inferno golden: intentionally unavailable",
+		"- HLTV map regression: latest external workflow required before tagging",
+		"- HLTV series regression: latest external workflow required before tagging",
+	} {
+		if !strings.Contains(markdown, want) {
+			t.Fatalf("release summary does not contain %q:\n%s", want, markdown)
+		}
+	}
+}
+
+func TestReleasePolicyRejectsPullRequestOnlySkip(t *testing.T) {
+	const pullRequestOnlySkip = "analysis/TestPullRequestOnlyDiagnostic"
+	originalPullRequestSkips := pullRequestSkipEntries
+	pullRequestSkipEntries = append(append([]string(nil), pullRequestSkipEntries...), pullRequestOnlySkip)
+	t.Cleanup(func() {
+		pullRequestSkipEntries = originalPullRequestSkips
+	})
+
+	run := passingPublicGoldenRun()
+	run.actions[pullRequestOnlySkip] = "skip"
+	if report := evaluate(profilePullRequest, run, nil, false); len(report.problems) != 0 {
+		t.Fatalf("pull-request policy problems = %#v, want none", report.problems)
+	}
+	if report := evaluate(profileRelease, run, nil, false); !containsProblem(report.problems, "unexpected skipped test "+pullRequestOnlySkip) {
+		t.Fatalf("release policy problems = %#v, want pull-request-only skip rejected", report.problems)
+	}
+}
+
 func TestExternalPolicyRequiresEightMapsSeriesAndNoSkips(t *testing.T) {
 	run := testRun{actions: map[string]string{hltvMapRegression: "pass", hltvSeriesRegression: "pass"}}
 	for i := 1; i <= externalMapCount; i++ {


### PR DESCRIPTION
## Summary

- add a GoReleaser v2 configuration pinned to v2.17.1 for Linux AMD64, Windows AMD64, macOS AMD64, and macOS ARM64
- add pull-request snapshot validation, semantic-tag verification, and a write-scoped publishing job
- resolve CLI versions from linker flags, module build information, or `dev`, with focused command and resolver tests
- document release downloads, checksum verification, Go installation, public package usage, compatibility policy, and the maintainer release sequence

## Release safeguards

- build exactly four deterministic archives with `CGO_ENABLED=0`, `-trimpath`, stripped binaries, README, LICENSE, and SHA-256 checksums
- verify archive names, contents, checksums, binary formats, architectures, and version output before publishing
- reject malformed tags, mismatched tag/event/checkout commits, and tags outside the default branch
- keep repository permissions read-only except for the publishing job and avoid persisted checkout credentials
- download the uploaded GitHub release assets and verify them again after publishing
- keep the GoReleaser action SHA and binary version in one reusable pinned action

## Verification

- `make download-test-demos`
- `REQUIRE_TEST_DEMO=1 go test -count=1 ./...`
- `go vet ./...`
- `go build ./...`
- `make build-all`
- `go run github.com/goreleaser/goreleaser/v2@v2.17.1 check`
- `go run github.com/goreleaser/goreleaser/v2@v2.17.1 release --snapshot --clean`
- locale-independent archive, checksum, format, architecture, and version checks
- `git diff --check`

This PR adds release automation only. Creating and publishing `v0.1.0` remains a separate human-approved step.

Closes #10
