### PR TITLE
Make external regression opt-in

### DIFF
--- a/.github/workflows/external-regression.yml
+++ b/.github/workflows/external-regression.yml
@@ -1,17 +1,15 @@
 name: External regression
 
 on:
-  schedule:
-    - cron: "17 3 * * *"
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  guard:
+  regression:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 90
     steps:
       - name: Reject non-default refs
         env:
@@ -23,11 +21,6 @@ jobs:
             exit 1
           fi
 
-  regression:
-    needs: guard
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.repository.default_branch }}
@@ -150,13 +143,13 @@ jobs:
         env:
           REQUIRE_TEST_DEMO: "1"
         run: |
-          results="$RUNNER_TEMP/nightly-go-test.json"
+          results="$RUNNER_TEMP/external-core-go-test.json"
 
           set +e
           set -o pipefail
           go test -count=1 -json ./... | tee "$results" >/dev/null
           pipeline_status=("${PIPESTATUS[@]}")
-          go run ./internal/citest -profile nightly < "$results"
+          go run ./internal/citest -profile pull-request < "$results"
           report_status=$?
           set -e
 

--- a/README.md
+++ b/README.md
@@ -214,11 +214,12 @@ Pull-request CI restores the two public golden demos, keeps `go vet ./...` and
 counts plus every package-relative skipped test. An unlisted skip fails the
 workflow, so adding `t.Skip` requires an intentional allowlist review.
 
