### PR TITLE
docs: make README a consistent CLI quick start

### DIFF
--- a/.github/scripts/verify-release-artifacts.sh
+++ b/.github/scripts/verify-release-artifacts.sh
@@ -47,7 +47,18 @@ else
   exit 1
 fi
 
-expected_unix_contents=(LICENSE README.md cs2-analyser-tool)
+expected_documentation=(
+  LICENSE
+  README.md
+  _docs/CLI.md
+  _docs/DEVELOPMENT.md
+  _docs/GO_LIBRARY.md
+  _docs/HLTV_REGRESSION.md
+  _docs/INSTALLATION.md
+  _docs/PLAYER_DATA.MD
+  _docs/RATING.MD
+)
+expected_unix_contents=("${expected_documentation[@]}" cs2-analyser-tool)
 for archive in "$dist_dir"/*.tar.gz; do
   if ! diff -u \
     <(printf '%s\n' "${expected_unix_contents[@]}") \
@@ -57,7 +68,7 @@ for archive in "$dist_dir"/*.tar.gz; do
   fi
 done
 if ! diff -u \
-  <(printf '%s\n' LICENSE README.md cs2-analyser-tool.exe) \
+  <(printf '%s\n' "${expected_documentation[@]}" cs2-analyser-tool.exe) \
   <(unzip -Z1 "$dist_dir/cs2-analyser-tool-windows-amd64.zip" | sort); then
   echo "::error::Windows archive does not contain the expected release files"
   exit 1
@@ -99,14 +110,16 @@ assert_binary_format "Windows AMD64" "$inspect_dir/windows-amd64/cs2-analyser-to
 assert_binary_format "macOS AMD64" "$inspect_dir/darwin-amd64/cs2-analyser-tool" 'Mach-O 64-bit x86_64'
 assert_binary_format "macOS ARM64" "$inspect_dir/darwin-arm64/cs2-analyser-tool" 'Mach-O 64-bit arm64'
 
-version_output=$("$inspect_dir/linux-amd64/cs2-analyser-tool" version)
+linux_binary="$inspect_dir/linux-amd64/cs2-analyser-tool"
+binary_name=${linux_binary##*/}
+version_output=$("$linux_binary" version)
 if [[ -n "${EXPECTED_RELEASE_VERSION:-}" ]]; then
-  expected_version_output="CS2 Analyser Tool version $EXPECTED_RELEASE_VERSION"
+  expected_version_output="$binary_name version $EXPECTED_RELEASE_VERSION"
   if [[ "$version_output" != "$expected_version_output" ]]; then
     echo "::error::release binary reported $version_output, expected $expected_version_output"
     exit 1
   fi
-elif [[ ! "$version_output" =~ ^CS2\ Analyser\ Tool\ version\ v.+$ ]]; then
+elif [[ ! "$version_output" =~ ^${binary_name}\ version\ v.+$ ]]; then
   echo "::error::snapshot binary reported an invalid version: $version_output"
   exit 1
 fi

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,5 @@ build/
 dist/
 
 # Ignore downloaded and locally supplied demo fixtures.
-# See cmd/demo_parser/testdata/README.md.
+# See analysis/testdata/README.md.
 *.dem

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,6 +38,7 @@ archives:
     files:
       - README.md
       - LICENSE
