### PR TITLE
ci: enforce Go formatting and static analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: ${{ (inputs.release_mode == 'snapshot' || inputs.release_mode == 'tag') && '0' || '1' }}
+          persist-credentials: false
       - name: Validate release tag and default-branch ancestry
         if: inputs.release_mode == 'tag'
         shell: bash
@@ -59,6 +60,15 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
+      - name: Check canonical Go formatting
+        if: inputs.release_mode != 'tag'
+        run: make fmt-check
+      - name: Check Go module files are tidy
+        if: inputs.release_mode != 'tag'
+        run: make tidy-check
+      - name: Run pinned Staticcheck
+        if: inputs.release_mode != 'tag'
+        run: make lint
       - name: Restore test demo fixtures
         if: inputs.release_mode != 'snapshot'
         uses: actions/cache@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ Use Go 1.26 or later, as required by `go.mod` and the installation guide.
 - `internal/history/` contains the local SQLite history implementation.
 - `internal/citest/` validates CI test results and the repository's explicit
   skip policy.
+- `tools/` pins development tools in a separate Go module so their dependencies
+  cannot change the application module's build list.
 - `_docs/` contains the CLI, public package, data-contract, rating, testing, and
   release documentation.
 - `analysis/testdata/` contains checked-in golden JSON and documentation for
@@ -81,11 +83,34 @@ its fixture contract.
 
 ## Format and check Go changes
 