-The scheduled/manual external workflow is separate from pull requests. It runs
-the eight checksum-pinned HLTV map regressions and the original BO3 series from
-an owner-approved private archive; absent provisioning configuration is a hard
-failure. The complete coverage matrix, private archive contract, summary fields,
-and manual diagnostic commands are in
+The optional External regression workflow is manually dispatched and separate
+from pull requests and releases. When its owner-approved private archive is
+configured, it runs the eight checksum-pinned HLTV map regressions and the
+original BO3 series; absent provisioning configuration is a hard failure. It is
+not a release prerequisite. The complete coverage matrix, private archive
+contract, summary fields, and manual diagnostic commands are in
 [HLTV_REGRESSION.md](./_docs/HLTV_REGRESSION.md#ci-coverage).
 
 For a local run of the ordinary suite:
@@ -233,12 +234,11 @@ REQUIRE_TEST_DEMO=1 go test -count=1 ./...
 Releases are maintainer-triggered and remain a human-approved operation:
 
 1. Confirm the normal CI workflow passed on the commit to release.
-2. Confirm the latest external-regression workflow run passed.
-3. Create an annotated, v-prefixed semantic-version tag, for example `git tag -a v0.1.0 -m "v0.1.0"`.
-4. Push only that tag, for example `git push origin v0.1.0`.
-5. Watch the release workflow until its verification and publishing jobs finish.
-6. In the GitHub release, verify all four platform archives, `checksums.txt`, each archive's contents, and the binary's `version` output.
-7. Never move a published tag. Publish a new patch release to correct a release.
+2. Create an annotated, v-prefixed semantic-version tag, for example `git tag -a v0.1.0 -m "v0.1.0"`.
+3. Push only that tag, for example `git push origin v0.1.0`.
+4. Watch the release workflow until its verification and publishing jobs finish.
+5. In the GitHub release, verify all four platform archives, `checksums.txt`, each archive's contents, and the binary's `version` output.
+6. Never move a published tag. Publish a new patch release to correct a release.
 
 ### Clone the repo
 

--- a/_docs/HLTV_REGRESSION.md
+++ b/_docs/HLTV_REGRESSION.md
@@ -11,7 +11,7 @@ SHA-256 digests. Demo bytes remain external, read-only inputs.
 
 ## CI coverage
 
-| Suite | Pull request | Nightly | Manual |
+| Suite | Pull request | External workflow | Local |
 | --- | --- | --- | --- |
 | Unit and synthetic tests | Required | Required | Available |
 | Public golden demos | Required | Required | Available |
@@ -88,11 +88,10 @@ spirit-vs-jijiehao-mirage.dem
 
 ## External regression workflow
 
-`.github/workflows/external-regression.yml` runs at 03:17 UTC each night and
-through `workflow_dispatch`. It has no pull-request trigger, grants only
-`contents: read`, fails a manual dispatch whose ref is not the repository's
-default branch through an explicit guard job, and explicitly checks out that
-default branch. The required map
+`.github/workflows/external-regression.yml` runs only through
+`workflow_dispatch`. It has no pull-request or release trigger, grants only
+`contents: read`, rejects a manual dispatch whose ref is not the repository's
+default branch, and explicitly checks out that default branch. The required map
 and series tests run together so their checksum-verified parse cache is shared:
 
 ```sh
@@ -144,13 +143,13 @@ body, verifies the archive digest, extracts only exact manifest members to a
 temp directory, and verifies each demo before a test can parse it. Missing or
 invalid HLTV files fail provisioning. If the Inferno member exists, it must
 verify and `REQUIRE_PRIVATE_TEST_DEMO=1` makes its golden subtest mandatory. If
-it is absent, the nightly core-test summary says **Private Inferno golden:
-unavailable**.
+it is absent, the external workflow's core-test summary says **Private Inferno
+golden: intentionally unavailable**.
 
 No private demo path is passed to `actions/cache` or an artifact upload step.
 The workflow does not create secrets, and the pull-request workflow neither
 references this secret nor provisions external files. Until an owner approves a
-source and creates both settings, scheduled/manual runs fail immediately with a
+source and creates both settings, manual runs fail immediately with a
 fixture-provisioning blocker instead of reporting unrun regressions as success.
 
 ## Commands and missing-demo behavior
@@ -427,10 +426,10 @@ HLTV_TRACE_STEAM_ID=76561199063238565 \
 ```
 
 These two tests stay manual. The trade-model matrix compares exploratory rules
-and has no accepted production gate; running it nightly would spend time
-reproducing diagnostic evidence. The trace test prints investigator-selected
-event evidence and has no regression oracle. Neither is evidence that the eight
-map or BO3 regression passed.
+and has no accepted production gate; running it in the external workflow would
+spend time reproducing diagnostic evidence. The trace test prints
+investigator-selected event evidence and has no regression oracle. Neither is
+evidence that the eight map or BO3 regression passed.
 
 The trace records participation, side, kills, normal/flash assists, death
 cause/frame/time/tick, the assister's name and SteamID64, every direct trade

--- a/internal/citest/main.go
+++ b/internal/citest/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	profileName := flag.String("profile", string(profilePullRequest), "summary and skip policy: pull-request, nightly, release, or external")
+	profileName := flag.String("profile", string(profilePullRequest), "summary and skip policy: pull-request, release, or external")
 	fixturesVerified := flag.Bool("fixtures-verified", false, "report that the external provisioning step verified every fixture checksum")
 	flag.Parse()
 

--- a/internal/citest/report.go
+++ b/internal/citest/report.go
@@ -15,7 +15,6 @@ type profile string
 
 const (
 	profilePullRequest profile = "pull-request"
-	profileNightly     profile = "nightly"
 	profileRelease     profile = "release"
 	profileExternal    profile = "external"
 )
@@ -245,7 +244,7 @@ func evaluate(profile profile, run testRun, parseErr error, fixturesVerified boo
 	}
 
 	switch profile {
-	case profilePullRequest, profileNightly, profileRelease:
+	case profilePullRequest, profileRelease:
 		skipEntries := pullRequestSkipEntries
 		if profile == profileRelease {
 			skipEntries = releaseSkipEntries
@@ -325,10 +324,7 @@ func renderMarkdown(profile profile, run testRun, report policyReport) string {
 	counts := run.counts()
 	var markdown strings.Builder
 	title := "Go test coverage"
-	switch profile {
-	case profileNightly:
-		title += " (nightly)"
-	case profileRelease:
+	if profile == profileRelease {
 		title += " (release)"
 	}
 	fmt.Fprintf(&markdown, "## %s\n\n", title)
@@ -336,20 +332,9 @@ func renderMarkdown(profile profile, run testRun, report policyReport) string {
 	fmt.Fprintf(&markdown, "- Failed: %d\n", counts.failed)
 	fmt.Fprintf(&markdown, "- Skipped: %d\n", counts.skipped)
 	fmt.Fprintf(&markdown, "- Public golden fixtures: %s\n", publicGoldenStatus(run))
-	switch profile {
-	case profilePullRequest:
-		fmt.Fprintf(&markdown, "- Private Inferno golden: %s\n", unprovisionedPrivateGoldenStatus(run))
-		markdown.WriteString("- HLTV map regression: external workflow\n")
-		markdown.WriteString("- HLTV series regression: external workflow\n")
-	case profileRelease:
-		fmt.Fprintf(&markdown, "- Private Inferno golden: %s\n", unprovisionedPrivateGoldenStatus(run))
-		markdown.WriteString("- HLTV map regression: latest external workflow required before tagging\n")
-		markdown.WriteString("- HLTV series regression: latest external workflow required before tagging\n")
-	default:
-		fmt.Fprintf(&markdown, "- Private Inferno golden: %s\n", nightlyPrivateGoldenStatus(run))
-		markdown.WriteString("- HLTV map regression: separate required step\n")
-		markdown.WriteString("- HLTV series regression: separate required step\n")
-	}
+	fmt.Fprintf(&markdown, "- Private Inferno golden: %s\n", privateGoldenStatus(run))
+	markdown.WriteString("- HLTV map regression: optional external workflow\n")
+	markdown.WriteString("- HLTV series regression: optional external workflow\n")
 	markdown.WriteString("- Trade-model diagnostic: manual\n")
 	markdown.WriteString("- Trace diagnostic: manual\n")
 
@@ -398,23 +383,10 @@ func publicGoldenStatus(run testRun) string {
 	return "ran"
 }
 
-func unprovisionedPrivateGoldenStatus(run testRun) string {
+func privateGoldenStatus(run testRun) string {
 	switch run.actions[privateGoldenTest] {
 	case "skip":
 		return "intentionally unavailable"
-	case "pass":
-		return "ran"
-	case "fail":
-		return "failed"
-	default:
-		return "not observed"
-	}
-}
-
-func nightlyPrivateGoldenStatus(run testRun) string {
-	switch run.actions[privateGoldenTest] {
-	case "skip":
-		return "unavailable"
 	case "pass":
 		return "ran"
 	case "fail":
@@ -447,7 +419,7 @@ func testActionStatus(action string) string {
 
 func parseProfile(value string) (profile, error) {
 	switch profile(value) {
-	case profilePullRequest, profileNightly, profileRelease, profileExternal:
+	case profilePullRequest, profileRelease, profileExternal:
 		return profile(value), nil
 	default:
 		return "", fmt.Errorf("unknown CI test profile %q", value)

--- a/internal/citest/report_test.go
+++ b/internal/citest/report_test.go
@@ -183,8 +183,8 @@ func TestPullRequestMarkdownIsDeterministic(t *testing.T) {
 - Skipped: 2
 - Public golden fixtures: ran
 - Private Inferno golden: intentionally unavailable
-- HLTV map regression: external workflow
-- HLTV series regression: external workflow
+- HLTV map regression: optional external workflow
+- HLTV series regression: optional external workflow
 - Trade-model diagnostic: manual
 - Trace diagnostic: manual
 
@@ -214,8 +214,8 @@ func TestReleasePolicyUsesItsOwnSkipRulesAndSummary(t *testing.T) {
 	for _, want := range []string{
 		"## Go test coverage (release)",
 		"- Private Inferno golden: intentionally unavailable",
-		"- HLTV map regression: latest external workflow required before tagging",
-		"- HLTV series regression: latest external workflow required before tagging",
+		"- HLTV map regression: optional external workflow",
+		"- HLTV series regression: optional external workflow",
 	} {
 		if !strings.Contains(markdown, want) {
 			t.Fatalf("release summary does not contain %q:\n%s", want, markdown)


### PR DESCRIPTION
## Summary

- run the private-fixture External regression workflow only through manual dispatch
- remove External regression as a release prerequisite while preserving normal CI and tag verification
- reuse the pull-request coverage policy for the manual workflow and remove the obsolete nightly profile
- keep strict fixture checksum and regression enforcement whenever the workflow is deliberately run
- update the README and regression guide to match the opt-in policy

## Why

The repository has no private fixture archive configured, so the scheduled workflow failed immediately and created operational noise. Private-fixture coverage remains available when maintainers choose to configure and run it, without blocking v0.1.0 or future releases.

## Verification

- make download-test-demos
- REQUIRE_TEST_DEMO=1 go test -count=1 ./...
- go vet ./...
- go build ./...
- go test -count=1 ./internal/citest
- git diff --check

No private fixture or secret was accessed. The existing failed External regression run is historical and does not need to be rerun.

Follow-up to #57.