+      - _docs/*
 
 checksum:
   name_template: checksums.txt

--- a/README.md
+++ b/README.md
@@ -1,312 +1,100 @@
 # cs2-analyser-tool
 
-Designed specifically for players and coaches, this command-line interface tool provides a simple display and easy data ready to analyse, compare and start your journey towards improving your team and your personal CS2 skills.
+[![CI](https://github.com/taua-almeida/cs2-analyser-tool/actions/workflows/ci.yml/badge.svg)](https://github.com/taua-almeida/cs2-analyser-tool/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/taua-almeida/cs2-analyser-tool)](https://github.com/taua-almeida/cs2-analyser-tool/releases)
+[![Go Reference](https://pkg.go.dev/badge/github.com/taua-almeida/cs2-analyser-tool/analysis.svg)](https://pkg.go.dev/github.com/taua-almeida/cs2-analyser-tool/analysis)
+[![License](https://img.shields.io/github/license/taua-almeida/cs2-analyser-tool)](./LICENSE)
+
+`cs2-analyser-tool` parses Counter-Strike 2 demo files into readable match and player statistics for players, coaches, and analysts. Use the CLI for interactive tables, JSON or CSV exports, completed-series analysis, and private local match history, or import the same analysis engine as a Go package.
+
+## Features
+
+- Analyse one map or a completed best-of-3/best-of-5 series.
+- Inspect kills, assists, ADR, KAST, opening duels, utility, side splits, trades, multi-kills, and an HLTV Rating 3.0-style approximation.
+- Choose demos and players through terminal-based pickers, or provide everything as flags for scripts.
+- Export complete analyses as JSON or flat player tables as CSV.
+- Keep a deduplicated local SQLite history and compare a player's Premier results over time.
+- Use the parser and series aggregation directly from the public Go `analysis` package.
+
+Demo files are parsed locally. The history database does not contain demo bytes or demo file paths, and the tool does not upload analysis data.
 
 ## Installation
 
-### Prebuilt archives
+### Prebuilt release
 
-Prebuilt archives are published for each release from `v0.1.0` onward at [GitHub Releases](https://github.com/taua-almeida/cs2-analyser-tool/releases). Download `checksums.txt` and the archive for your system from the same release:
+Download the archive and `checksums.txt` for your platform from [GitHub Releases](https://github.com/taua-almeida/cs2-analyser-tool/releases). The [installation guide](./_docs/INSTALLATION.md) lists every archive and includes checksum and extraction commands.
 
-| System | Archive |
-| --- | --- |
-| Linux, 64-bit Intel/AMD | `cs2-analyser-tool-linux-amd64.tar.gz` |
-| Windows, 64-bit Intel/AMD | `cs2-analyser-tool-windows-amd64.zip` |
-| macOS, Intel | `cs2-analyser-tool-darwin-amd64.tar.gz` |
-| macOS, Apple silicon | `cs2-analyser-tool-darwin-arm64.tar.gz` |
+### Go install
 
-Verify the downloaded archive before extracting it. On Linux, replace the archive name if needed:
-
-```sh
-grep 'cs2-analyser-tool-linux-amd64.tar.gz$' checksums.txt | sha256sum --check -
-```
-
-On macOS:
-
-```sh
-grep 'cs2-analyser-tool-darwin-arm64.tar.gz$' checksums.txt | shasum -a 256 --check -
-```
-
-On Windows PowerShell:
-
-```powershell
-$archive = "cs2-analyser-tool-windows-amd64.zip"
-$expected = ((Get-Content checksums.txt | Where-Object { $_ -match ([regex]::Escape($archive) + '$') }) -split '\s+')[0]
-$actual = (Get-FileHash $archive -Algorithm SHA256).Hash.ToLowerInvariant()
-if ($actual -ne $expected) { throw "checksum mismatch" }
-```
-
-Extract a Linux or macOS archive into its own directory and run the binary:
-
-```sh
-mkdir cs2-analyser-tool-release
-tar -xzf cs2-analyser-tool-linux-amd64.tar.gz -C cs2-analyser-tool-release
-./cs2-analyser-tool-release/cs2-analyser-tool version
-```
-
-For Windows:
-
-```powershell
-Expand-Archive cs2-analyser-tool-windows-amd64.zip -DestinationPath cs2-analyser-tool-release
-.\cs2-analyser-tool-release\cs2-analyser-tool.exe version
-```
-
-Each archive also contains `README.md` and `LICENSE`.
-
-### Install with Go
-
-Install the latest available CLI version with a supported Go toolchain:
+With Go 1.26 or later, ensure the Go install directory is on `PATH`. Go uses `GOBIN` when it is set; otherwise it uses the `bin` directory under `GOPATH`.
 
 ```sh
 go install github.com/taua-almeida/cs2-analyser-tool@latest
+cs2-analyser-tool version
 ```
 
-`@latest` resolves a pseudo-version of `main` until the first tag is published; after that it selects the latest tagged release.
+## Five-minute quick start
 
-## Usage
+Start with a CS2 `.dem` file and run:
 
-### Analyse
-
-This command parses a CS2 demo file and provides statistical analysis of players' performance.
-
-#### Command Syntax
-
-```bash
-analyse [flags]
+```sh
+cs2-analyser-tool analyse --demo /path/to/match.dem
 ```
 
-#### Flags
+After parsing, use the arrow keys to move, Space or Enter to select players, and `y` to confirm. Pressing `q` or Ctrl+C closes the player selector without a selection; it does not cancel the command, which continues by printing and storing everyone. The result is printed as a terminal table and stored automatically in the local history.
 
-- `-d, --demo <path>`: Path to a CS2 demo file. Repeat the flag in played order to analyse a completed BO3/BO5 series together with `--best-of`.
-- `--best-of <n>`: Series format for multiple demos, `3` or `5`. A completed BO3 takes 2 or 3 demos, a completed BO5 takes 3, 4 or 5. Multiple demos always require this flag — the series format is never inferred from the file count — and one demo with it is invalid.
-- `-p, --players <players>`: A list of players to analyse. This should be provided as a comma-separated list of player names. Names match case-insensitively, and if any requested name is not in the demo the command fails and lists the available players. In a series, names match any alias the player used across the maps, and a name matching more than one SteamID fails with the candidate SteamIDs.
-- `-s, --save`: Flag to save the demo player's data.
-- `--save-type <type>`: Type of file to save the data. Options are `json` and `csv`. The default is `json`.
-- `--details`: Print the extra stat tables that do not fit the main one: the rating breakdown, approximate Rating 3.0 metrics, multi-kill rounds, trades, CT/T side splits, utility effectiveness and grenades thrown. For a series these show the aggregate values.
+If you omit `--demo`, the file picker appears inside the current terminal. It starts in your home directory when the operating system can resolve it, otherwise in the current directory. It does not open a desktop window.
 
-#### Options
+Useful next commands:
 
-- `d`: If -d not provided, the CLI will pop a window to select the file in our system. Series analysis never opens the picker: every map must be passed explicitly.
-- `p`: If no players are provided, a multiselect option will show on terminal. Series analysis skips the multiselect and analyses everyone unless `--players` is given.
+```sh
+# Include the additional rating, trade, side, and utility tables.
+cs2-analyser-tool analyse --demo /path/to/match.dem --details
 
-#### Examples
+# Save the complete selected analysis as JSON in the current directory.
+cs2-analyser-tool analyse --demo /path/to/match.dem --save --save-type json
 
-**Analyzing a Specific Demo**
-
-```bash
-analyse --demo path/to/demo/file
-```
-This command will process the specified demo file and output the analysis to the console and will display all available players to analyse.
-
-**Analyzing Specific Players and Saving the Data**
-
-```bash
-analyse --demo path/to/demo --players "player1,player2" --save --save-type csv
+# List analyses already stored in local history.
+cs2-analyser-tool history
 ```
 
-This will analyse only "player1" and "player2" from the specified demo and save the data in CSV format.
+`--save` names the file `<unix-seconds>_data.json` (or `.csv`) and prints the exact filename after writing it.
 
-**Analyzing a Completed BO3/BO5 Series**
+Run `cs2-analyser-tool --help` or read the [CLI guide](./_docs/CLI.md) for player selection, CSV export, series analysis, history replay, and Premier trends.
 
-```bash
-analyse --best-of 3 --demo map1.dem --demo map2.dem
-analyse --best-of 3 --demo map1.dem --demo map2.dem --demo map3.dem
-analyse --best-of 5 --demo map1.dem --demo map2.dem --demo map3.dem
+## Representative output
+
+This is the current main-table rendering for two players from the checked-in Mirage golden data. Processing and timing lines are omitted; `--details` prints more stat groups in separate tables.
+
+```text
+$ cs2-analyser-tool analyse --demo match.dem --players "123,NIGHTSOUL"
++--------------+-----------+--------+-------+----+---------+-------+----------+--------+-------+---------------+-------------+
+| NAME         |     KILLS | DEATHS | K/D   | HS | ASSISTS | ADR   | KAST (%) | RATING | ENTRY | PRECISION (%) | BEST WEAPON |
++--------------+-----------+--------+-------+----+---------+-------+----------+--------+-------+---------------+-------------+
+| 123          |        11 |      4 | 2.750 |  8 |       1 | 113.9 | 100.0    | 1.44   | 1:0   | 72.7          | AK-47       |
+| NIGHTSOUL    |        10 |      5 | 2.000 |  6 |       1 | 94.2  | 90.0     | 1.17   | 5:0   | 60.0          | AK-47       |
++--------------+-----------+--------+-------+----+---------+-------+----------+--------+-------+---------------+-------------+
+| MAP PLAYED   | DE_MIRAGE |        |       |    |         |       |          |        |       |               |             |
+| SCORE CT : T |     2 : 8 |        |       |    |         |       |          |        |       |               |             |
++--------------+-----------+--------+-------+----+---------+-------+----------+--------+-------+---------------+-------------+
+This is a demo of a: PREMIER game
+History: stored match 84a1a4191302
 ```
 
-The demos must be the series' played maps in order. The tool hashes each file (rejecting the same demo supplied twice), parses every map, resolves the two series teams by their rosters, and prints the ordered map results, the overall map and round score, the series winner and an aggregate player table. Only completed competitive 5v5 series are accepted: Wingman-sized maps are rejected, and the final demo must be the map on which a team clinched, so a 1-1 BO3 or a map supplied after the clinch is an error. With `--save` the JSON contains the full series envelope — see [PLAYER_DATA](./_docs/PLAYER_DATA.MD#series-analysis-bo3bo5) — while CSV stays the flat aggregate-player table with the exact single-map columns; full per-map series data requires JSON.
+## Documentation
 
-#### Saved files
-
-Saved JSON is a complete analysis record, not a bare player map:
-
-```json
-{
-  "players": {
-    "76561198000000000": { "team_id": 1, "...": "player data" }
-  },
-  "teams": [
-    {
-      "team_id": 1,
-      "name": "Rooster",
-      "aliases": ["Rooster"],
-      "score": 13,
-      "roster": [76561198000000000]
-    },
-    { "team_id": 2, "...": "the other logical team" }
-  ],
-  "map_data": {
-    "map_name": "de_mirage",
-    "total_rounds": 24,
-    "rounds_won_ct": 11,
-    "rounds_won_t": 13
-  },
-  "game_mode": "premier"
-}
-```
-
-Read players from `.players`, keyed by SteamID (a JSON string). `map_data`, `teams` and `game_mode` describe the whole match and always accompany the players; `--players` limits only `.players`. `game_mode` can be `""` when the demo metadata does not expose it, and `rounds_won_ct`/`rounds_won_t` are the final side scores, not team identities. `teams` carries the two logical teams of the map — the lineups that persist through halftime and overtime side switches — with each team's map-local ID, clan-name aliases, final round wins and SteamID roster; each player references their team through `team_id`. The details, including how identity is resolved and when parsing fails instead of guessing, are in [PLAYER_DATA](./_docs/PLAYER_DATA.MD#logical-teams-teams). CSV remains a flat player-only table with the same columns as before. This is an intentional breaking change from the previous format, which was the bare `{ "<steam-id>": ... }` map now nested under `players`.
-
-#### Analyzed data
-
-The data output showed in the terminal table is not all the analyzed data, to get more info about the available data, go to [PLAYER_DATA](./_docs/PLAYER_DATA.MD). The `Rating` column is an HLTV Rating 3.0-style approximation; how it is calculated, constant by constant, is documented in [RATING](./_docs/RATING.MD).
-
-### Match history
-
-Every successful analysis is also stored automatically in a local SQLite history — single maps and each played map of a `--best-of` series alike. No flag is needed; `--save` remains the separate, explicit file export it always was. If storing fails, the analysis you just saw is still valid: the command prints it, then reports the storage error.
-
-#### Where the history lives, and what it contains
-
-The database is `history.db` inside:
-
-- `$CS2_ANALYSER_HISTORY_DIR` when that environment variable is set, otherwise
-- `<user config dir>/cs2-analyser-tool/history` (on Linux `~/.config/cs2-analyser-tool/history`, on macOS `~/Library/Application Support/cs2-analyser-tool/history`, on Windows `%AppData%\cs2-analyser-tool\history`).
-
-Everything is local and private: nothing is ever uploaded, the directory and database are created owner-only where the platform supports it, and the history never stores the original demo bytes nor any demo file path. A match is identified by the SHA-256 of the exact demo bytes that were parsed, so re-analysing the same demo — from any path or filename — never creates a duplicate: the canonical record is kept unchanged and only your player display selection is updated. The stored record is always the complete, unfiltered analysis in the same JSON envelope `--save json` writes; `--players` only chooses who is displayed.
-
-Timestamps in the history are **analysis times** — when you ran the analysis, stored in UTC and displayed in your local time zone. Demos carry no trustworthy record of when the match was played, so no match time is invented.
-
-The schema is versioned with SQLite's `user_version` and every history database is stamped with the tool's `application_id`. A newer database (created by a newer release) is refused with a clear error instead of being downgraded, and a corrupt file, a database another application put at that path, a stranded WAL or journal beside a missing or empty database file, or any file the tool did not create is refused — inspected on a private temporary copy first, so the refused file, its journal and its directory keep their exact bytes: never modified, deleted, recreated or converted.
-
-#### history
-
-```bash
-cs2-analyser history
-```
-
-Lists stored matches, newest analysis first: a stable 12-character ID (the digest prefix), the local analysis time, map, score and game mode. Logical-team scores are preferred; maps without two resolved teams fall back to the final CT/T side scores. An empty history prints a message and exits successfully.
-
-#### history show
-
-```bash
-cs2-analyser history show <id>
-cs2-analyser history show <id> --details
-```
-
-Re-renders a stored match from the database alone — the original demo is not needed and is never opened. `<id>` is the full SHA-256 or any unique prefix of at least 8 hexadecimal characters; an ambiguous prefix fails listing the candidate IDs. The player selection stored with the match narrows the view exactly as the live rendering did, and the stored record itself always keeps everyone: without a stored selection everyone is shown, and a series map where none of the selected players appeared keeps its explicit empty view rather than falling back to everyone. `--details` adds the same extra stat tables `analyse --details` prints.
-
-#### compare
-
-```bash
-cs2-analyser compare --player <steam-id-or-name>
-```
-
-Shows a player's Premier trend across the stored history: one row per stored map that is explicitly recorded as `premier` game mode and contains that player, chronologically by analysis time, plus an aggregate totals row. Other modes are never inferred into the trend, and a series is stored only as its individual maps, so nothing is ever counted twice.
-
-`--player` is resolved as a nonzero decimal SteamID64 first; anything else must match exactly one alias observed in the stored matches, compared case-insensitively under Unicode simple case folding: one-to-one case pairs match (`Ö` finds `ö`, Cyrillic `И` finds `и`), while multi-character expansions do not (`STRASSE` does not find `Straße`). Aliases accumulate across matches — a player who renamed still resolves under either name — and an alias shared by several SteamIDs fails with each candidate's SteamID and known aliases so you can pass the SteamID64 instead.
-
-Aggregate values are calculated additively from exact stored facts, never by averaging the per-map numbers you see displayed:
-
-- K/D = sum(kills) / sum(deaths) — a deathless run divides by one
-- ADR = sum(damage given) / sum(map rounds)
-- KAST = 100 × sum(KAST-credited rounds) / sum(map rounds)
-- HS% = 100 × sum(headshots) / sum(kills)
-- Opening success = 100 × sum(opening rounds won) / sum(opening kills)
-
-Counts (opening duels, trade kills, deaths traded, utility damage, flashes, grenades thrown) are summed directly. No aggregate rating is fabricated by averaging map ratings.
-
-## Using the engine as a Go library
-
-Everything the CLI computes lives in the importable `analysis` package, which has no CLI, TUI or rendering dependencies of its own:
-
-```go
-import "github.com/taua-almeida/cs2-analyser-tool/analysis"
-```
-
-Add the module to your project with `go get github.com/taua-almeida/cs2-analyser-tool@latest`.
-
-### Analysing one map
-
-`Analyse` reads a complete demo from any `io.Reader` — a file, an uploaded stream, an in-memory buffer, an object-storage reader — and returns the map's players, logical teams, map data and game mode:
-
-```go
-result, err := analysis.Analyse(ctx, reader)
-```
-
-`AnalyseFile` is the file convenience wrapper. It owns the file it opens — open failures name the path, and the file is always closed before returning:
-
-```go
-result, err := analysis.AnalyseFile(ctx, "match.dem")
-```
-
-- **Input ownership**: `Analyse` borrows the reader and never closes it, even when it is an `io.Closer`. No rewindability is assumed and none survives a call: after success, failure or cancellation the reader has been consumed to an unspecified position, so reusing it requires rewinding or reopening it first.
-- **Stream failures**: a failing reader is an error, never a panic. An empty stream's immediate `io.EOF` or a connection dropped mid-demo comes back wrapping the reader's own error, so `errors.Is` still sees its identity.
-- **Cancellation**: cancelling the context interrupts parsing at the next demo frame instead of being checked only before or after the whole demo, and it also unblocks a `Read` currently blocked inside the reader — a stalled upload or network stream cannot pin the call. The returned error wraps the context's error, so `errors.Is(err, context.Canceled)` and `errors.Is(err, context.DeadlineExceeded)` hold as appropriate. A `Read` abandoned by cancellation may still be running inside the reader when `Analyse` returns; its result is discarded, and the reader stays yours to close if that read itself needs releasing.
-- **Team identity**: each map reports two logical teams — the lineups that persist through side swaps — whose IDs are map-local (team 1 played CT in the seeding round). A series numbers its own teams 1 and 2 series-locally, and each series map carries the explicit map-local-to-series translation in `team_assignments`. The two scopes never mix implicitly.
-
-### Building a series
-
-`BuildSeries` aggregates a completed, explicitly-stated BO3 or BO5 from maps parsed with `Analyse`/`AnalyseFile`, supplied in played order with each demo's SHA-256 content digest:
-
-```go
-series, err := analysis.BuildSeries(3, []analysis.SeriesMapInput{
-    {Demo: mapOne, SHA256: digestOne},
-    {Demo: mapTwo, SHA256: digestTwo},
-})
-```
-
-It is pure aggregation — no I/O, inputs never mutated — and enforces the completed-series rule: the final supplied map must be the clinching one. When the two series teams cannot be resolved from rosters alone, the structured `SeriesTeamConflictError` and `SeriesTeamAmbiguityError` carry the competing evidence and match through `errors.As`.
-
-### JSON contract and v0.x API stability
-
-Every result type marshals with `encoding/json` into the same envelopes the CLI's `--save` writes, documented in [PLAYER_DATA](./_docs/PLAYER_DATA.MD): `MapAnalysis` is the standalone map document, `SeriesAnalysis` the series document embedding each map's unchanged analysis. A series player whose rating cannot be recomputed from raw per-map facts marshals it as `null` rather than a fabricated value.
-
-While releases remain `v0.x` the Go API is not frozen — exported names and fields may still change between minor versions as the surface settles. The JSON contracts are the stable part. The full API reference is available with `go doc github.com/taua-almeida/cs2-analyser-tool/analysis`.
+- [Installation](./_docs/INSTALLATION.md): release archives, checksum verification, extraction, and Go installation.
+- [CLI guide](./_docs/CLI.md): `analyse`, exports, completed series, local history, and `compare`.
+- [Player data](./_docs/PLAYER_DATA.MD): JSON and CSV contracts plus field-by-field semantics.
+- [Rating methodology](./_docs/RATING.MD): every formula, constant, limitation, and worked example.
+- [Go package guide](./_docs/GO_LIBRARY.md) and [generated API reference](https://pkg.go.dev/github.com/taua-almeida/cs2-analyser-tool/analysis).
+- [Testing and HLTV regression](./_docs/HLTV_REGRESSION.md): fixture contracts, coverage, and diagnostics.
+- [Development, contributing, and releases](./_docs/DEVELOPMENT.md): local build/test commands, pull requests, and the maintainer release checklist.
 
 ## Contributing
 
-The opt-in external-oracle test for HLTV match 129241 is documented in
-[HLTV_REGRESSION.md](./_docs/HLTV_REGRESSION.md). It is separate from the
-repository's self-golden integration fixtures and never downloads demos or
-scrapes HLTV during a test run.
+See [Development, contributing, and releases](./_docs/DEVELOPMENT.md) for the repository setup, test suites, pull-request entry point, and release process.
 
-### CI and test coverage
+## License
 
-Pull-request CI restores the two public golden demos, keeps `go vet ./...` and
-`go build ./...` as separate checks, and runs uncached tests with
-`go test -count=1 -json ./...`. Its Actions summary gives pass, fail, and skip
-counts plus every package-relative skipped test. An unlisted skip fails the
-workflow, so adding `t.Skip` requires an intentional allowlist review.
-
-The optional External regression workflow is manually dispatched and separate
-from pull requests and releases. When its owner-approved private archive is
-configured, it runs the eight checksum-pinned HLTV map regressions and the
-original BO3 series; absent provisioning configuration is a hard failure. It is
-not a release prerequisite. The complete coverage matrix, private archive
-contract, summary fields, and manual diagnostic commands are in
-[HLTV_REGRESSION.md](./_docs/HLTV_REGRESSION.md#ci-coverage).
-
-For a local run of the ordinary suite:
-
-```sh
-make download-test-demos
-REQUIRE_TEST_DEMO=1 go test -count=1 ./...
-```
-
-### Publishing a release
-
-Releases are maintainer-triggered and remain a human-approved operation:
-
-1. Confirm the normal CI workflow passed on the commit to release.
-2. Create an annotated, v-prefixed semantic-version tag, for example `git tag -a v0.1.0 -m "v0.1.0"`.
-3. Push only that tag, for example `git push origin v0.1.0`.
-4. Watch the release workflow until its verification and publishing jobs finish.
-5. In the GitHub release, verify all four platform archives, `checksums.txt`, each archive's contents, and the binary's `version` output.
-6. Never move a published tag. Publish a new patch release to correct a release.
-
-### Clone the repo
-
-```bash
-git clone https://github.com/taua-almeida/cs2-analyser-tool.git
-cd cs2-analyser-tool
-```
-
-### Build the project
-
-```bash
-go build
-```
-
-### Submit a pull request
-
-If you'd like to contribute, please fork the repository and open a pull request to the `main` branch.
+This project is available under the [MIT License](./LICENSE).

--- a/_docs/CLI.md
+++ b/_docs/CLI.md
@@ -1,0 +1,143 @@
+# CLI guide
+
+Use `cs2-analyser-tool --help` to list commands or `cs2-analyser-tool <command> --help` for the current command flags.
+
+## Analyse
+
+The `analyse` command parses a CS2 demo file and provides statistical analysis of player performance.
+
+### Command syntax
+
+```sh
+cs2-analyser-tool analyse [flags]
+```
+
+### Flags
+
+- `-d, --demo <path>`: Path to a CS2 demo file. Repeat the flag in played order to analyse a completed BO3/BO5 series together with `--best-of`.
+- `--best-of <n>`: Series format for multiple demos, `3` or `5`. A completed BO3 takes 2 or 3 demos, a completed BO5 takes 3, 4 or 5. Multiple demos always require this flag; the series format is never inferred from the file count, and one demo with it is invalid.
+- `-p, --players <players>`: A comma-separated list of player names. Names match case-insensitively, and if any requested name is not in the demo the command fails and lists the available players. In a series, names match any alias the player used across the maps, and a name matching more than one SteamID fails with the candidate SteamIDs.
+- `-s, --save`: Save the selected player data.
+- `--save-type <type>`: Save as `json` or `csv`. The default is `json`.
+- `--details`: Print the extra stat tables that do not fit the main one: the rating breakdown, approximate Rating 3.0 metrics, multi-kill rounds, trades, CT/T side splits, utility effectiveness, and grenades thrown. For a series these show the aggregate values.
+
+### Interactive selection
+
+If `--demo` is omitted, an interactive file picker appears inside the current terminal. It starts in your home directory when the operating system can resolve it, otherwise in the current directory. It does not open a desktop window. Series analysis never starts the picker; every map must be passed explicitly.
+
+If `--players` is omitted, an interactive multiselect appears in the terminal after the demo is parsed. Use the arrow keys or `j`/`k` to move, Space or Enter to toggle a player, and `y` to confirm. Pressing `q` or Ctrl+C closes the selector without a selection; it does not cancel the command, which continues by printing and storing everyone. Series analysis skips the multiselect and analyses everyone unless `--players` is given.
+
+### Analyse one demo
+
+```sh
+cs2-analyser-tool analyse --demo path/to/demo/file.dem
+```
+
+The command processes the demo, then displays the available players to analyse.
+
+To analyse specific players and save CSV data:
+
+```sh
+cs2-analyser-tool analyse --demo path/to/demo/file.dem --players "player1,player2" --save --save-type csv
+```
+
+### Analyse a completed BO3/BO5 series
+
+```sh
+cs2-analyser-tool analyse --best-of 3 --demo map1.dem --demo map2.dem
+cs2-analyser-tool analyse --best-of 3 --demo map1.dem --demo map2.dem --demo map3.dem
+cs2-analyser-tool analyse --best-of 5 --demo map1.dem --demo map2.dem --demo map3.dem
+```
+
+The demos must be the series' played maps in order. The tool hashes each file (rejecting the same demo supplied twice), parses every map, resolves the two series teams by their rosters, and prints the ordered map results, the overall map and round score, the series winner, and an aggregate player table. Only completed competitive 5v5 series are accepted: Wingman-sized maps are rejected, and the final demo must be the map on which a team clinched, so a 1-1 BO3 or a map supplied after the clinch is an error. With `--save` the JSON contains the full series envelope; see [Player data](./PLAYER_DATA.MD#series-analysis-bo3bo5). CSV stays the flat aggregate-player table with the exact single-map columns, so full per-map series data requires JSON.
+
+### Saved files
+
+Saved JSON is a complete analysis record, not a bare player map:
+
+```json
+{
+  "players": {
+    "76561198000000000": { "team_id": 1, "...": "player data" }
+  },
+  "teams": [
+    {
+      "team_id": 1,
+      "name": "Rooster",
+      "aliases": ["Rooster"],
+      "score": 13,
+      "roster": [76561198000000000]
+    },
+    { "team_id": 2, "...": "the other logical team" }
+  ],
+  "map_data": {
+    "map_name": "de_mirage",
+    "total_rounds": 24,
+    "rounds_won_ct": 11,
+    "rounds_won_t": 13
+  },
+  "game_mode": "premier"
+}
+```
+
+Read players from `.players`, keyed by SteamID (a JSON string). `map_data`, `teams`, and `game_mode` describe the whole match and always accompany the players; `--players` limits only `.players`. `game_mode` can be `""` when the demo metadata does not expose it, and `rounds_won_ct`/`rounds_won_t` are the final side scores, not team identities. `teams` carries the two logical teams of the map: the lineups that persist through halftime and overtime side switches. Each team has its map-local ID, clan-name aliases, final round wins, and SteamID roster; each player references their team through `team_id`. The details, including how identity is resolved and when parsing fails instead of guessing, are in [Player data](./PLAYER_DATA.MD#logical-teams-teams).
+
+CSV remains a flat player-only table with the same columns as before. This is an intentional breaking change from the previous JSON format, which was the bare `{ "<steam-id>": ... }` map now nested under `players`.
+
+Saved files are created in the current working directory as `<unix-seconds>_data.json` or `<unix-seconds>_data.csv`. The command prints the exact filename after the write succeeds.
+
+The terminal table is narrower than the saved data. See [Player data](./PLAYER_DATA.MD) for every available field. The `Rating` column is an HLTV Rating 3.0-style approximation; the full calculation is in [Rating methodology](./RATING.MD).
+
+## Match history
+
+Every successful analysis is stored automatically in a local SQLite history, including single maps and each played map of a `--best-of` series. No flag is needed; `--save` remains the separate, explicit file export. If storing fails, the analysis already printed remains valid, but the command reports the storage error and exits with status 1.
+
+### Location and contents
+
+The database is `history.db` inside:
+
+- `$CS2_ANALYSER_HISTORY_DIR` when that environment variable is set, otherwise
+- `<user config dir>/cs2-analyser-tool/history` (on Linux `~/.config/cs2-analyser-tool/history`, on macOS `~/Library/Application Support/cs2-analyser-tool/history`, on Windows `%AppData%\cs2-analyser-tool\history`).
+
+Everything is local and private: nothing is uploaded, the directory and database are created owner-only where the platform supports it, and the history never stores the original demo bytes or any demo file path. A match is identified by the SHA-256 of the exact demo bytes that were parsed, so re-analysing the same demo from any path or filename never creates a duplicate. The canonical record is kept unchanged and only the player display selection is updated. The stored record is always the complete, unfiltered analysis in the same JSON envelope `--save json` writes; `--players` only chooses who is displayed.
+
+Timestamps in the history are analysis times: when the analysis ran, stored in UTC and displayed in the local time zone. Demos carry no trustworthy record of when the match was played, so no match time is invented.
+
+The schema is versioned with SQLite's `user_version` and every history database is stamped with the tool's `application_id`. A newer database is refused instead of being downgraded. A corrupt file, a database another application put at that path, a stranded WAL or journal beside a missing or empty database file, or any file the tool did not create is also refused. Inspection happens on a private temporary copy, so the refused file, its journal, and its directory keep their exact bytes.
+
+### List history
+
+```sh
+cs2-analyser-tool history
+```
+
+This lists stored matches newest analysis first: a stable 12-character ID (the digest prefix), the local analysis time, map, score, and game mode. Logical-team scores are preferred; maps without two resolved teams fall back to the final CT/T side scores. An empty history prints a message and exits successfully.
+
+### Show a stored match
+
+```sh
+cs2-analyser-tool history show <id>
+cs2-analyser-tool history show <id> --details
+```
+
+This re-renders a stored match from the database alone; the original demo is not needed and is never opened. `<id>` is the full SHA-256 or any unique prefix of at least 8 hexadecimal characters. An ambiguous prefix fails and lists the candidate IDs. The player selection stored with the match narrows the view exactly as the live rendering did, and the stored record itself always keeps everyone. Without a stored selection everyone is shown, and a series map where none of the selected players appeared keeps its explicit empty view rather than falling back to everyone. `--details` adds the same extra stat tables as `cs2-analyser-tool analyse --details`.
+
+### Compare Premier results
+
+```sh
+cs2-analyser-tool compare --player <steam-id-or-name>
+```
+
+This shows a player's Premier trend across the stored history: one row per stored map explicitly recorded as `premier` and containing that player, chronologically by analysis time, plus an aggregate totals row. Other modes are never inferred into the trend. A series is stored only as its individual maps, so nothing is counted twice.
+
+`--player` is resolved as a nonzero decimal SteamID64 first. Anything else must match exactly one alias observed in the stored matches, compared case-insensitively under Unicode simple case folding: one-to-one case pairs match (`Ö` finds `ö`, Cyrillic `И` finds `и`), while multi-character expansions do not (`STRASSE` does not find `Straße`). Aliases accumulate across matches, and an alias shared by several SteamIDs fails with each candidate's SteamID and known aliases so you can pass the SteamID64 instead.
+
+Aggregate values are calculated additively from exact stored facts, never by averaging the per-map numbers displayed:
+
+- K/D = sum(kills) / sum(deaths); a deathless run divides by one
+- ADR = sum(damage given) / sum(map rounds)
+- KAST = 100 × sum(KAST-credited rounds) / sum(map rounds)
+- HS% = 100 × sum(headshots) / sum(kills)
+- Opening success = 100 × sum(opening rounds won) / sum(opening kills)
+
+Counts (opening duels, trade kills, deaths traded, utility damage, flashes, and grenades thrown) are summed directly. No aggregate rating is fabricated by averaging map ratings.

--- a/_docs/DEVELOPMENT.md
+++ b/_docs/DEVELOPMENT.md
@@ -1,0 +1,39 @@
+# Development, contributing, and releases
+
+## Tests and CI
+
+The opt-in external-oracle test for HLTV match 129241 is documented in [HLTV regression](./HLTV_REGRESSION.md). It is separate from the repository's self-golden integration fixtures and never downloads demos or scrapes HLTV during a test run.
+
+Pull-request CI restores the two public golden demos, keeps `go vet ./...` and `go build ./...` as separate checks, and runs uncached tests with `go test -count=1 -json ./...`. Its Actions summary gives pass, fail, and skip counts plus every package-relative skipped test. An unlisted skip fails the workflow, so adding `t.Skip` requires an intentional allowlist review.
+
+The optional External regression workflow is manually dispatched and separate from pull requests and releases. When its owner-approved private archive is configured, it runs the eight checksum-pinned HLTV map regressions and the original BO3 series; absent provisioning configuration is a hard failure. It is not a release prerequisite. The complete coverage matrix, private archive contract, summary fields, and manual diagnostic commands are in [HLTV regression](./HLTV_REGRESSION.md#ci-coverage).
+
+For a local run of the ordinary suite:
+
+```sh
+make download-test-demos
+REQUIRE_TEST_DEMO=1 go test -count=1 ./...
+```
+
+## Publishing a release
+
+Releases are maintainer-triggered and remain a human-approved operation:
+
+1. Confirm the normal CI workflow passed on the commit to release.
+2. Create an annotated, v-prefixed semantic-version tag, for example `git tag -a v0.1.0 -m "v0.1.0"`.
+3. Push only that tag, for example `git push origin v0.1.0`.
+4. Watch the release workflow until its verification and publishing jobs finish.
+5. In the GitHub release, verify all four platform archives, `checksums.txt`, each archive's contents, and the binary's `version` output.
+6. Never move a published tag. Publish a new patch release to correct a release.
+
+## Clone and build
+
+```sh
+git clone https://github.com/taua-almeida/cs2-analyser-tool.git
+cd cs2-analyser-tool
+go build
+```
+
+## Contributing
+
+Fork the repository and open a focused pull request to the `main` branch. Include the tests and documentation needed to explain the change.

--- a/_docs/GO_LIBRARY.md
+++ b/_docs/GO_LIBRARY.md
@@ -1,0 +1,47 @@
+# Using the analysis engine as a Go library
+
+Everything the CLI computes lives in the importable `analysis` package, which has no CLI, TUI, or rendering dependencies of its own. The generated API reference is available on [pkg.go.dev](https://pkg.go.dev/github.com/taua-almeida/cs2-analyser-tool/analysis).
+
+```go
+import "github.com/taua-almeida/cs2-analyser-tool/analysis"
+```
+
+Add the module to your project with `go get github.com/taua-almeida/cs2-analyser-tool@latest`.
+
+## Analysing one map
+
+`Analyse` reads a complete demo from any `io.Reader`, such as a file, uploaded stream, in-memory buffer, or object-storage reader, and returns the map's players, logical teams, map data, and game mode:
+
+```go
+result, err := analysis.Analyse(ctx, reader)
+```
+
+`AnalyseFile` is the file convenience wrapper. It owns the file it opens: open failures name the path, and the file is always closed before returning.
+
+```go
+result, err := analysis.AnalyseFile(ctx, "match.dem")
+```
+
+- **Input ownership**: `Analyse` borrows the reader and never closes it, even when it is an `io.Closer`. No rewindability is assumed and none survives a call. After success, failure, or cancellation the reader has been consumed to an unspecified position, so reusing it requires rewinding or reopening it first.
+- **Stream failures**: A failing reader is an error, never a panic. An empty stream's immediate `io.EOF` or a connection dropped mid-demo comes back wrapping the reader's own error, so `errors.Is` still sees its identity.
+- **Cancellation**: Cancelling the context interrupts parsing at the next demo frame instead of being checked only before or after the whole demo. It also unblocks a `Read` currently blocked inside the reader, so a stalled upload or network stream cannot pin the call. The returned error wraps the context's error, so `errors.Is(err, context.Canceled)` and `errors.Is(err, context.DeadlineExceeded)` hold as appropriate. A `Read` abandoned by cancellation may still be running inside the reader when `Analyse` returns; its result is discarded, and the reader stays yours to close if that read itself needs releasing.
+- **Team identity**: Each map reports two logical teams, the lineups that persist through side swaps, whose IDs are map-local (team 1 played CT in the seeding round). A series numbers its own teams 1 and 2 series-locally, and each series map carries the explicit map-local-to-series translation in `team_assignments`. The two scopes never mix implicitly.
+
+## Building a series
+
+`BuildSeries` aggregates a completed, explicitly stated BO3 or BO5 from maps parsed with `Analyse` or `AnalyseFile`, supplied in played order with each demo's SHA-256 content digest:
+
+```go
+series, err := analysis.BuildSeries(3, []analysis.SeriesMapInput{
+    {Demo: mapOne, SHA256: digestOne},
+    {Demo: mapTwo, SHA256: digestTwo},
+})
+```
+
+It is pure aggregation with no I/O and never mutates its inputs. It enforces the completed-series rule: the final supplied map must be the clinching one. When the two series teams cannot be resolved from rosters alone, the structured `SeriesTeamConflictError` and `SeriesTeamAmbiguityError` carry the competing evidence and match through `errors.As`.
+
+## JSON contract and v0.x API stability
+
+Every result type marshals with `encoding/json` into the same envelopes the CLI's `--save` writes, documented in [Player data](./PLAYER_DATA.MD). `MapAnalysis` is the standalone map document, while `SeriesAnalysis` is the series document embedding each map's unchanged analysis. A series player whose rating cannot be recomputed from raw per-map facts marshals it as `null` rather than a fabricated value.
+
+While releases remain `v0.x`, the Go API is not frozen. Exported names and fields may change between minor versions as the surface settles. The JSON contracts are the stable part. You can also inspect the installed package with `go doc github.com/taua-almeida/cs2-analyser-tool/analysis`.

--- a/_docs/INSTALLATION.md
+++ b/_docs/INSTALLATION.md
@@ -1,0 +1,63 @@
+# Installation
+
+## Prebuilt archives
+
+Prebuilt archives are published for each release from `v0.1.0` onward at [GitHub Releases](https://github.com/taua-almeida/cs2-analyser-tool/releases). Download `checksums.txt` and the archive for your system from the same release:
+
+| System | Archive |
+| --- | --- |
+| Linux, 64-bit Intel/AMD | `cs2-analyser-tool-linux-amd64.tar.gz` |
+| Windows, 64-bit Intel/AMD | `cs2-analyser-tool-windows-amd64.zip` |
+| macOS, Intel | `cs2-analyser-tool-darwin-amd64.tar.gz` |
+| macOS, Apple silicon | `cs2-analyser-tool-darwin-arm64.tar.gz` |
+
+Verify the downloaded archive before extracting it. On Linux, replace the archive name if needed:
+
+```sh
+grep 'cs2-analyser-tool-linux-amd64.tar.gz$' checksums.txt | sha256sum --check -
+```
+
+On macOS:
+
+```sh
+grep 'cs2-analyser-tool-darwin-arm64.tar.gz$' checksums.txt | shasum -a 256 --check -
+```
+
+On Windows PowerShell:
+
+```powershell
+$archive = "cs2-analyser-tool-windows-amd64.zip"
+$expected = ((Get-Content checksums.txt | Where-Object { $_ -match ([regex]::Escape($archive) + '$') }) -split '\s+')[0]
+$actual = (Get-FileHash $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($actual -ne $expected) { throw "checksum mismatch" }
+```
+
+Extract a Linux or macOS archive into its own directory and run the binary:
+
+```sh
+mkdir cs2-analyser-tool-release
+tar -xzf cs2-analyser-tool-linux-amd64.tar.gz -C cs2-analyser-tool-release
+./cs2-analyser-tool-release/cs2-analyser-tool version
+```
+
+For Windows:
+
+```powershell
+Expand-Archive cs2-analyser-tool-windows-amd64.zip -DestinationPath cs2-analyser-tool-release
+.\cs2-analyser-tool-release\cs2-analyser-tool.exe version
+```
+
+Each archive also contains `README.md`, `LICENSE`, and the linked `_docs` reference files.
+
+## Install with Go
+
+Install the latest available CLI version with a supported Go toolchain. Ensure the Go install directory is on `PATH`: Go uses `GOBIN` when set, otherwise the `bin` directory under `GOPATH`.
+
+```sh
+go install github.com/taua-almeida/cs2-analyser-tool@latest
+cs2-analyser-tool version
+```
+
+`@latest` resolves a pseudo-version of `main` until the first tag is published; after that it selects the latest tagged release.
+
+Continue with the [five-minute quick start](../README.md#five-minute-quick-start) or the full [CLI guide](./CLI.md).

--- a/_docs/PLAYER_DATA.MD
+++ b/_docs/PLAYER_DATA.MD
@@ -357,7 +357,7 @@ Players keep their existing CT/T side splits (`side_stats`), which remain attrib
 
 ## Series analysis (BO3/BO5)
 
-`analyse --best-of 3|5` with repeated `--demo` flags aggregates a *completed* series. The format is always explicit: multiple demos without `--best-of` are rejected, a series is never inferred from the file count, and history never infers one either. The demos are the played maps in order, and that order is preserved everywhere — parsing, output, errors and JSON. Every file is streamed through SHA-256 while it is parsed, so the digest covers exactly the bytes that were analysed; two inputs with the same digest are rejected as the same demo regardless of their paths, as soon as the repeated copy has been parsed and hashed.
+`cs2-analyser-tool analyse --best-of 3|5` with repeated `--demo` flags aggregates a *completed* series. The format is always explicit: multiple demos without `--best-of` are rejected, a series is never inferred from the file count, and history never infers one either. The demos are the played maps in order, and that order is preserved everywhere — parsing, output, errors and JSON. Every file is streamed through SHA-256 while it is parsed, so the digest covers exactly the bytes that were analysed; two inputs with the same digest are rejected as the same demo regardless of their paths, as soon as the repeated copy has been parsed and hashed.
 
 ### Completed series only
 

--- a/analysis/doc.go
+++ b/analysis/doc.go
@@ -1,6 +1,6 @@
 // Package analysis parses Counter-Strike 2 demos and aggregates completed
 // best-of-3 and best-of-5 series, exposing both as plain Go values. It is the
-// engine behind the cs2-analyser CLI and is importable on its own: it never
+// engine behind the cs2-analyser-tool CLI and is importable on its own: it never
 // renders, prompts, writes files or exits the process.
 //
 // # Analysing a map

--- a/cmd/analyse.go
+++ b/cmd/analyse.go
@@ -42,7 +42,7 @@ func init() {
 var analyseCmd = &cobra.Command{
 	Use:          "analyse",
 	Short:        "Analyse a CS2 game demo.",
-	Long:         "This command will parse your cs2 demo and give you some stats about it. Use history to see your previous demos.",
+	Long:         "Parse a CS2 demo and display its statistics. Run '" + rootCmd.Name() + " history' to list previous analyses.",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if saveType != "json" && saveType != "csv" {

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -72,7 +72,7 @@ func runHistoryList(ctx context.Context, db *history.DB, output io.Writer) error
 		return err
 	}
 	if len(matches) == 0 {
-		fmt.Fprintln(output, "No matches in history yet. Run 'cs2-analyser analyse' and successful analyses are stored automatically.")
+		fmt.Fprintf(output, "No matches in history yet. Run '%s analyse' and successful analyses are stored automatically.\n", rootCmd.Name())
 		return nil
 	}
 	t := table.NewWriter()

--- a/cmd/history_test.go
+++ b/cmd/history_test.go
@@ -114,8 +114,9 @@ func TestRunHistoryListEmpty(t *testing.T) {
 	if err := runHistoryList(context.Background(), db, &out); err != nil {
 		t.Fatalf("runHistoryList: %v", err)
 	}
-	if !strings.Contains(out.String(), "No matches in history yet") {
-		t.Errorf("output %q lacks the empty-history message", out.String())
+	const want = "No matches in history yet. Run 'cs2-analyser-tool analyse' and successful analyses are stored automatically.\n"
+	if got := out.String(); got != want {
+		t.Errorf("output = %q, want %q", got, want)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,9 +10,9 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "cs2-analyser",
-	Short: "A CLI tool to analyse cs2 games demos",
-	Long:  "CS2 Analyser Tool is a CLI tool that allows players and coaches to parse demos from CS2 games and analyse them.",
+	Use:   "cs2-analyser-tool",
+	Short: "Analyse Counter-Strike 2 demos.",
+	Long:  "Parse Counter-Strike 2 demo files, display player and team statistics, export results, and review local match history.",
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCommandsUseCanonicalExecutableName(t *testing.T) {
+	const canonicalName = "cs2-analyser-tool"
+	if got := rootCmd.Name(); got != canonicalName {
+		t.Fatalf("root command name = %q, want %q", got, canonicalName)
+	}
+
+	var output bytes.Buffer
+	rootCmd.SetOut(&output)
+	t.Cleanup(func() { rootCmd.SetOut(nil) })
+	rootCmd.InitDefaultHelpFlag()
+	rootCmd.Help()
+
+	help := output.String()
+	const usage = "Usage:\n  cs2-analyser-tool [flags]\n  cs2-analyser-tool [command]"
+	if !strings.Contains(help, usage) {
+		t.Fatalf("root help does not use the canonical executable name:\n%s", help)
+	}
+
+	const guidance = "Run 'cs2-analyser-tool history'"
+	if !strings.Contains(analyseCmd.Long, guidance) {
+		t.Fatalf("analyse help %q does not contain %q", analyseCmd.Long, guidance)
+	}
+}

--- a/cmd/ui/file-picker/filepicker.go
+++ b/cmd/ui/file-picker/filepicker.go
@@ -31,7 +31,9 @@ func clearErrorAfter(t time.Duration) tea.Cmd {
 func PickDemoFile() (string, error) {
 	fp := filepicker.New()
 	fp.AllowedTypes = []string{".dem"}
-	fp.CurrentDirectory, _ = os.UserHomeDir()
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		fp.CurrentDirectory = homeDir
+	}
 
 	m := model{
 		filepicker: fp,

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,6 +1,3 @@
-/*
-CS2 Analyser Tool version.
-*/
 package cmd
 
 import (
@@ -16,7 +13,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Display application version information.",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Fprintf(cmd.OutOrStdout(), "CS2 Analyser Tool version %s\n", currentVersion())
+		fmt.Fprintf(cmd.OutOrStdout(), "%s version %s\n", cmd.Root().Name(), currentVersion())
 	},
 }
 

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -52,7 +52,7 @@ func TestVersionCommandOutput(t *testing.T) {
 		t.Fatalf("executing version command: %v", err)
 	}
 
-	const want = "CS2 Analyser Tool version v0.1.0\n"
+	const want = "cs2-analyser-tool version v0.1.0\n"
 	if got := output.String(); got != want {
 		t.Fatalf("version output = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary

- make cs2-analyser-tool the canonical executable in Cobra help, runtime guidance, tests, and documentation
- reshape README into a concise landing page while preserving the detailed CLI, installation, Go library, player-data, development, testing, and release references
- package the referenced _docs files in release archives and keep artifact verification aligned with the built binary name
- correct terminal file-picker fallback wording and the stale .gitignore fixture path

Closes #63

## Verification

- GOPROXY=off go build ./...
- GOPROXY=off go test -count=1 ./...
- four synthetic platform release archives passed .github/scripts/verify-release-artifacts.sh
- Markdown links passed in the repository and in an extracted release archive

Fixture-backed tests remained skipped when local .dem files were absent; no fixtures or tools were downloaded.