-Format each changed Go file with `gofmt`, then run the separate vet, build, and
-test checks used by pull-request CI:
+Apply canonical Go formatting, then run the same non-mutating formatting and
+static-analysis checks used by pull-request CI:
 
 ```sh
-gofmt -w path/to/changed.go
+make fmt
+make fmt-check
+make tidy-check
+make lint
+```
+
+`make fmt-check` uses `go list` to find package source and test files, lists
+every file that needs formatting, and fails without editing it.
+`make tidy-check` verifies both the application and tool module files without
+changing them. `make lint` runs
+`go tool -modfile=tools/go.mod staticcheck ./...` using the
+`honnef.co/go/tools` version pinned in `tools/go.mod` (Staticcheck 2026.1,
+module version `v0.7.0`). The first run may download that pinned tool and its
+isolated module dependencies through Go's tool dependency mechanism.
+
+Run all non-mutating checks above plus the ordinary test suite with:
+
+```sh
+make check
+```
+
+Run the existing vet, build, and uncached test checks separately:
+
+```sh
 go vet ./...
 go build ./...
 go test -count=1 ./...

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 GOCMD := go
 GOBUILD := $(GOCMD) build -ldflags "-X github.com/taua-almeida/cs2-analyser-tool/cmd.CS2AnalyserVersion=$(VERSION)"
 GOCLEAN := $(GOCMD) clean
+GOFILES = $(GOCMD) list -f '{{range .GoFiles}}{{$$.Dir}}/{{.}} {{end}}{{range .CgoFiles}}{{$$.Dir}}/{{.}} {{end}}{{range .IgnoredGoFiles}}{{$$.Dir}}/{{.}} {{end}}{{range .TestGoFiles}}{{$$.Dir}}/{{.}} {{end}}{{range .XTestGoFiles}}{{$$.Dir}}/{{.}} {{end}}' ./...
+GOFMT := gofmt
 GOTIDY := $(GOCMD) mod tidy
 GOTEST := $(GOCMD) test
 
@@ -55,7 +57,7 @@ endef
 # Ensure GOBIN is not set, which can conflict with cross compilation
 unexport GOBIN
 
-.PHONY: build-all clean tidy test download-test-demos $(BUILD_TARGETS)
+.PHONY: build-all check clean download-test-demos fmt fmt-check lint test tidy tidy-check $(BUILD_TARGETS)
 
 build-all: $(BUILD_TARGETS)
 
@@ -65,6 +67,31 @@ $(BUILD_TARGETS):
 test:
 	$(GOTEST) ./...
 
+fmt:
+	@files="$$($(GOFILES))" || exit $$?; \
+	if [ -z "$$files" ]; then echo "No Go package files found." >&2; exit 1; fi; \
+	$(GOFMT) -w $$files
+
+fmt-check:
+	@files="$$($(GOFILES))" || exit $$?; \
+	if [ -z "$$files" ]; then echo "No Go package files found." >&2; exit 1; fi; \
+	unformatted="$$($(GOFMT) -l $$files)" || exit $$?; \
+	if [ -n "$$unformatted" ]; then \
+		echo "Go files must be formatted with gofmt:" >&2; \
+		printf '%s\n' "$$unformatted" >&2; \
+		echo "Run 'make fmt' and commit the resulting changes." >&2; \
+		exit 1; \
+	fi
+
+lint:
+	$(GOCMD) tool -modfile=tools/go.mod staticcheck ./...
+
+tidy-check:
+	$(GOTIDY) -diff
+	$(GOCMD) -C tools mod tidy -diff
+
+check: fmt-check tidy-check lint test
+
 # Fetch the demos the integration test runs against.
 download-test-demos:
 	@$(call fetch_demo,$(TESTDATA_DIR)/mirage.dem,$(MIRAGE_DEMO_URL),$(MIRAGE_DEMO_SHA256))
@@ -72,6 +99,7 @@ download-test-demos:
 
 tidy:
 	$(GOTIDY)
+	$(GOCMD) -C tools mod tidy
 
 clean:
 	$(GOCLEAN)

--- a/_docs/DEVELOPMENT.md
+++ b/_docs/DEVELOPMENT.md
@@ -4,7 +4,13 @@
 
 The opt-in external-oracle test for HLTV match 129241 is documented in [HLTV regression](./HLTV_REGRESSION.md). It is separate from the repository's self-golden integration fixtures and never downloads demos or scrapes HLTV during a test run.
 
-Pull-request CI restores the two public golden demos, keeps `go vet ./...` and `go build ./...` as separate checks, and runs uncached tests with `go test -count=1 -json ./...`. Its Actions summary gives pass, fail, and skip counts plus every package-relative skipped test. An unlisted skip fails the workflow, so adding `t.Skip` requires an intentional allowlist review.
+Pull-request CI checks canonical Go formatting, verifies that the application
+and tool module files are tidy, and runs the pinned Staticcheck version before
+restoring the two public golden demos. It keeps `go vet ./...` and
+`go build ./...` as separate checks, and runs uncached tests with
+`go test -count=1 -json ./...`. Its Actions summary gives pass, fail, and skip
+counts plus every package-relative skipped test. An unlisted skip fails the
+workflow, so adding `t.Skip` requires an intentional allowlist review.
 
 The optional External regression workflow is manually dispatched and separate from pull requests and releases. When its owner-approved private archive is configured, it runs the eight checksum-pinned HLTV map regressions and the original BO3 series; absent provisioning configuration is a hard failure. It is not a release prerequisite. The complete coverage matrix, private archive contract, summary fields, and manual diagnostic commands are in [HLTV regression](./HLTV_REGRESSION.md#ci-coverage).
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,0 +1,14 @@
+module github.com/taua-almeida/cs2-analyser-tool/tools
+
+go 1.26.0
+
+require (
+	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c // indirect
+	golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 // indirect
+	golang.org/x/mod v0.31.0 // indirect
+	golang.org/x/sync v0.19.0 // indirect
+	golang.org/x/tools v0.40.1-0.20260108161641-ca281cf95054 // indirect
+	honnef.co/go/tools v0.7.0 // indirect
+)
+
+tool honnef.co/go/tools/cmd/staticcheck

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,0 +1,16 @@
+github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c h1:pxW6RcqyfI9/kWtOwnv/G+AzdKuy2ZrqINhenH4HyNs=
+github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 h1:1P7xPZEwZMoBoz0Yze5Nx2/4pxj6nw9ZqHWXqP0iRgQ=
+golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
+golang.org/x/mod v0.31.0 h1:HaW9xtz0+kOcWKwli0ZXy79Ix+UW/vOfmWI5QVd2tgI=
+golang.org/x/mod v0.31.0/go.mod h1:43JraMp9cGx1Rx3AqioxrbrhNsLl2l/iNAvuBkrezpg=
+golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
+golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/tools v0.40.1-0.20260108161641-ca281cf95054 h1:CHVDrNHx9ZoOrNN9kKWYIbT5Rj+WF2rlwPkhbQQ5V4U=
+golang.org/x/tools v0.40.1-0.20260108161641-ca281cf95054/go.mod h1:Ik/tzLRlbscWpqqMRjyWYDisX8bG13FrdXp3o4Sr9lc=
+golang.org/x/tools/go/expect v0.1.1-deprecated h1:jpBZDwmgPhXsKZC6WhL20P4b/wmnpsEAGHaNy0n/rJM=
+golang.org/x/tools/go/expect v0.1.1-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
+honnef.co/go/tools v0.7.0 h1:w6WUp1VbkqPEgLz4rkBzH/CSU6HkoqNLp6GstyTx3lU=
+honnef.co/go/tools v0.7.0/go.mod h1:pm29oPxeP3P82ISxZDgIYeOaf9ta6Pi0EWvCFoLG2vc=


### PR DESCRIPTION
## Summary

- add `make fmt`, `make fmt-check`, `make tidy-check`, `make lint`, and the aggregate `make check` target
- pin Staticcheck 2026.1 (`v0.7.0`) with Go's tool dependency mechanism in an isolated `tools` module, keeping analyzer dependencies out of the application build list
- run formatting, module-tidiness, and Staticcheck gates as clearly named steps in the existing CI job
- keep CI permissions read-only, disable persisted checkout credentials before executing the pinned analyzer, and preserve the existing vet, build, and test checks

## Related issue

Closes #62

## Test plan

- `make fmt`
- `make fmt-check`
- `make tidy-check`
- `make lint`
- `make check`
- `go vet ./...`
- `go build ./...`
- `go test -count=1 ./...`
- verified `fmt-check` reports both tracked and untracked unformatted package files without modifying them
- verified root `go.mod` and `go.sum` remain unchanged and both modules are tidy
- parsed `.github/workflows/ci.yml` locally; GitHub-hosted workflow execution remains pending

## Documentation

Updated `CONTRIBUTING.md` with the exact local commands and isolated tool-module layout. Updated `_docs/DEVELOPMENT.md` to describe the required pull-request CI checks.

## Compatibility

None. This does not change CLI flags or output, JSON/CSV data, the public Go API, or production dependency versions.

## Fixtures, generated files, and private data

No fixtures, golden files, generated files, or private data changed. No demo fixtures were downloaded.
